### PR TITLE
Fix test about hollow account creation on hbar transfer to non existing EVM address

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -687,6 +687,10 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         assertGasLimit(ETH_CALL, TRANSACTION_GAS_LIMIT);
     }
 
+    /**
+     * Testing that sending HBAR to a randomly generated 20-byte EVM address, that
+     * is not mapped to an existing accountId will result in hollow account creation.
+     */
     @Test
     void hollowAccountCreationWorks() {
         // Given
@@ -698,7 +702,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         testWeb3jService.setSender(senderAddress.toHexString());
 
         // When
-        final var functionCall = contract.send_transferHbarsToAddress(
+        final var functionCall = contract.send_createHollowAccount(
                 Bytes.wrap(hollowAccountAlias).toHexString(), BigInteger.valueOf(value));
 
         // Then

--- a/hedera-mirror-web3/src/test/solidity/EthCall.sol
+++ b/hedera-mirror-web3/src/test/solidity/EthCall.sol
@@ -20,6 +20,21 @@ contract EthCall is HederaTokenService {
         _recipient.transfer(msg.value);
     }
 
+    function createHollowAccount(address payable _recipient) public payable {
+        require(msg.value > 0, "Not enough HBAR to proceed");
+
+        (uint balance) = _recipient.balance;
+        require(balance == 0, "Account already exists and have positive balance");
+
+        //call() - Solidity function for sending funds and calling other contracts
+        //the empty payload "" means the transaction is only transferring funds
+        (bool success,) = _recipient.call{value: msg.value}("");
+        require(success, "Failed to transfer funds");
+
+        balance = _recipient.balance;
+        require(balance > 0, "Failed to update recipient balance");
+    }
+
     // External function that has an argument for test value that will be written to contract storage slot
     function writeToStorageSlot(string memory _value) payable external returns (string memory){
         emptyStorageData = _value;


### PR DESCRIPTION
**Description**:
Fix test about hollow account creation on hbar transfer to non existing EVM address

Fixes: [#10087](https://github.com/hiero-ledger/hiero-mirror-node/issues/10087)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
