### PR TITLE
 Remove addition jmeter time assert of threads

### DIFF
--- a/hedera-mirror-test/src/test/jmeter/E2E_200_TPS_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_200_TPS_All_Messages.jmx
@@ -195,12 +195,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
       <PostThreadGroup guiclass="PostThreadGroupGui" testclass="PostThreadGroup" testname="DB_Cleanup_TG" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_Client_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_Client_Subscribe_Only.jmx
@@ -38,12 +38,6 @@
           </elementProp>
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.MultiTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
     </hashTree>
   </hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_All_Messages.jmx
@@ -195,12 +195,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
       <PostThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="DB_Cleanup_TG" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_Heavy_Load_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_Heavy_Load_All_Messages.jmx
@@ -195,12 +195,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
       <PostThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="DB_Cleanup_TG" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Single_User_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Single_User_All_Messages.jmx
@@ -195,12 +195,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
       <PostThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="DB_Cleanup_TG" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
@@ -29,12 +29,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
     </hashTree>
   </hashTree>

--- a/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
+++ b/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
@@ -29,12 +29,6 @@
         <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
-        <hashTree>
-          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
-          </DurationAssertion>
-          <hashTree/>
-        </hashTree>
       </hashTree>
     </hashTree>
   </hashTree>


### PR DESCRIPTION
**Detailed description**:
2 timeout settings aren't necessary for the jmeter perf tests.
Removing the DurationAssertion.duration setting to rely solely on subscribeThreadCount

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

