### PR TITLE
Fix importer crash on startup

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
@@ -35,7 +34,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Data
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Validated
 @ConfigurationProperties("hedera.mirror.importer")
 public class MirrorProperties {
@@ -72,7 +70,7 @@ public class MirrorProperties {
     @NotNull
     private Instant verifyHashAfter = Instant.EPOCH;
 
-    public String getNetworkPrefix() {
+    public String getEffectiveNetwork() {
         if (!StringUtils.isBlank(networkPrefix)) {
             return networkPrefix.toLowerCase();
         } else {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -125,7 +125,7 @@ public final class S3StreamFileProvider implements StreamFileProvider {
     }
 
     private String getNodeIdPrefix(PathKey key) {
-        var networkPrefix = commonDownloaderProperties.getMirrorProperties().getNetworkPrefix();
+        var networkPrefix = commonDownloaderProperties.getMirrorProperties().getEffectiveNetwork();
         var shard = commonDownloaderProperties.getMirrorProperties().getShard();
         var streamFolder = key.type().getNodeIdBasedSuffix();
         return TEMPLATE_NODE_ID_PREFIX.formatted(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/MirrorPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/MirrorPropertiesTest.java
@@ -44,14 +44,14 @@ class MirrorPropertiesTest {
     void networkPrefixDefined(HederaNetwork network) {
         mirrorProperties.setNetworkPrefix(MIXED_CASE_NETWORK_PREFIX);
         mirrorProperties.setNetwork(network);
-        assertEquals(LOWER_CASE_NETWORK_PREFIX, mirrorProperties.getNetworkPrefix());
+        assertEquals(LOWER_CASE_NETWORK_PREFIX, mirrorProperties.getEffectiveNetwork());
     }
 
     @ParameterizedTest(name = "Default to lowercase network name: {0}")
     @EnumSource(value = HederaNetwork.class, mode = Mode.EXCLUDE, names = "OTHER")
     void networkPrefixUndefined(HederaNetwork network) {
         mirrorProperties.setNetwork(network);
-        assertEquals(network.name().toLowerCase(), mirrorProperties.getNetworkPrefix());
+        assertEquals(network.name().toLowerCase(), mirrorProperties.getEffectiveNetwork());
     }
 
     @Test
@@ -59,7 +59,7 @@ class MirrorPropertiesTest {
         mirrorProperties.setNetwork(HederaNetwork.OTHER);
         assertThrows(
                 InvalidConfigurationException.class,
-                () -> mirrorProperties.getNetworkPrefix(),
+                () -> mirrorProperties.getEffectiveNetwork(),
                 "InvalidConfigurationException was expected");
     }
 }


### PR DESCRIPTION
**Description**:
Prevent lombok generated `hashCode()` from invoking `getNetworkPrefix()`.  If the `networkPrefix` property is not set when `network` is set to `OTHER`, `InvalidConfigurationException` will be thrown and while the Spring application context is being created and the downloader will fail to start up.

* Rename `getNetworkPrefix()` to `getEffectiveNetwork()` so it is not associated with the `networkPrefix` field.

**Related issue(s)**:

Fixes #6025

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
