### PR TITLE
Update web3 docs for newer unsupported operations

### DIFF
--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -12,7 +12,7 @@ is used for the persistence layer.
 ## Supported Operations
 
 | Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- | ---------- | ----- | ------------- |
+|----------|--------|-------------------------------------------------------------------------------------------|-----------|------------|-------|---------------|
 | Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
 | Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
@@ -22,6 +22,16 @@ is used for the persistence layer.
 | Y        | N      | modifying operations for HTS system contract                                              | Y         | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block
+
+## Unsupported Operations
+
+| Operation Type                                                | Supported |
+|---------------------------------------------------------------|-----------|
+| operations for HederaAccountService system contract           | N         |
+| operations for HederaScheduleService system contract          | N         | 
+| token airdrop operations (airdropTokens, claimAirdrops, etc.) | N         | 
+| update token custom fees                                      | N         |
+| HRC isAssociated()                                            | N         |
 
 ## Acceptance Tests
 

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -12,7 +12,7 @@ is used for the persistence layer.
 ## Supported Operations
 
 | Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-|----------|--------|-------------------------------------------------------------------------------------------|-----------|------------|-------|---------------|
+| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- | ---------- | ----- | ------------- |
 | Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
 | Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
@@ -26,10 +26,10 @@ _Note:_ Gas estimation only supports the `latest` block
 ## Unsupported Operations
 
 | Operation Type                                                | Supported |
-|---------------------------------------------------------------|-----------|
+| ------------------------------------------------------------- | --------- |
 | operations for HederaAccountService system contract           | N         |
-| operations for HederaScheduleService system contract          | N         | 
-| token airdrop operations (airdropTokens, claimAirdrops, etc.) | N         | 
+| operations for HederaScheduleService system contract          | N         |
+| token airdrop operations (airdropTokens, claimAirdrops, etc.) | N         |
 | update token custom fees                                      | N         |
 | HRC isAssociated()                                            | N         |
 

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -11,27 +11,27 @@ is used for the persistence layer.
 
 ## Supported Operations
 
-| Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- | ---------- | ----- | ------------- |
-| Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
-| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
-| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
-| Y        | Y      | read-only ERC precompile functions                                                        | Y         | Y          | Y     | N             |
-| Y        | Y      | modifying ERC precompile functions                                                        | Y         | Y          | Y     | Y             |
-| Y        | Y      | read-only operations for HTS system contract                                              | Y         | Y          | Y     | N             |
-| Y        | N      | modifying operations for HTS system contract                                              | Y         | Y          | Y     | Y             |
+| Estimate | Static | Operation Type                                                                            | Historical | Reads | Modifications |
+| -------- | ------ | ----------------------------------------------------------------------------------------- | ---------- | ----- | ------------- |
+| Y        | Y      | non precompile functions                                                                  | Y          | Y     | Y             |
+| Y        | N      | non precompile functions with lazy account creation                                       | Y          | Y     | Y             |
+| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y          | Y     | N             |
+| Y        | Y      | read-only ERC precompile functions                                                        | Y          | Y     | N             |
+| Y        | Y      | modifying ERC precompile functions                                                        | Y          | Y     | Y             |
+| Y        | Y      | read-only operations for HTS system contract                                              | Y          | Y     | N             |
+| Y        | N      | modifying operations for HTS system contract                                              | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block
 
 ## Unsupported Operations
 
-| Operation Type                                                | Supported |
-| ------------------------------------------------------------- | --------- |
-| operations for HederaAccountService system contract           | N         |
-| operations for HederaScheduleService system contract          | N         |
-| token airdrop operations (airdropTokens, claimAirdrops, etc.) | N         |
-| update token custom fees                                      | N         |
-| HRC isAssociated()                                            | N         |
+| Operation Type                                                |
+| ------------------------------------------------------------- |
+| operations for HederaAccountService system contract           |
+| operations for HederaScheduleService system contract          |
+| token airdrop operations (airdropTokens, claimAirdrops, etc.) |
+| update token custom fees                                      |
+| HRC isAssociated()                                            |
 
 ## Acceptance Tests
 


### PR DESCRIPTION
**Description**:
Update web3 docs and add any new precompiles added after the modularization and are still unsupported from web3 logic.

**Related issue(s)**:

Fixes #10421 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
