### PR TITLE
HIP-584: Adapt resolving address for evm addressed contract with long zero address eth_call

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -46,6 +46,9 @@ public class AccountAccessorImpl implements AccountAccessor {
     }
 
     public Address getAddressOrAlias(final Address address) {
+        if (mirrorEntityAccess.isExtant(address)) {
+            return address;
+        }
         // An EIP-1014 address is always canonical
         if (!aliases.isMirror(address)) {
             return address;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -103,4 +103,11 @@ class AccountAccessorImplTest {
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ECDSA_KEY_ALIAS_ADDRESS);
     }
+
+    @Test
+    void getAddress() {
+        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
+        final var result = accountAccessor.canonicalAddress(ADDRESS);
+        assertThat(result).isEqualTo(ADDRESS);
+    }
 }


### PR DESCRIPTION
**Description**:
- create an erc20 contract, not HTS - ie 0x710b04f6ab801c65d85dd618f753749835537d6f
- query the mirror node to get contract info - http://localhost:5551/api/v1/contracts/0x710b04f6ab801c65d85dd618f753749835537d6f returns id 0.0.1054
- calculate the contract's long zero address - 0x000000000000000000000000000000000000041e
- execute eth_call for .name() with long zero address - expect to be successful but throws an error

Fixed AccountAccessorImpl to check if the account is extant before checking for aliases

**Related issue(s)**:

Fixes #6498 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
