### PR TITLE
Fix balance downloader and rest api docker images

### DIFF
--- a/docker/MirrorNodeClientImage
+++ b/docker/MirrorNodeClientImage
@@ -1,11 +1,5 @@
 # Pull base image.
 FROM ubuntu:latest
 
-# Update
-RUN apt-get update || true
-
-# Install Java
-RUN apt-get install default-jre || true
-
-# Install psql client
-RUN apt-get install postgresql-client || true
+# Install Java && psql client
+RUN apt-get update && apt-get install -y default-jre postgresql-client

--- a/docker/RecordsDownloader
+++ b/docker/RecordsDownloader
@@ -1,11 +1,8 @@
 # Pull base image.
 FROM ubuntu:latest
 
-# Update
-RUN apt-get update || true
-
 # Install Java
-RUN apt-get install default-jre || true
+RUN apt-get update && apt-get install -y default-jre
 
 RUN mkdir -p /config
 RUN mkdir -p /lib

--- a/docker/RecordsParser
+++ b/docker/RecordsParser
@@ -1,11 +1,8 @@
 # Pull base image.
 FROM ubuntu:latest
 
-# Update
-RUN apt-get update || true
-
 # Install Java
-RUN apt-get install default-jre || true
+RUN apt-get update && apt-get install -y default-jre
 
 RUN mkdir -p /config
 RUN mkdir -p /lib

--- a/docker/RestClientImage
+++ b/docker/RestClientImage
@@ -1,7 +1,4 @@
 FROM node:11
 
-# Update
-RUN apt-get update || true
-
 # Install psql client
-RUN apt-get install postgresql-client || true
+RUN apt-get update && apt-get install -y postgresql-client

--- a/docker/update102.sh
+++ b/docker/update102.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-java -Dlog4j.configurationFile=./log4j2.xml -cp mirrorNode.jar com.hedera.addressBook.NetworkAddressBook
+java -Dlog4j.configurationFile=./config/log4j2.xml -cp mirrorNode.jar com.hedera.addressBook.NetworkAddressBook
 rm .102env


### PR DESCRIPTION
Dockerfiles were recently changed to use `RUN apt-get install <package> || true`. This is wrong for multiple reasons:

- Docker is non-interactive and the above removed the `-y` option, causing it to always fail
- Failed commands should never be skipped by using `|| true` since that required package won't be in the image.
- Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions can fail as recommended by docker [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)

I also fixed a log4j issue with 102 downloader.

Fixes #19