### PR TITLE
Fix non-deterministic order of fees in token REST API

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/token-info-05-custom-fees.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/token-info-05-custom-fees.spec.json
@@ -149,16 +149,6 @@
       "fractional_fees": [
         {
           "amount": {
-            "denominator": 13,
-            "numerator": 9
-          },
-          "collector_account_id": "0.0.8902",
-          "denominating_token_id": "0.0.1135",
-          "minimum": 1,
-          "net_of_transfers": false
-        },
-        {
-          "amount": {
             "denominator": 17,
             "numerator": 11
           },
@@ -166,6 +156,16 @@
           "denominating_token_id": "0.0.1135",
           "maximum": 987,
           "minimum": 79,
+          "net_of_transfers": false
+        },
+        {
+          "amount": {
+            "denominator": 13,
+            "numerator": 9
+          },
+          "collector_account_id": "0.0.8902",
+          "denominating_token_id": "0.0.1135",
+          "minimum": 1,
           "net_of_transfers": false
         },
         {

--- a/hedera-mirror-rest/__tests__/specs/token-info-09-nft-custom-fees.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/token-info-09-nft-custom-fees.spec.json
@@ -147,14 +147,10 @@
       "royalty_fees": [
         {
           "amount": {
-            "denominator": 131,
-            "numerator": 41
+            "denominator": 17,
+            "numerator": 11
           },
-          "collector_account_id": "0.0.8904",
-          "fallback_fee": {
-            "amount": 8,
-            "denominating_token_id": null
-          }
+          "collector_account_id": "0.0.8901"
         },
         {
           "amount": {
@@ -169,10 +165,14 @@
         },
         {
           "amount": {
-            "denominator": 17,
-            "numerator": 11
+            "denominator": 131,
+            "numerator": 41
           },
-          "collector_account_id": "0.0.8901"
+          "collector_account_id": "0.0.8904",
+          "fallback_fee": {
+            "amount": 8,
+            "denominating_token_id": null
+          }
         }
       ]
     }

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1338,7 +1338,7 @@ describe('token extractSqlFromTokenInfoRequest tests', () => {
                      'royalty_denominator', royalty_denominator,
                      'royalty_numerator', royalty_numerator,
                      'token_id', token_id::text
-                    ) order by amount, collector_account_id, denominating_token_id)
+                    ) order by collector_account_id, denominating_token_id, amount, royalty_numerator)
                     from custom_fee cf
                     where token_id = $1 ${timestampCondition && 'and ' + timestampCondition}
                     group by cf.created_timestamp

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -423,7 +423,9 @@ const extractSqlFromTokenInfoRequest = (tokenId, filters) => {
         'royalty_denominator', ${CustomFee.ROYALTY_DENOMINATOR},
         'royalty_numerator', ${CustomFee.ROYALTY_NUMERATOR},
         'token_id', ${CustomFee.TOKEN_ID}::text
-    ) order by ${CustomFee.AMOUNT}, ${CustomFee.COLLECTOR_ACCOUNT_ID}, ${CustomFee.DENOMINATING_TOKEN_ID})
+    ) order by ${CustomFee.COLLECTOR_ACCOUNT_ID}, ${CustomFee.DENOMINATING_TOKEN_ID}, ${CustomFee.AMOUNT}, ${
+    CustomFee.ROYALTY_NUMERATOR
+  })
     from ${CustomFee.tableName} ${CustomFee.tableAlias}
     where ${conditions.join(' and ')}
     group by ${CustomFee.CREATED_TIMESTAMP_FULL_NAME}


### PR DESCRIPTION
**Description**:
Fix non-deterministic order of fees in token REST API

**Related issue(s)**:

**Notes for reviewer**:
It doesn't make sense to sort by `amount` first because it can be null (for some royalty fees) or part of a fraction. The `amount` would then appear in different fields depending upon type.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
