### PR TITLE
Fix multiple bean definition errors in web3

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -157,11 +157,6 @@ public class EvmConfiguration {
     }
 
     @Bean
-    MessageCallProcessor messageCallProcessor(final EVM evm, final PrecompileContractRegistry precompiles) {
-        return new MessageCallProcessor(evm, precompiles);
-    }
-
-    @Bean
     Map<String, Provider<ContractCreationProcessor>> contractCreationProcessors(
             final ContractCreationProcessor contractCreationProcessor) {
         return Map.of(
@@ -170,8 +165,8 @@ public class EvmConfiguration {
 
     @Bean
     Map<String, Provider<MessageCallProcessor>> messageCallProcessors(
-            final MessageCallProcessor messageCallProcessor,
-            final MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor) {
+            EVM evm, MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor) {
+        var messageCallProcessor = new MessageCallProcessor(evm, precompileContractRegistry());
         return Map.of(
                 EVM_VERSION_0_30, () -> messageCallProcessor, EVM_VERSION_0_34, () -> mirrorEvmMessageCallProcessor);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -714,18 +714,16 @@ public class ServicesConfiguration {
 
     @Bean
     HTSPrecompiledContract htsPrecompiledContract(
-            final EvmInfrastructureFactory evmInfrastructureFactory,
             final MirrorNodeEvmProperties mirrorNodeEvmProperties,
             final PrecompileMapper precompileMapper,
-            final EvmHTSPrecompiledContract evmHTSPrecompiledContract,
             final Store store,
             final TokenAccessorImpl tokenAccessor,
             final PrecompilePricingUtils precompilePricingUtils) {
         return new HTSPrecompiledContract(
-                evmInfrastructureFactory,
+                evmInfrastructureFactory(),
                 mirrorNodeEvmProperties,
                 precompileMapper,
-                evmHTSPrecompiledContract,
+                evmHTSPrecompiledContract(),
                 store,
                 tokenAccessor,
                 precompilePricingUtils);


### PR DESCRIPTION
**Description**:

* Fix `NoUniqueBeanDefinitionException` for `EvmHTSPrecompiledContract`
* Fix `NoUniqueBeanDefinitionException` for `MessageCallProcessor`

**Related issue(s)**:

Fixes #7339

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
