### PR TITLE
Fix bugs on and add missing fields to OpenAPI spec

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1080,6 +1080,8 @@ components:
         expiry_timestamp:
           example: null
           nullable: true
+        fee_schedule_key:
+          $ref: '#/components/schemas/Key'
         freeze_default:
           type: boolean
           example: false
@@ -1087,12 +1089,12 @@ components:
           $ref: '#/components/schemas/Key'
         initial_supply:
           type: string
-          example: 1000000
+          example: "1000000"
         kyc_key:
           $ref: '#/components/schemas/Key'
         max_supply:
-          type: number
-          example: 9223372036854775807
+          type: string
+          example: "9223372036854775807"
         modified_timestamp:
           type: string
           example: "1234567890.000000001"
@@ -1111,8 +1113,8 @@ components:
         token_id:
           $ref: '#/components/schemas/EntityId'
         total_supply:
-          type: number
-          example: 1000000
+          type: string
+          example: "1000000"
         treasury_account_id:
           $ref: '#/components/schemas/EntityId'
         type:
@@ -1207,6 +1209,11 @@ components:
       properties:
         consensus_timestamp:
           type: string
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        bytes:
+          type: string
+          format: byte
         transaction_hash:
           type: string
           format: byte
@@ -1290,11 +1297,13 @@ components:
                 $ref: '#/components/schemas/EntityId'
       example:
         consensus_timestamp: "1234567890.000000007"
-        transaction_hash: aGFzaA==
+        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
         valid_start_timestamp: "1234567890.000000006"
         charged_tx_fee: 7
         memo_base64: null
+        bytes: null
         result: SUCCESS
+        entity_id: "0.0.2281979"
         name: CRYPTOTRANSFER
         nft_transfers:
           - receiver_account_id: 0.0.121
@@ -1328,8 +1337,8 @@ components:
           - amount: 100
             collector_account_id: 0.0.10
             effective_payer_account_ids:
-             - 0.0.8
-             - 0.0.72
+              - 0.0.8
+              - 0.0.72
             token_id: 0.0.90001
     Transactions:
       type: array
@@ -1592,9 +1601,11 @@ components:
           summary: Example of timestamp less than or equals operator
           value: lte:1234567890.000000700
       schema:
-        type: string
-        format: >
-          ^(\d{1,10}.\d{1,9}|gte?:\d{1,10}.\d{1,9}|lte?:\d{1,10}.\d{1,9}|eq:\d{1,10}.\d{1,9}|ne:\d{1,10}.\d{1,9})$
+        type: array
+        items:
+          type: string
+          format: >
+            ^(\d{1,10}.\d{1,9}|gte?:\d{1,10}.\d{1,9}|lte?:\d{1,10}.\d{1,9}|eq:\d{1,10}.\d{1,9}|ne:\d{1,10}.\d{1,9})$
     tokenInfoTimestampQueryParam:
       name: timestamp
       in: query
@@ -1654,7 +1665,7 @@ components:
         items:
           type: string
     tokenIdPathParam:
-      name: tokenid
+      name: tokenId
       in: path
       required: true
       description: Token entity id


### PR DESCRIPTION
Signed-off-by: Long Nguyen <longnguyen@circle.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies our OpenAPI spec YAML file to fix some glaring bugs that pass client generation, but _do not_ pass actual usage when writing real code that attempts to talk to the REST API.

**Related issue(s)**: #2447 

Fixes # 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
- `tokenid` -> `tokenId` The API spec had this case typo, which trickles down into the generated Jersey client and causes us to fail to send the right query parameter.
- Supply fields had the wrong type; screenshots included.
- Three unknown fields were added, which should have been added at the time of their implementation in the mirror node: `transaction.bytes`, `transaction.entity_id`, and `token.fee_schedule_key`. From now on, if you add any new fields to any objects in the API, _please_ add them to the spec as well. OpenAPI Generator does _not_ have an option to inject the generated client files with `@IgnoreUnknownProperties`, and likely never will, so any time the generated client sees an unknown property, it fails fast and breaks downstream code.
- `api/v1/transactions` can actually take multiple timestamp constraints to provide a clear search window with left and right boundaries, ex. https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?timestamp=lte:2000000000.711927001&&timestamp=gte:1500000000.711927001. I updated the spec to reflect this, and it does work as expected (Jersey will send all parameters).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
