### PR TITLE
Fix off-by-1 bug in migration that filled in the new ed25519_public_key_hex

### DIFF
--- a/src/main/resources/db/migration/V1.11.3__entity_key.sql
+++ b/src/main/resources/db/migration/V1.11.3__entity_key.sql
@@ -1,0 +1,11 @@
+-- Fill in the ed25519_public_key_hex from the raw 'key' column.
+-- From BasicTypes.proto, message Key, extract the ED25519 key as hex.
+-- This will convert conformant keys (protobuf option #2, length = 32 bytes)
+-- NOTE: if the DB has many entities, this may need to be broken up into batches.
+update t_entities
+    -- This is where the key data starts in the protobuf (and fixes a bug in migration V1.11.0)
+    -- Index here are 1-based, not 0-based.
+    -- Skip the 4 byte protobuf header
+    set ed25519_public_key_hex = substring(encode(key::bytea, 'hex'), 5)
+    where key is not null
+        and encode(key::bytea, 'hex') like '1220%'; -- This indicates it's a single ED25519 key of proper length.


### PR DESCRIPTION
**Detailed description**:

The migration V1.11.0 that added a new field t_entities.ed25519_public_key_hex and filled it in based on the existing protobuf key in t_entities.key had an off-by-1 error when converting the protobuf to the new field. The off by 1 was that there is a 4 hex-character header in the protobuf data and the code converted it by substring(key, 4) but postgres substring is 1-based not 0-based so that started the substring on the 4th character leading to an extra 0 prefixed.

The java code writing the new field is fine.

This re-creates the ed25519 data based on the key field.

**Which issue(s) this PR fixes**:
Fixes #248

**Special notes for your reviewer**:

The only environment this has been deployed to was QA, and that data was fixed in place by hand.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated