### PR TITLE
ci: Update runners to use new hiero configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*   @hashgraph/mirror-node
+*   @hiero-ledger/hiero-mirror-node-maintainers
 
 #########################
 #####  Core Files  ######
@@ -8,23 +8,23 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/mirror-node @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/mirror-node @hashgraph/release-engineering-managers
+/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-mirror-node-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-mirror-node-maintainers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
-.remarkrc                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
+/config/                                        @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers
+.remarkrc                                       @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
-**/LICENSE                                      @hashgraph/release-engineering-managers
+/README.md                                      @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers
+**/LICENSE                                      @hiero-ledger/github-maintainers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
+**/codecov.yml                                  @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
-**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/mirror-node
+**/.gitignore                                   @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers
+**/.gitignore.*                                 @hiero-ledger/github-maintainers  @hiero-ledger/hiero-mirror-node-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*   @hiero-ledger/hiero-mirror-node-maintainers
+*                                               @hiero-ledger/hiero-mirror-node-committers
 
 #########################
 #####  Core Files  ######

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -42,7 +42,7 @@ jobs:
         run: ct lint --config .github/ct.yaml --all
 
   install:
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   images:
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     strategy:
       matrix:
         module:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     if: github.event.client_payload.severity == 'info'
     steps:
       - name: Harden Runner

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     strategy:
       matrix:
         project:

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     env:
       RELEASE_NOTES_FILENAME: release_notes
     outputs:
@@ -143,7 +143,7 @@ jobs:
 
   create_pr:
     name: Create PR
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     needs: release
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       CONTEXT: hedera-mirror-${{ matrix.project }}
       IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.project }}
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -99,7 +99,7 @@ jobs:
 
   deploy:
     needs: publish
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -34,7 +34,7 @@ jobs:
       CONTEXT: hedera-mirror-${{ matrix.project }}
       IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.project }}
     name: Publish images
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -102,7 +102,7 @@ jobs:
   chart:
     name: Publish charts
     needs: image
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     permissions:
       contents: write
     steps:
@@ -127,7 +127,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     timeout-minutes: 15
     env:
       MPDEV: "/home/runner/mpdev"

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   validate:
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     timeout-minutes: 30
     env:
       ROSETTA_CLI_VERSION: v0.10.3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   dependencies:
     name: Dependency Check
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Harden Runner
@@ -73,7 +73,7 @@ jobs:
     name: GoSec Code Scan
     env:
       GO111MODULE: on
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -109,7 +109,7 @@ jobs:
   sonar:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: SonarCloud
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -151,7 +151,7 @@ jobs:
   snyk:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: Snyk Open Source
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -198,7 +198,7 @@ jobs:
   snyk-code:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: Snyk Code
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -244,7 +244,7 @@ jobs:
 
   spotless-check:
     name: Spotless Code Format Check
-    runs-on: mirror-node-linux-medium
+    runs-on: hiero-mirror-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   snyk-monitor:
     name: Snyk Monitor
-    runs-on: mirror-node-linux-large
+    runs-on: hiero-mirror-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ hedera-mirror-test/src/test/resources/solidity/artifacts/@openzeppelin.contracts
 .gradle
 build
 !gradle/wrapper/gradle-wrapper.jar
+**/.kotlin/
 
 # Security
 .dccache

--- a/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
+++ b/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
@@ -33,16 +33,16 @@ abstract class SnykCodeTask : io.snyk.gradle.plugin.SnykTask() {
 tasks.register<SnykCodeTask>("snyk-code") {
     dependsOn("snyk-check-binary")
     snyk {
-        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-code.json")
+        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-code.json --org=hiero-mirror-node")
         setSeverity("high")
     }
 }
 
-tasks.`snyk-monitor` { doFirst { snyk { setArguments("--all-sub-projects") } } }
+tasks.`snyk-monitor` { doFirst { snyk { setArguments("--all-sub-projects --org=hiero-mirror-node") } } }
 
 tasks.`snyk-test` {
     snyk {
-        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-test.json")
+        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-test.json --org=hiero-mirror-node")
         setSeverity("high")
     }
 }

--- a/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
+++ b/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
@@ -33,16 +33,22 @@ abstract class SnykCodeTask : io.snyk.gradle.plugin.SnykTask() {
 tasks.register<SnykCodeTask>("snyk-code") {
     dependsOn("snyk-check-binary")
     snyk {
-        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-code.json --org=hiero-mirror-node")
+        setArguments(
+            "--all-sub-projects --json-file-output=build/reports/snyk-code.json --org=hiero-mirror-node"
+        )
         setSeverity("high")
     }
 }
 
-tasks.`snyk-monitor` { doFirst { snyk { setArguments("--all-sub-projects --org=hiero-mirror-node") } } }
+tasks.`snyk-monitor` {
+    doFirst { snyk { setArguments("--all-sub-projects --org=hiero-mirror-node") } }
+}
 
 tasks.`snyk-test` {
     snyk {
-        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-test.json --org=hiero-mirror-node")
+        setArguments(
+            "--all-sub-projects --json-file-output=build/reports/snyk-test.json --org=hiero-mirror-node"
+        )
         setSeverity("high")
     }
 }


### PR DESCRIPTION
**Details**:

Changes the runners to use the hiero-mirror-node-linux-* runner namespaces

Updates CODEOWNERS file

Adds **/.kotlin/ to .gitignore

**Related Issue(s)**

Fixes #10423 