### PR TITLE
Add missing TOKENPAUSE/UNPAUSE to OpenApi spec (0.43)

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1357,8 +1357,10 @@ components:
         - TOKENFREEZE
         - TOKENGRANTKYC
         - TOKENMINT
+        - TOKENPAUSE
         - TOKENREVOKEKYC
         - TOKENUNFREEZE
+        - TOKENUNPAUSE
         - TOKENUPDATE
         - TOKENWIPE
         - UNCHECKEDSUBMIT


### PR DESCRIPTION
**Description**:
Port of #2762 to `release/0.43`:
* Add missing TOKENUNPAUSE to OpenApi spec
* Add missing TOKENPAUSE to OpenApi spec

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
