### PR TITLE
Fix Gradle JUnit deprecation warnings

### DIFF
--- a/hedera-mirror-common/build.gradle.kts
+++ b/hedera-mirror-common/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("io.micrometer:micrometer-core")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testClasses(sourceSets["test"].output)
 }
 

--- a/hedera-mirror-graphql/build.gradle.kts
+++ b/hedera-mirror-graphql/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.springframework.graphql:spring-graphql-test")
     testImplementation("org.testcontainers:postgresql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 generatePojoConf {

--- a/hedera-mirror-grpc/build.gradle.kts
+++ b/hedera-mirror-grpc/build.gradle.kts
@@ -55,4 +55,5 @@ dependencies {
     testImplementation("org.flywaydb:flyway-database-postgresql")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/hedera-mirror-importer/build.gradle.kts
+++ b/hedera-mirror-importer/build.gradle.kts
@@ -67,4 +67,5 @@ dependencies {
     testImplementation("org.gaul:s3proxy")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/hedera-mirror-monitor/build.gradle.kts
+++ b/hedera-mirror-monitor/build.gradle.kts
@@ -52,4 +52,5 @@ dependencies {
     testImplementation("io.fabric8:kubernetes-server-mock")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("uk.org.webcompere:system-stubs-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/hedera-mirror-rest-java/build.gradle.kts
+++ b/hedera-mirror-rest-java/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.compileJava {

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     testImplementation("org.mockito:mockito-inline")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 web3j {


### PR DESCRIPTION
**Description**:

Fix the below Gradle JUnit deprecation warning:

```
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.11.1/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
```

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
