### PR TITLE
Fix record downloader file order - addresses #110

### DIFF
--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -141,7 +141,6 @@ public class RecordFileDownloader extends Downloader {
 		Collections.sort(fileNames);
 
 		for (String fileName : fileNames) {
-			System.out.println(fileName);
 			if (Utility.checkStopFile()) {
 				log.info("Stop file found, stopping");
 				break;


### PR DESCRIPTION
Fixes #110 by sorting the `sigFilesMap` in `verifySigsAndDownloadRecordFiles`