### PR TITLE
Update REST API tokens query to correct for deleted token timestamps

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
@@ -18,7 +18,8 @@
         "type": "TOKEN",
         "memo": "token.0.0.1135",
         "expiration_timestamp": "1234567890000010001",
-        "deleted": false
+        "deleted": false,
+        "timestamp_range": "[1234567890000000002,)"
       },
       {
         "realm": 7,

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
@@ -19,7 +19,7 @@
         "memo": "token.0.0.1135",
         "expiration_timestamp": "1234567890000010001",
         "deleted": false,
-        "timestamp_range": "[1234567890000000002,)"
+        "timestamp_range": "[1234567890000000001,)"
       },
       {
         "realm": 7,

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/historical-custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/historical-custom-fees.json
@@ -17,7 +17,8 @@
         "num": 1135,
         "type": "TOKEN",
         "memo": "token.0.0.1135",
-        "deleted": false
+        "deleted": false,
+        "timestamp_range": "[1234567890000000002,)"
       },
       {
         "realm": 7,

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/nft-custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/nft-custom-fees.json
@@ -17,7 +17,8 @@
         "num": 1135,
         "type": "TOKEN",
         "memo": "token.0.0.1135",
-        "deleted": false
+        "deleted": false,
+        "timestamp_range": "[1234567890000000002,)"
       },
       {
         "realm": 7,

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
@@ -11,7 +11,7 @@
       {
         "auto_renew_period": 6999999,
         "num": 1135,
-        "timestamp_range": "[1234567890000000002,)",
+        "timestamp_range": "[1234567890000000003,)",
         "type": "TOKEN",
         "memo": "token.0.0.1135",
         "deleted": null
@@ -97,7 +97,7 @@
       "_type": "ProtobufEncoded",
       "key": "34613561643531346630393537666131373061363736323130633962646264646633626339353139373032636639313566613637363761343034363362393678"
     },
-    "modified_timestamp": "1234567890.000000002",
+    "modified_timestamp": "1234567890.000000003",
     "name": "Token name",
     "pause_key": null,
     "pause_status": "NOT_APPLICABLE",

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
@@ -11,6 +11,7 @@
       {
         "auto_renew_period": 6999999,
         "num": 1135,
+        "timestamp_range": "[1234567890000000002,)",
         "type": "TOKEN",
         "memo": "token.0.0.1135",
         "deleted": null

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/non-fungible-unique-token-types.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/non-fungible-unique-token-types.json
@@ -13,7 +13,8 @@
         "auto_renew_account_id": 0,
         "type": "TOKEN",
         "memo": "token.0.0.1135",
-        "deleted": false
+        "deleted": false,
+        "timestamp_range": "[1234567890000000002,)"
       },
       {
         "realm": 7,

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1444,7 +1444,7 @@ describe('token extractSqlFromTokenInfoRequest tests', () => {
                    e.memo,
                    metadata,
                    metadata_key,
-                   lower(t.timestamp_range) as modified_timestamp,
+                   lower(e.timestamp_range) as modified_timestamp,
                    name,
                    pause_key,
                    pause_status,

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1444,7 +1444,7 @@ describe('token extractSqlFromTokenInfoRequest tests', () => {
                    e.memo,
                    metadata,
                    metadata_key,
-                   greater(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp,
+                   greatest(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp,
                    name,
                    pause_key,
                    pause_status,

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1444,7 +1444,7 @@ describe('token extractSqlFromTokenInfoRequest tests', () => {
                    e.memo,
                    metadata,
                    metadata_key,
-                   lower(e.timestamp_range) as modified_timestamp,
+                   greater(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp,
                    name,
                    pause_key,
                    pause_status,

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -131,7 +131,7 @@ const tokenInfoSelectFields = [
   'e.memo',
   'metadata',
   'metadata_key',
-  'lower(e.timestamp_range) as modified_timestamp',
+  'greater(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp',
   'name',
   'pause_key',
   'pause_status',

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -131,7 +131,7 @@ const tokenInfoSelectFields = [
   'e.memo',
   'metadata',
   'metadata_key',
-  'greatest(lower(t.timestamp_range)::bigint, lower(e.timestamp_range)::bigint) as modified_timestamp',
+  'greatest(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp',
   'name',
   'pause_key',
   'pause_status',

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -131,7 +131,7 @@ const tokenInfoSelectFields = [
   'e.memo',
   'metadata',
   'metadata_key',
-  'greater(lower(t.timestamp_range), lower(e.timestamp_range)) as modified_timestamp',
+  'greatest(lower(t.timestamp_range)::bigint, lower(e.timestamp_range)::bigint) as modified_timestamp',
   'name',
   'pause_key',
   'pause_status',

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -131,7 +131,7 @@ const tokenInfoSelectFields = [
   'e.memo',
   'metadata',
   'metadata_key',
-  'lower(t.timestamp_range) as modified_timestamp',
+  'lower(e.timestamp_range) as modified_timestamp',
   'name',
   'pause_key',
   'pause_status',


### PR DESCRIPTION
**Description**:
Updates the REST API query for the /api/v1/tokens endpoint to get the modified timestamp from the entity table. 

**Related issue(s)**:

Fixes #10406  

**Notes for reviewer**:
Tested this new query on testnet.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
