### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at da@hedera.com. All
+reported by contacting the project team at oss@hedera.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Legal greenlit using the Contributor Covenant (https://contributor-covenant.org/) as our code of conduct. I've used da@hedera.com as the point of contact in the code of conduct. Please confirm that's correct @gregscullard.

Fixes #78 