### PR TITLE
Fix mint fungible test for modularized

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -73,7 +73,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -114,7 +113,7 @@ public class CallFeature extends AbstractFeature {
         address1 = new BigInteger(address1, 16).toString(16);
         address2 = new BigInteger(address2, 16).toString(16);
 
-        return new String[]{address1, address2};
+        return new String[] {address1, address2};
     }
 
     @RetryAsserts
@@ -437,7 +436,7 @@ public class CallFeature extends AbstractFeature {
                 MINT_TOKEN_GET_TOTAL_SUPPLY_AND_BALANCE,
                 asAddress(fungibleTokenId),
                 1L,
-                new byte[][]{},
+                new byte[][] {},
                 asAddress(admin));
 
         var response = callContract(data, precompileContractAddress);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -85,11 +85,11 @@ public class CallFeature extends AbstractFeature {
 
     private static final String HEX_REGEX = "^[0-9a-fA-F]+$";
     private static DeployedContract deployedPrecompileContract;
-    private DeployedContract deployedErcTestContract;
-    private DeployedContract deployedEstimatePrecompileContract;
     private final AccountClient accountClient;
     private final MirrorNodeClient mirrorClient;
     private final TokenClient tokenClient;
+    private DeployedContract deployedErcTestContract;
+    private DeployedContract deployedEstimatePrecompileContract;
     private String ercContractAddress;
     private String precompileContractAddress;
     private String estimateContractAddress;
@@ -114,7 +114,7 @@ public class CallFeature extends AbstractFeature {
         address1 = new BigInteger(address1, 16).toString(16);
         address2 = new BigInteger(address2, 16).toString(16);
 
-        return new String[] {address1, address2};
+        return new String[]{address1, address2};
     }
 
     @RetryAsserts
@@ -437,7 +437,7 @@ public class CallFeature extends AbstractFeature {
                 MINT_TOKEN_GET_TOTAL_SUPPLY_AND_BALANCE,
                 asAddress(fungibleTokenId),
                 1L,
-                asByteArray(Arrays.asList("0x00")),
+                new byte[][]{},
                 asAddress(admin));
 
         var response = callContract(data, precompileContractAddress);
@@ -459,7 +459,7 @@ public class CallFeature extends AbstractFeature {
                 MINT_TOKEN_GET_TOTAL_SUPPLY_AND_BALANCE,
                 asAddress(nonFungibleTokenId),
                 0L,
-                asByteArray(Arrays.asList("0x02")),
+                asByteArray(List.of("0x02")),
                 asAddress(tokenClient
                         .getSdkClient()
                         .getExpandedOperatorAccountId()


### PR DESCRIPTION
**Description**:
This PR fixes failing `I mint FUNGIBLE token and get the total supply and balance`.
Based on the contract method implementation for fungible we should not pass any metadata in the function parameter otherwise the call goes through erc720 intertace and fails the test. Now just passing empty metadata for fungible call.

**Related issue(s)**:
Partially completes #10430 


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
