### PR TITLE
Fix contractId key in contract call (0.85)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JContractIDKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JContractIDKey.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.jproto;
+
+import com.hederahashgraph.api.proto.java.ContractID;
+
+/**
+ * Maps to proto Key of type contractID.
+ *
+ * <p>Just as a public-private key pair is used to control permissions for a Hedera entity (e.g., an
+ * account), a {@code contractID} key is <i>also</i> used to control permissions for an entity. The
+ * difference is that a {@code contractID} key requires a particular contract to be executing in
+ * order to count as having "signed".
+ *
+ * <p>For example, suppose {@code 0.0.X} is an account. Its key is {@code Key{contractID=0.0.C}}.
+ *
+ * <p>Then <b>if</b> we are executing a contract operation, and the EVM receiver address in the
+ * current frame is {@code 0.0.C}, then this EVM transaction can use system contracts to, for
+ * example, transfer all the hbar from account {@code 0.0.X}.
+ */
+public class JContractIDKey extends JKey {
+    private final long shardNum;
+    private final long realmNum;
+    private final long contractNum;
+
+    public JContractIDKey(final ContractID contractID) {
+        this.shardNum = contractID.getShardNum();
+        this.realmNum = contractID.getRealmNum();
+        this.contractNum = contractID.getContractNum();
+    }
+
+    @Override
+    public JContractIDKey getContractIDKey() {
+        return this;
+    }
+
+    @Override
+    public boolean hasContractID() {
+        return true;
+    }
+
+    public ContractID getContractID() {
+        return ContractID.newBuilder()
+                .setShardNum(shardNum)
+                .setRealmNum(realmNum)
+                .setContractNum(contractNum)
+                .build();
+    }
+
+    public long getShardNum() {
+        return shardNum;
+    }
+
+    public long getRealmNum() {
+        return realmNum;
+    }
+
+    @Override
+    public String toString() {
+        return "<JContractID: " + shardNum + "." + realmNum + "." + contractNum + ">";
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (0 == contractNum);
+    }
+
+    @Override
+    public boolean isValid() {
+        return !isEmpty();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
@@ -124,6 +124,10 @@ public abstract class JKey {
             rv = Key.newBuilder()
                     .setECDSASecp256K1(ByteString.copyFrom(jkey.getECDSASecp256k1Key()))
                     .build();
+        } else if (jkey.hasContractID()) {
+            rv = Key.newBuilder()
+                    .setContractID(jkey.getContractIDKey().getContractID())
+                    .build();
         } else {
             throw new DecoderException("Key type not implemented: key=" + jkey);
         }
@@ -146,6 +150,8 @@ public abstract class JKey {
         } else if (!key.getECDSASecp256K1().isEmpty()) {
             byte[] pubKeyBytes = key.getECDSASecp256K1().toByteArray();
             rv = new JECDSASecp256k1Key(pubKeyBytes);
+        } else if (key.getContractID().getContractNum() != 0) {
+            rv = new JContractIDKey(key.getContractID());
         } else {
             throw new org.apache.commons.codec.DecoderException("Key type not implemented: key=" + key);
         }
@@ -180,6 +186,10 @@ public abstract class JKey {
         return false;
     }
 
+    public boolean hasContractID() {
+        return false;
+    }
+
     public boolean hasKeyList() {
         return false;
     }
@@ -198,5 +208,9 @@ public abstract class JKey {
 
     public byte[] getECDSASecp256k1Key() {
         return MISSING_ECDSA_SECP256K1_KEY;
+    }
+
+    public JContractIDKey getContractIDKey() {
+        return null;
     }
 }


### PR DESCRIPTION
**Description**:

Executing eth_call for getTokenKey returns an empty struct if the chosen key is of type ContractID. We need to add mapping for ContractID in Jkey

**Related issue(s)**:

Fixes #6478

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
