### PR TITLE
Update OpenAPI max_automatic_token_associations type to int32 (0.43)

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -786,7 +786,7 @@ components:
           $ref: '#/components/schemas/Key'
         max_automatic_token_associations:
           type: integer
-          format: int64
+          format: int32
         memo:
           type: string
         receiver_sig_required:


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
In OpenAPI spec `max_automatic_token_associations` was incorrectly set as an `int64` type, when in should be to int32

- Update OpenAPI `max_automatic_token_associations` type to `int32`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
