### PR TITLE
Fix contract storage readable kv state slot values

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 
 @CustomLog
@@ -68,5 +69,15 @@ public class Utils {
         }
 
         return Arrays.equals(MIRROR_PREFIX, 0, 12, address, 0, 12);
+    }
+
+    public static byte[] padToBytes32(byte[] input) {
+        if (input.length >= Bytes32.SIZE) {
+            return input;
+        }
+        byte[] padded = new byte[Bytes32.SIZE];
+        int offset = Bytes32.SIZE - input.length;
+        System.arraycopy(input, 0, padded, offset, input.length);
+        return padded;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVState.java
@@ -16,6 +16,8 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
+import static com.hedera.mirror.web3.state.Utils.padToBytes32;
+
 import com.hedera.hapi.node.state.contract.SlotKey;
 import com.hedera.hapi.node.state.contract.SlotValue;
 import com.hedera.mirror.web3.common.ContractCallContext;
@@ -49,7 +51,7 @@ public class ContractStorageReadableKVState extends AbstractReadableKVState<Slot
         return timestamp
                 .map(t -> contractStateRepository.findStorageByBlockTimestamp(entityId, keyBytes, t))
                 .orElse(contractStateRepository.findStorage(entityId, keyBytes))
-                .map(byteArr -> new SlotValue(Bytes.wrap(byteArr), Bytes.EMPTY, Bytes.EMPTY))
+                .map(byteArr -> new SlotValue(Bytes.wrap(padToBytes32(byteArr)), Bytes.EMPTY, Bytes.EMPTY))
                 .orElse(null);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVStateTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
+import static com.hedera.mirror.web3.state.Utils.padToBytes32;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -49,7 +50,7 @@ class ContractStorageReadableKVStateTest {
 
     private static final ContractID CONTRACT_ID =
             new ContractID(1L, 0L, new OneOf<>(ContractOneOfType.CONTRACT_NUM, 1L));
-    private static final Bytes BYTES = Bytes.fromBase64("123456");
+    private static final Bytes BYTES = Bytes.wrap(padToBytes32("123456".getBytes()));
     private static final SlotKey SLOT_KEY = new SlotKey(CONTRACT_ID, BYTES);
     private static final EntityId ENTITY_ID =
             EntityId.of(CONTRACT_ID.shardNum(), CONTRACT_ID.realmNum(), CONTRACT_ID.contractNum());


### PR DESCRIPTION
**Description**:
This PR fixes slot values in `ContractStorageReadableKVState` and expand the slot values to 32 bytes.

Partially completes #10430 

**Notes for reviewer**:

Tests that this pr fixes
```
Then I call function with update and I expect return of the updated value
Then I call function that makes N times state update
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
