### PR TITLE
HIP-584: Disable isApprovedForAll ERC precompile (0.78)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,6 +553,7 @@ Name                                                        | Default           
 `hedera.mirror.web3.db.sslMode`                             | DISABLE                                    | The ssl level of protection against eavesdropping, man-in-the-middle (MITM) and impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA or VERIFY_FULL.
 `hedera.mirror.web3.db.username`                            | mirror_web3                                | The username used to connect to the database
 `hedera.mirror.web3.evm.allowanceEnabled`                   | false                                      | Flag enabling ERC approve precompile
+`hedera.mirror.web3.evm.approvedForAllEnabled`              | false                                      | Flag enabling ERC isApprovedForAll precompile
 `hedera.mirror.web3.evm.directTokenCall`                    | true                                       | Flag enabling contract like calls to tokens
 `hedera.mirror.web3.evm.dynamicEvmVersion`                  | false                                      | Flag indicating whether a dynamic evm version to be used
 `hedera.mirror.web3.evm.evmVersion`                         | v0.32                                      | The besu EVM version to be used as dynamic one

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -46,7 +46,10 @@ import static com.swirlds.common.utility.CommonUtils.unhex;
 public class MirrorNodeEvmProperties implements EvmProperties {
     @Getter
     private boolean allowanceEnabled = false;
-    
+
+    @Getter
+    private boolean approvedForAllEnabled = false;
+
     private boolean directTokenCall = true;
 
     private boolean dynamicEvmVersion = true;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -244,6 +244,10 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     @Override
     public boolean staticIsOperator(final Address owner, final Address operator, final Address token) {
+        if (!properties.isApprovedForAllEnabled()) {
+            throw new UnsupportedOperationException("isApprovedForAll(address owner, address operator) is not supported.");
+        }
+
         final var nftAllowanceId = new AbstractNftAllowance.Id();
         nftAllowanceId.setOwner(entityIdFromAccountAddress(owner));
         nftAllowanceId.setSpender(entityIdFromAccountAddress(operator));

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -73,6 +73,7 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
     @EnumSource(ContractFunctions.class)
     void ercPrecompileOperationsTest(ContractFunctions ercFunction) {
         properties.setAllowanceEnabled(true);
+        properties.setApprovedForAllEnabled(true);
 
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(ercFunction.name, ABI_PATH, ercFunction.functionParameters);
@@ -99,6 +100,16 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
                 isInstanceOf(UnsupportedOperationException.class).hasMessage("allowance(address owner, address spender) is not supported.");
+    }
+
+    @Test
+    void unsupportedIsApprovedForAllPrecompileTest() {
+        final var functionHash =
+                functionEncodeDecoder.functionHashFor("isApprovedForAll", ABI_PATH, new Address[] {NFT_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS});
+        final var serviceParameters = serviceParameters(functionHash);
+
+        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
+                isInstanceOf(UnsupportedOperationException.class).hasMessage("isApprovedForAll(address owner, address operator) is not supported.");
     }
 
     @RequiredArgsConstructor


### PR DESCRIPTION
**Description**:

This PR disables the function isApprovedForAll(address token, address owner, address operator) public view returns (bool) precompile by throwing UnsupportedOperationException if it is accessed. There are some incorrect data

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
