### PR TITLE
Disable validate-maintainers check in chart linting

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,3 +5,5 @@ chart-repos:
   - timescaledb=https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   - traefik=https://helm.traefik.io/traefik
 check-version-increment: false
+validate-maintainers: false
+


### PR DESCRIPTION
**Description**:
The chart-testing tool by default validates chart maintainers against the GitHub API and it was being rate limited with `Error validating maintainer 'xin-hedera': 429 Too Many Requests`.

* Disable validate-maintainers check in chart linting

**Related issue(s)**:

**Notes for reviewer**:
Maintainers list never changes and if it does we can manually validate during PR review.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
