### PR TITLE
ci: Fix labels on runs-on stanza such that they use Linux instead of linux

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -42,7 +42,7 @@ jobs:
         run: ct lint --config .github/ct.yaml --all
 
   install:
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     if: github.event.client_payload.severity == 'info'
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     env:
       RELEASE_NOTES_FILENAME: release_notes
     outputs:
@@ -143,7 +143,7 @@ jobs:
 
   create_pr:
     name: Create PR
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     needs: release
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       CONTEXT: hedera-mirror-${{ matrix.project }}
       IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.project }}
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -94,7 +94,7 @@ jobs:
 
   deploy:
     needs: publish
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -34,7 +34,7 @@ jobs:
       CONTEXT: hedera-mirror-${{ matrix.project }}
       IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.project }}
     name: Publish images
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -96,7 +96,7 @@ jobs:
   chart:
     name: Publish charts
     needs: image
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     permissions:
       contents: write
     steps:
@@ -121,7 +121,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: [self-hosted, linux, large, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     timeout-minutes: 15
     env:
       MPDEV: "/home/runner/mpdev"


### PR DESCRIPTION
**Description**:

replace the `linux` label with `Linux` on the self-hosted runner `runs-on` stanza.

**Related issue(s)**:

Fixes #8627

**Notes for reviewer**:

labels are case insensitive, the update is more for consistency.

