### PR TITLE
Add topic custom fee fields to `/topics/{id}` endpoint

### DIFF
--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/controller/TopicController.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/controller/TopicController.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.restjava.controller;
 import com.hedera.mirror.rest.model.Topic;
 import com.hedera.mirror.restjava.common.EntityIdNumParameter;
 import com.hedera.mirror.restjava.mapper.TopicMapper;
+import com.hedera.mirror.restjava.service.CustomFeeService;
 import com.hedera.mirror.restjava.service.EntityService;
 import com.hedera.mirror.restjava.service.TopicService;
 import lombok.CustomLog;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class TopicController {
 
+    private final CustomFeeService customFeeService;
     private final EntityService entityService;
     private final TopicMapper topicMapper;
     private final TopicService topicService;
@@ -42,6 +44,7 @@ public class TopicController {
     Topic getTopic(@PathVariable EntityIdNumParameter id) {
         var topic = topicService.findById(id.id());
         var entity = entityService.findById(id.id());
-        return topicMapper.map(entity, topic);
+        var customFee = customFeeService.findById(id.id());
+        return topicMapper.map(customFee, entity, topic);
     }
 }

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/exception/InvalidMappingException.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/exception/InvalidMappingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package com.hedera.mirror.restjava.exception;
 import java.io.Serial;
 
 @SuppressWarnings("java:S110")
-public class InvalidFilterException extends RestJavaException {
+public class InvalidMappingException extends RestJavaException {
 
     @Serial
-    private static final long serialVersionUID = 1518569037954950068L;
+    private static final long serialVersionUID = -857679581991526245L;
 
-    public InvalidFilterException(String message) {
-        super(message);
+    public InvalidMappingException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CommonMapper.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CommonMapper.java
@@ -17,12 +17,19 @@
 package com.hedera.mirror.restjava.mapper;
 
 import com.google.common.collect.Range;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.rest.model.Key;
 import com.hedera.mirror.rest.model.Key.TypeEnum;
 import com.hedera.mirror.rest.model.TimestampRange;
+import com.hedera.mirror.restjava.exception.InvalidMappingException;
+import com.hederahashgraph.api.proto.java.KeyList;
+import jakarta.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingInheritanceStrategy;
@@ -68,6 +75,25 @@ public interface CommonMapper {
         }
 
         return new Key().key(hex).type(TypeEnum.PROTOBUF_ENCODED);
+    }
+
+    default List<Key> mapKeyList(byte[] source) {
+        if (ArrayUtils.isEmpty(source)) {
+            return Collections.emptyList();
+        }
+
+        try {
+            var keyList = KeyList.parseFrom(source);
+            return keyList.getKeysList().stream()
+                    .map(key -> mapKey(key.toByteArray()))
+                    .toList();
+        } catch (InvalidProtocolBufferException e) {
+            throw new InvalidMappingException("Error parsing protobuf message", e);
+        }
+    }
+
+    default String mapLowerRange(@Nonnull Range<Long> source) {
+        return mapTimestamp(source.lowerEndpoint());
     }
 
     default TimestampRange mapRange(Range<Long> source) {

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CommonMapper.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CommonMapper.java
@@ -24,7 +24,6 @@ import com.hedera.mirror.rest.model.Key.TypeEnum;
 import com.hedera.mirror.rest.model.TimestampRange;
 import com.hedera.mirror.restjava.exception.InvalidMappingException;
 import com.hederahashgraph.api.proto.java.KeyList;
-import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -92,7 +91,11 @@ public interface CommonMapper {
         }
     }
 
-    default String mapLowerRange(@Nonnull Range<Long> source) {
+    default String mapLowerRange(Range<Long> source) {
+        if (source == null || !source.hasLowerBound()) {
+            return null;
+        }
+
         return mapTimestamp(source.lowerEndpoint());
     }
 

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CustomFeeMapper.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/CustomFeeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,14 @@
 
 package com.hedera.mirror.restjava.mapper;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import org.springframework.util.CollectionUtils;
+import com.hedera.mirror.common.domain.token.CustomFee;
+import com.hedera.mirror.rest.model.ConsensusCustomFees;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-public interface CollectionMapper<S, T> {
+@Mapper(config = MapperConfiguration.class, uses = FixedCustomFeeMapper.class)
+public interface CustomFeeMapper {
 
-    T map(S source);
-
-    default List<T> map(Collection<S> sources) {
-        if (CollectionUtils.isEmpty(sources)) {
-            return Collections.emptyList();
-        }
-
-        List<T> list = new ArrayList<>(sources.size());
-        for (S source : sources) {
-            list.add(map(source));
-        }
-
-        return list;
-    }
+    @Mapping(source = "timestampRange", target = "createdTimestamp")
+    ConsensusCustomFees map(CustomFee customFee);
 }

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/FixedCustomFeeMapper.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/FixedCustomFeeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,9 @@
 
 package com.hedera.mirror.restjava.mapper;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import org.springframework.util.CollectionUtils;
+import com.hedera.mirror.common.domain.token.FixedFee;
+import com.hedera.mirror.rest.model.FixedCustomFee;
+import org.mapstruct.Mapper;
 
-public interface CollectionMapper<S, T> {
-
-    T map(S source);
-
-    default List<T> map(Collection<S> sources) {
-        if (CollectionUtils.isEmpty(sources)) {
-            return Collections.emptyList();
-        }
-
-        List<T> list = new ArrayList<>(sources.size());
-        for (S source : sources) {
-            list.add(map(source));
-        }
-
-        return list;
-    }
-}
+@Mapper(config = MapperConfiguration.class)
+public interface FixedCustomFeeMapper extends CollectionMapper<FixedFee, FixedCustomFee> {}

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/TopicMapper.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/mapper/TopicMapper.java
@@ -19,16 +19,18 @@ package com.hedera.mirror.restjava.mapper;
 import static com.hedera.mirror.restjava.mapper.CommonMapper.QUALIFIER_TIMESTAMP;
 
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.token.CustomFee;
 import com.hedera.mirror.rest.model.Topic;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(config = MapperConfiguration.class)
+@Mapper(config = MapperConfiguration.class, uses = CustomFeeMapper.class)
 public interface TopicMapper {
 
+    @Mapping(source = "customFee", target = "customFees")
     @Mapping(source = "entity.autoRenewAccountId", target = "autoRenewAccount")
     @Mapping(source = "entity.createdTimestamp", target = "createdTimestamp", qualifiedByName = QUALIFIER_TIMESTAMP)
     @Mapping(source = "entity.id", target = "topicId")
     @Mapping(source = "entity.timestampRange", target = "timestamp")
-    Topic map(Entity entity, com.hedera.mirror.common.domain.topic.Topic topic);
+    Topic map(CustomFee customFee, Entity entity, com.hedera.mirror.common.domain.topic.Topic topic);
 }

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/repository/CustomFeeRepository.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/repository/CustomFeeRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.repository;
+
+import com.hedera.mirror.common.domain.token.CustomFee;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CustomFeeRepository extends CrudRepository<CustomFee, Long> {}

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/service/CustomFeeService.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/service/CustomFeeService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.service;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.token.CustomFee;
+import jakarta.annotation.Nonnull;
+
+public interface CustomFeeService {
+
+    CustomFee findById(@Nonnull EntityId id);
+}

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/service/CustomFeeServiceImpl.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/service/CustomFeeServiceImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.service;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.token.CustomFee;
+import com.hedera.mirror.restjava.repository.CustomFeeRepository;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Named
+@RequiredArgsConstructor
+public class CustomFeeServiceImpl implements CustomFeeService {
+
+    private final CustomFeeRepository customFeeRepository;
+    private final Validator validator;
+
+    @Override
+    public CustomFee findById(@Nonnull EntityId id) {
+        validator.validateShard(id, id.getShard());
+
+        return customFeeRepository
+                .findById(id.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Custom fee for entity id %s not found".formatted(id)));
+    }
+}

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/TopicControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/TopicControllerTest.java
@@ -51,6 +51,13 @@ class TopicControllerTest extends ControllerTest {
         protected RequestHeadersSpec<?> defaultRequest(RequestHeadersUriSpec<?> uriSpec) {
             var entity = domainBuilder.topicEntity().persist();
             domainBuilder
+                    .customFee()
+                    .customize(c -> c.entityId(entity.getId())
+                            .fractionalFees(null)
+                            .royaltyFees(null)
+                            .timestampRange(entity.getTimestampRange()))
+                    .persist();
+            domainBuilder
                     .topic()
                     .customize(t -> t.createdTimestamp(entity.getCreatedTimestamp())
                             .id(entity.getId())
@@ -64,6 +71,13 @@ class TopicControllerTest extends ControllerTest {
         void success(String id) {
             // Given
             var entity = domainBuilder.topicEntity().customize(e -> e.id(1000L)).persist();
+            var customFee = domainBuilder
+                    .customFee()
+                    .customize(c -> c.entityId(1000L)
+                            .fractionalFees(null)
+                            .royaltyFees(null)
+                            .timestampRange(entity.getTimestampRange()))
+                    .persist();
             var topic = domainBuilder
                     .topic()
                     .customize(t -> t.createdTimestamp(entity.getCreatedTimestamp())
@@ -75,7 +89,7 @@ class TopicControllerTest extends ControllerTest {
             var response = restClient.get().uri("", id).retrieve().toEntity(Topic.class);
 
             // Then
-            assertThat(response.getBody()).isNotNull().isEqualTo(topicMapper.map(entity, topic));
+            assertThat(response.getBody()).isNotNull().isEqualTo(topicMapper.map(customFee, entity, topic));
             // Based on application.yml response headers configuration
             assertThat(response.getHeaders().getAccessControlAllowOrigin()).isEqualTo("*");
             assertThat(response.getHeaders().getCacheControl()).isEqualTo("public, max-age=5");

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
@@ -27,6 +27,7 @@ import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.rest.model.Key.TypeEnum;
 import com.hedera.mirror.rest.model.TimestampRange;
 import com.hedera.mirror.restjava.exception.InvalidMappingException;
+import com.hederahashgraph.api.proto.java.FeeExemptKeyList;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import java.util.List;
@@ -70,7 +71,8 @@ class CommonMapperTest {
         var innerKeyListKey = Key.newBuilder().setKeyList(innerKeyList).build();
         var bytesInnerKeyListKey = innerKeyListKey.toByteArray();
         var keyList = innerKeyList.toBuilder().addKeys(innerKeyListKey).build();
-        var feeExemptKeyList = innerKeyList.toBuilder().addKeys(innerKeyListKey).build();
+        var feeExemptKeyList =
+                FeeExemptKeyList.newBuilder().addAllKeys(keyList.getKeysList()).build();
         var expectedKeyList = List.of(
                 new com.hedera.mirror.rest.model.Key()
                         .key(Hex.encodeHexString(bytesEcdsa))

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.restjava.mapper;
 
 import static com.hedera.mirror.restjava.mapper.CommonMapper.NANO_DIGITS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.DomainBuilder;
@@ -25,8 +26,11 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.rest.model.Key.TypeEnum;
 import com.hedera.mirror.rest.model.TimestampRange;
+import com.hedera.mirror.restjava.exception.InvalidMappingException;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
+import java.util.List;
+import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -50,6 +54,46 @@ class CommonMapperTest {
     void mapEntityIdLong() {
         assertThat(commonMapper.mapEntityId((Long) null)).isNull();
         assertThat(commonMapper.mapEntityId(0L)).isNull();
+    }
+
+    @Test
+    void mapKeyList() {
+        // Given
+        var bytesEcdsa = domainBuilder.bytes(DomainBuilder.KEY_LENGTH_ECDSA);
+        var ecdsa = Key.newBuilder()
+                .setECDSASecp256K1(DomainUtils.fromBytes(bytesEcdsa))
+                .build();
+        var bytesEd25519 = domainBuilder.bytes(DomainBuilder.KEY_LENGTH_ED25519);
+        var ed25519 =
+                Key.newBuilder().setEd25519(DomainUtils.fromBytes(bytesEd25519)).build();
+        var innerKeyList = KeyList.newBuilder().addKeys(ecdsa).addKeys(ed25519).build();
+        var innerKeyListKey = Key.newBuilder().setKeyList(innerKeyList).build();
+        var bytesInnerKeyListKey = innerKeyListKey.toByteArray();
+        var keyList = innerKeyList.toBuilder().addKeys(innerKeyListKey).build();
+        var feeExemptKeyList = innerKeyList.toBuilder().addKeys(innerKeyListKey).build();
+        var expectedKeyList = List.of(
+                new com.hedera.mirror.rest.model.Key()
+                        .key(Hex.encodeHexString(bytesEcdsa))
+                        .type(TypeEnum.ECDSA_SECP256_K1),
+                new com.hedera.mirror.rest.model.Key()
+                        .key(Hex.encodeHexString(bytesEd25519))
+                        .type(TypeEnum.ED25519),
+                new com.hedera.mirror.rest.model.Key()
+                        .key(Hex.encodeHexString(bytesInnerKeyListKey))
+                        .type(TypeEnum.PROTOBUF_ENCODED));
+
+        // Then
+        assertThat(commonMapper.mapKeyList(null)).isEmpty();
+        assertThat(commonMapper.mapKeyList(new byte[0])).isEmpty();
+        assertThat(commonMapper.mapKeyList(keyList.toByteArray())).isEqualTo(expectedKeyList);
+        assertThat(commonMapper.mapKeyList(feeExemptKeyList.toByteArray())).isEqualTo(expectedKeyList);
+    }
+
+    @SneakyThrows
+    @Test
+    void mapKeyListThrow() {
+        byte[] data = Hex.decodeHex("deadbeef");
+        assertThatThrownBy(() -> commonMapper.mapKeyList(data)).isInstanceOf(InvalidMappingException.class);
     }
 
     @Test
@@ -81,6 +125,13 @@ class CommonMapperTest {
         assertThat(commonMapper.mapKey(ed25519.toByteArray())).isEqualTo(toKey(bytesEd25519, TypeEnum.ED25519));
         assertThat(commonMapper.mapKey(ed25519List.toByteArray())).isEqualTo(toKey(bytesEd25519, TypeEnum.ED25519));
         assertThat(commonMapper.mapKey(protobufEncoded)).isEqualTo(toKey(protobufEncoded, TypeEnum.PROTOBUF_ENCODED));
+    }
+
+    @Test
+    void mapLowerRange() {
+        assertThat(commonMapper.mapLowerRange(Range.atLeast(0L))).isEqualTo("0.0");
+        assertThat(commonMapper.mapLowerRange(Range.atLeast(1500123456789L))).isEqualTo("1500.123456789");
+        assertThat(commonMapper.mapLowerRange(Range.atLeast(1500123456000L))).isEqualTo("1500.123456000");
     }
 
     @Test

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CommonMapperTest.java
@@ -129,6 +129,8 @@ class CommonMapperTest {
 
     @Test
     void mapLowerRange() {
+        assertThat(commonMapper.mapLowerRange(null)).isNull();
+        assertThat(commonMapper.mapLowerRange(Range.atMost(200L))).isNull();
         assertThat(commonMapper.mapLowerRange(Range.atLeast(0L))).isEqualTo("0.0");
         assertThat(commonMapper.mapLowerRange(Range.atLeast(1500123456789L))).isEqualTo("1500.123456789");
         assertThat(commonMapper.mapLowerRange(Range.atLeast(1500123456000L))).isEqualTo("1500.123456000");

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CustomFeeMapperTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/CustomFeeMapperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.rest.model.ConsensusCustomFees;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CustomFeeMapperTest {
+
+    private CommonMapper commonMapper;
+    private DomainBuilder domainBuilder;
+    private FixedCustomFeeMapper fixedCustomFeeMapper;
+    private CustomFeeMapper mapper;
+
+    @BeforeEach
+    void setup() {
+        domainBuilder = new DomainBuilder();
+        commonMapper = new CommonMapperImpl();
+        fixedCustomFeeMapper = new FixedCustomFeeMapperImpl(commonMapper);
+        mapper = new CustomFeeMapperImpl(fixedCustomFeeMapper, commonMapper);
+    }
+
+    @Test
+    void map() {
+        var customFee = domainBuilder.customFee().get();
+        var expected = new ConsensusCustomFees()
+                .createdTimestamp(commonMapper.mapLowerRange(customFee.getTimestampRange()))
+                .fixedFees(fixedCustomFeeMapper.map(customFee.getFixedFees()));
+        assertThat(mapper.map(customFee)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void mapEmptyOrNullFixedFees(boolean nullFixedFees) {
+        var customFee = domainBuilder
+                .customFee()
+                .customize(c -> c.fixedFees(nullFixedFees ? null : Collections.emptyList()))
+                .get();
+        var expected = new ConsensusCustomFees()
+                .createdTimestamp(commonMapper.mapLowerRange(customFee.getTimestampRange()))
+                .fixedFees(Collections.emptyList());
+        assertThat(mapper.map(customFee)).isEqualTo(expected);
+    }
+}

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/FixedCustomFeeMapperTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/mapper/FixedCustomFeeMapperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.token.FixedFee;
+import com.hedera.mirror.rest.model.FixedCustomFee;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FixedCustomFeeMapperTest {
+
+    private CommonMapper commonMapper;
+    private DomainBuilder domainBuilder;
+    private FixedCustomFeeMapper mapper;
+
+    @BeforeEach
+    void setup() {
+        commonMapper = new CommonMapperImpl();
+        domainBuilder = new DomainBuilder();
+        mapper = new FixedCustomFeeMapperImpl(commonMapper);
+    }
+
+    @Test
+    void map() {
+        var fixedFees = List.of(domainBuilder.fixedFee(), domainBuilder.fixedFee());
+        var expected = fixedFees.stream()
+                .map(fixedFee -> new FixedCustomFee()
+                        .amount(fixedFee.getAmount())
+                        .collectorAccountId(commonMapper.mapEntityId(fixedFee.getCollectorAccountId()))
+                        .denominatingTokenId(commonMapper.mapEntityId(fixedFee.getDenominatingTokenId())))
+                .toList();
+        assertThat(mapper.map(fixedFees)).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void mapEmptyOrNull() {
+        assertThat(mapper.map(List.of())).isEmpty();
+        assertThat(mapper.map((Collection<FixedFee>) null)).isEmpty();
+    }
+}

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/repository/CustomFeeRepositoryTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/repository/CustomFeeRepositoryTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.mirror.restjava.RestJavaIntegrationTest;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+class CustomFeeRepositoryTest extends RestJavaIntegrationTest {
+
+    private final CustomFeeRepository customFeeRepository;
+
+    @Test
+    void findById() {
+        var expected = domainBuilder.customFee().persist();
+        assertThat(customFeeRepository.findById(expected.getEntityId())).contains(expected);
+    }
+}

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/service/CustomFeeServiceTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/service/CustomFeeServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.restjava.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.restjava.RestJavaIntegrationTest;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+class CustomFeeServiceTest extends RestJavaIntegrationTest {
+
+    private final CustomFeeService service;
+
+    @Test
+    void findById() {
+        var customFee = domainBuilder.customFee().persist();
+        assertThat(service.findById(EntityId.of(customFee.getEntityId()))).isEqualTo(customFee);
+    }
+
+    @Test
+    void findByInvalidShard() {
+        var entityId = EntityId.of(1, 0, 200);
+        assertThatThrownBy(() -> service.findById(entityId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID " + entityId + " has an invalid shard. Shard must be 0");
+    }
+
+    @Test
+    void findByIdNotFound() {
+        var entityId = EntityId.of(10L);
+        assertThatThrownBy(() -> service.findById(entityId)).isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -3172,6 +3172,27 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Block"
+    ConsensusCustomFees:
+      description: Custom fees assessed for each message submitted to the topic
+      type: object
+      properties:
+        created_timestamp:
+          $ref: "#/components/schemas/Timestamp"
+        fixed_fees:
+          type: array
+          items:
+            $ref: "#/components/schemas/FixedCustomFee"
+    FixedCustomFee:
+      type: object
+      properties:
+        amount:
+          example: 100
+          format: int64
+          type: integer
+        collector_account_id:
+          $ref: "#/components/schemas/EntityId"
+        denominating_token_id:
+          $ref: "#/components/schemas/EntityId"
     NftTransactionHistory:
       type: object
       properties:
@@ -3673,11 +3694,20 @@ components:
           type: integer
         created_timestamp:
           $ref: "#/components/schemas/TimestampNullable"
+        custom_fees:
+          $ref: "#/components/schemas/ConsensusCustomFees"
         deleted:
           description: Whether the topic is deleted or not.
           example: false
           nullable: true
           type: boolean
+        fee_exempt_key_list:
+          description: Keys permitted to submit messages to the topic without paying custom fees
+          type: array
+          items:
+            $ref: "#/components/schemas/Key"
+        fee_schedule_key:
+          $ref: "#/components/schemas/Key"
         memo:
           description: The memo associated with the topic.
           example: topic memo
@@ -3693,7 +3723,10 @@ components:
         - auto_renew_account
         - auto_renew_period
         - created_timestamp
+        - custom_fees
         - deleted
+        - fee_exempt_key_list
+        - fee_schedule_key
         - memo
         - submit_key
         - timestamp


### PR DESCRIPTION
**Description**:

This PR adds topic custom fee fields to `/topics/{id}` endpoint

- Add topic custom fee fields to openapi spec
- Update `TopicController` to also get topic custom fee schedule
- Add mapper support for new fields 

**Related issue(s)**:

Fixes #9566

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)