### PR TITLE
Add missing TOKENPAUSE/UNPAUSE to OpenApi spec

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1357,6 +1357,7 @@ components:
         - TOKENFREEZE
         - TOKENGRANTKYC
         - TOKENMINT
+        - TOKENPAUSE
         - TOKENREVOKEKYC
         - TOKENUNFREEZE
         - TOKENUNPAUSE


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

PR https://github.com/hashgraph/hedera-mirror-node/pull/2602 added token pausing support, but this was never actually addressed in `openapi.yml`, causing our deserialization to complain.

```
Wrapped by: com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `org.openapitools.client.model.TransactionTypes`, problem: Unexpected value 'TOKENUNPAUSE'
```

**Related issue(s)**:

Fixes #

- Added `TOKENPAUSE` and `TOKENUNPAUSE` to the list of supported transaction types.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
