### PR TITLE
Eliminate unique constraint on t_transactions TransactionID

### DIFF
--- a/rest-api/accounts.js
+++ b/rest-api/accounts.js
@@ -191,8 +191,7 @@ const getOneAccount = function (req, res) {
 
     const innerQuery =
         'select distinct t.id\n' +
-        '	, t.vs_seconds\n' +
-        '	, t.vs_nanos\n' +
+        '	, t.valid_stard_ns\n' +
         '	, t.consensus_seconds\n' +
         '	, t.consensus_nanos\n' +
         '	, t.consensus_ns\n' +
@@ -215,7 +214,6 @@ const getOneAccount = function (req, res) {
 
     let transactionsQuery =
         "select etrans.entity_shard,  etrans.entity_realm, etrans.entity_num\n" +
-        "   , t.valid_start_ns\n" +
         "   , t.memo\n" +
         "   , t.consensus_seconds\n" +
         "   , t.consensus_nanos\n" +

--- a/rest-api/transactions.js
+++ b/rest-api/transactions.js
@@ -114,7 +114,6 @@ const getTransactions = function (req) {
 
     let sqlQuery =
         "select etrans.entity_shard,  etrans.entity_realm, etrans.entity_num\n" +
-        "   , t.valid_start_ns\n" +
         "   , t.memo\n" +
         '	, t.consensus_ns\n' +
         '   , valid_start_ns\n' +
@@ -192,7 +191,6 @@ const getOneTransaction = function (req, res) {
 
     let sqlQuery =
         "select etrans.entity_shard,  etrans.entity_realm, etrans.entity_num\n" +
-        "   , t.valid_start_ns\n" +
         "   , t.memo\n" +
         '	, t.consensus_ns\n' +
         '   , valid_start_ns\n' +

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -58,8 +58,6 @@ public class RecordFileLogger {
         ,ID
         ,FK_NODE_ACCOUNT_ID
         ,MEMO
-        ,VS_SECONDS
-        ,VS_NANOS
         ,VALID_START_NS
         ,FK_TRANS_TYPE_ID
         ,FK_PAYER_ACCOUNT_ID
@@ -157,10 +155,10 @@ public class RecordFileLogger {
         }
 		try {
 			sqlInsertTransaction = connect.prepareStatement("INSERT INTO t_transactions"
-					+ " (id, fk_node_acc_id, memo, vs_seconds, vs_nanos, valid_start_ns, fk_trans_type_id, fk_payer_acc_id"
+					+ " (id, fk_node_acc_id, memo, valid_start_ns, fk_trans_type_id, fk_payer_acc_id"
 					+ ", fk_result_id, consensus_seconds, consensus_nanos, consensus_ns, fk_cud_entity_id, charged_tx_fee"
 					+ ", initial_balance, fk_rec_file_id)"
-					+ " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+					+ " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 					+ " RETURNING id");
 			sqlInsertTransferList = connect.prepareStatement("INSERT INTO t_cryptotransferlists"
 					+ " (fk_trans_id, account_id, amount)"
@@ -301,8 +299,6 @@ public class RecordFileLogger {
 			sqlInsertTransaction.setLong(F_TRANSACTION.ID.ordinal(), fkTransactionId);
 			sqlInsertTransaction.setLong(F_TRANSACTION.FK_NODE_ACCOUNT_ID.ordinal(), fkNodeAccountId);
 			sqlInsertTransaction.setBytes(F_TRANSACTION.MEMO.ordinal(), body.getMemo().getBytes());
-			sqlInsertTransaction.setLong(F_TRANSACTION.VS_SECONDS.ordinal(), seconds);
-			sqlInsertTransaction.setLong(F_TRANSACTION.VS_NANOS.ordinal(), nanos);
 			sqlInsertTransaction.setLong(F_TRANSACTION.VALID_START_NS.ordinal(), validStartNs);
 			sqlInsertTransaction.setInt(F_TRANSACTION.FK_TRANS_TYPE_ID.ordinal(), getTransactionTypeId(body));
 			sqlInsertTransaction.setLong(F_TRANSACTION.FK_REC_FILE_ID.ordinal(), fileId);

--- a/src/main/resources/db/migration/V1.9.1__transactions_indexes.sql
+++ b/src/main/resources/db/migration/V1.9.1__transactions_indexes.sql
@@ -1,0 +1,11 @@
+-- transaction_ids (valid start timestamp + payer account id) are not unique; remove unique constraint.
+-- the transaction_id is not actually part of any where clause in the rest-api, so remove all related index.
+drop index if exists idx_t_transactions_transaction_id_unq;
+drop index if exists idx_t_transactions_seconds;
+drop index if exists idx_t_transactions_vs_ns;
+
+alter table t_transactions drop column vs_seconds;
+alter table t_transactions drop column vs_nanos;
+
+-- The t_transactions.valid_start_ns appears in 1 query (transactions.js/getOneTransaction), so add index for that.
+create index idx__t_transactions__transaction_id on t_transactions (valid_start_ns, fk_payer_acc_id);


### PR DESCRIPTION
TransactionID being (vs_seconds, vs_nanos, fk_payer_account_id).

Transactions with the same TransactionID can actually make it through the system (first may succeed, remainder fail as DUPLICATE).

- unique index on consensus_ns is already there and good
- removing the unique constraint on the "old-style" transaction_id using vs_seconds/vs_nanos.
- removing the vs_seconds, vs_nanos columns (which were replaced by valid_start_ns).
- removing unused/unnecessary indexes because of those changes.
- updating rest-api to use valid_start_ns instead and adding appropriate index for the query
- updating insert code on java

fixes #122
