### PR TITLE
Refactor hardcoded id of system account in web3 tests

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
@@ -54,7 +54,8 @@ class SelfDestructOperationTest extends AbstractContractCallServiceTest {
 
     @Test
     void testExecuteWithInvalidOwner() {
-        final var systemAccountAddress = toAddress(700);
+        final var systemAccountId = generateSystemAccountId();
+        final var systemAccountAddress = toAddress(systemAccountId);
         final var contract = testWeb3jService.deployWithValue(SelfDestructContract::deploy, BigInteger.valueOf(1000));
         final var functionCall = contract.send_destructContract(systemAccountAddress.toUnprefixedHexString());
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -423,9 +423,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         return domainBuilder
                 .entity()
                 .customize(e -> {
-                    e.id(systemAccount.getId())
-                            .num(systemAccount.getNum())
-                            .alias(toEvmAddress(systemAccount));
+                    e.id(systemAccount.getId()).num(systemAccount.getNum()).alias(toEvmAddress(systemAccount));
                     customizer.accept(e);
                 })
                 .persist();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final int SYSTEM_ACCOUNT_ID_LOWER_BOUND_INCLUSIVE = 1;
     protected static final int SYSTEM_ACCOUNT_ID_HIGHER_BOUND_EXCLUSIVE = 751;
     protected static final List<Long> EXCLUDED_SPECIAL_IDS = List.of(2L, 98L);
-    public static final long DEFAULT_SYSTEM_ACCOUNT_BALANCE = 20000L;
+    protected static final long DEFAULT_SYSTEM_ACCOUNT_BALANCE = 20000L;
 
     @Resource
     protected TestWeb3jService testWeb3jService;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -81,7 +81,6 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final int SYSTEM_ACCOUNT_ID_LOWER_BOUND_INCLUSIVE = 1;
     protected static final int SYSTEM_ACCOUNT_ID_HIGHER_BOUND_EXCLUSIVE = 751;
     protected static final List<Long> EXCLUDED_SPECIAL_IDS = List.of(2L, 98L);
-    protected static final long DEFAULT_SYSTEM_ACCOUNT_BALANCE = 20000L;
 
     @Resource
     protected TestWeb3jService testWeb3jService;
@@ -426,8 +425,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .customize(e -> {
                     e.id(systemAccount.getId())
                             .num(systemAccount.getNum())
-                            .alias(toEvmAddress(systemAccount))
-                            .balance(DEFAULT_SYSTEM_ACCOUNT_BALANCE);
+                            .alias(toEvmAddress(systemAccount));
                     customizer.accept(e);
                 })
                 .persist();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -79,8 +79,9 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final long DEFAULT_ACCOUNT_BALANCE = 100_000_000_000_000_000L;
     protected static final int DEFAULT_TOKEN_BALANCE = 100;
     protected static final int SYSTEM_ACCOUNT_ID_LOWER_BOUND_INCLUSIVE = 1;
-    protected static final int SYSTEM_ACCOUNT_HIGHER_BOUND_EXCLUSIVE = 751;
+    protected static final int SYSTEM_ACCOUNT_ID_HIGHER_BOUND_EXCLUSIVE = 751;
     protected static final List<Long> EXCLUDED_SPECIAL_IDS = List.of(2L, 98L);
+    public static final long DEFAULT_SYSTEM_ACCOUNT_BALANCE = 20000L;
 
     @Resource
     protected TestWeb3jService testWeb3jService;
@@ -411,7 +412,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         long id;
         do {
             id = ThreadLocalRandom.current()
-                    .nextLong(SYSTEM_ACCOUNT_ID_LOWER_BOUND_INCLUSIVE, SYSTEM_ACCOUNT_HIGHER_BOUND_EXCLUSIVE);
+                    .nextLong(SYSTEM_ACCOUNT_ID_LOWER_BOUND_INCLUSIVE, SYSTEM_ACCOUNT_ID_HIGHER_BOUND_EXCLUSIVE);
         } while (EXCLUDED_SPECIAL_IDS.contains(id));
         return id;
     }
@@ -426,7 +427,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                     e.id(systemAccount.getId())
                             .num(systemAccount.getNum())
                             .alias(toEvmAddress(systemAccount))
-                            .balance(20000L);
+                            .balance(DEFAULT_SYSTEM_ACCOUNT_BALANCE);
                     customizer.accept(e);
                 })
                 .persist();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -298,16 +298,8 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
     @Test
     void selfDestructCallWithSystemAccount() {
         // Given
-        final var systemAccountAddress = toAddress(700);
-        final var systemAccountEntityId = entityIdFromEvmAddress(systemAccountAddress);
-        domainBuilder
-                .entity()
-                .customize(e -> e.id(systemAccountEntityId.getId())
-                        .num(systemAccountEntityId.getNum())
-                        .evmAddress(null)
-                        .alias(toEvmAddress(systemAccountEntityId))
-                        .balance(20000L))
-                .persist();
+        final var systemAccount = systemAccountEntityCustomizable(e -> e.evmAddress(null));
+        final var systemAccountAddress = toAddress(systemAccount.toEntityId());
         // When
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -16,7 +16,6 @@
 
 package com.hedera.mirror.web3.service;
 
-import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.exception.BlockNumberNotFoundException.UNKNOWN_BLOCK_NUMBER;
 import static com.hedera.mirror.web3.service.ContractCallService.GAS_LIMIT_METRIC;
@@ -45,8 +44,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.Range;
-import com.hedera.mirror.common.domain.entity.Entity;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmTxProcessor;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
@@ -426,7 +423,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     void balanceCallToSystemAccountReturnsZero() throws Exception {
         // Given
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
-        final var systemAccount = systemAccountEntityWithEvmAddressPersist();
+        final var systemAccount = systemAccountEntityCustomizable(e -> {});
         final var systemAccountAddress = EntityIdUtils.asHexedEvmAddress(
                 new Id(systemAccount.getShard(), systemAccount.getRealm(), systemAccount.getNum()));
         final var contract = testWeb3jService.deploy(EthCall::deploy);
@@ -445,7 +442,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     void balanceCallToSystemAccountViaAliasReturnsBalance() throws Exception {
         // Given
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
-        final var systemAccount = systemAccountEntityWithEvmAddressPersist();
+        final var systemAccount = systemAccountEntityCustomizable(e -> {});
         final var systemAccountAddress =
                 Bytes.wrap(systemAccount.getEvmAddress()).toHexString();
         final var contract = testWeb3jService.deploy(EthCall::deploy);
@@ -1083,18 +1080,6 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 .sender(new HederaEvmAccount(senderAddress))
                 .value(value)
                 .build();
-    }
-
-    private Entity systemAccountEntityWithEvmAddressPersist() {
-        final var systemAccountEntityId = EntityId.of(700);
-
-        return domainBuilder
-                .entity()
-                .customize(e -> e.id(systemAccountEntityId.getId())
-                        .num(systemAccountEntityId.getNum())
-                        .alias(toEvmAddress(systemAccountEntityId))
-                        .balance(20000L))
-                .persist();
     }
 
     @Nested


### PR DESCRIPTION
**Description**:
This PR refactors the hardcoded id of 700 for system account and instead generates one between 1 to 750 inclusive with the exception of 2 and 98 which i found to be special ids. 

**Related issue(s)**:

Fixes [#10407](https://github.com/hiero-ledger/hiero-mirror-node/issues/10407)

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)