### PR TITLE
Fix Rosetta SQL parsing int4 overflow issue

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/block.go
+++ b/hedera-mirror-rosetta/app/persistence/block.go
@@ -81,7 +81,7 @@ const (
                                              coalesce((
                                                select consensus_start-1
                                                from record_file
-                                               where index = @index + 1
+                                               where index = @index + 1::bigint
                                              ), consensus_end) as consensus_end,
                                              hash,
                                              index,

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -21,6 +21,8 @@
 package persistence
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
@@ -462,6 +464,32 @@ func (suite *blockRepositorySuite) TestRetrieveGenesis() {
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), expectedGenesisBlock, actual)
+}
+
+func (suite *blockRepositorySuite) TestRetrieveGenesisIndexOverflowInt4() {
+	genesisIndexes := []int64{int64(math.MaxInt32) + 1, int64(math.MinInt32) - 1}
+	for _, genesisIndex := range genesisIndexes {
+		suite.T().Run(fmt.Sprintf("%d", genesisIndex), func(t *testing.T) {
+			// given
+			db.ExecSql(dbClient, truncateRecordFileSql)
+			recordFile1 := *recordFiles[0]
+			recordFile1.Index = genesisIndex
+			recordFile2 := *recordFiles[1]
+			recordFile2.Index = genesisIndex + 1
+			db.CreateDbRecords(dbClient, []*domain.RecordFile{&recordFile1, &recordFile2})
+			expected := *expectedGenesisBlock
+			expected.Index = genesisIndex
+			expected.ParentIndex = genesisIndex
+			repo := NewBlockRepository(dbClient)
+
+			// when
+			actual, err := repo.RetrieveGenesis(defaultContext)
+
+			// then
+			assert.Nil(suite.T(), err)
+			assert.Equal(suite.T(), &expected, actual)
+		})
+	}
 }
 
 func (suite *blockRepositorySuite) TestRetrieveGenesisNoAccountBalanceFile() {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the SQL parsing int4 overflow issue in Rosetta

- Add explicit `::bigint` conversion in named SQL param arithmetic operation

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
go's SQL & Postgres parser will treat the named param in `where index = @index + 1` as a pg `int4` if there's no explicit type conversion to indicate it's a `bigint` / pg `int8`.


```sql
select consensus_start,
       coalesce((
         select consensus_start-1
         from record_file
         where index = @index + 1
       ), consensus_end) as consensus_end,
       hash,
       index,
       prev_hash
from record_file
where index = @index
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
