### PR TITLE
Fix rosetta construction parse error

### DIFF
--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
@@ -53,7 +53,7 @@ func (c *compositeTransactionConstructor) Parse(ctx context.Context, transaction
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	name := reflect.TypeOf(transaction).Elem().Name()
+	name := reflect.TypeOf(transaction).Name()
 	h, ok := c.constructorsByTransactionType[name]
 	if !ok {
 		log.Errorf("No constructor to parse constructed transaction %s", name)

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	cryptoTransferTransaction = hiero.NewTransferTransaction()
-	tokenCreateTransaction    = hiero.NewTokenCreateTransaction()
+	cryptoTransferTransaction = *hiero.NewTransferTransaction()
+	tokenCreateTransaction    = *hiero.NewTokenCreateTransaction()
 	cryptoTransferOperations  = types.OperationSlice{{Type: types.OperationTypeCryptoTransfer}}
 	mixedOperations           = types.OperationSlice{
 		{Type: types.OperationTypeCryptoTransfer},

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
@@ -65,7 +65,7 @@ func (c *cryptoCreateTransactionConstructor) Parse(_ context.Context, transactio
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	cryptoCreateTransaction, ok := transaction.(*hiero.AccountCreateTransaction)
+	cryptoCreateTransaction, ok := transaction.(hiero.AccountCreateTransaction)
 	if !ok {
 		return nil, nil, errors.ErrTransactionInvalidType
 	}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -150,7 +150,7 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestConstruct() {
 
 func (suite *cryptoCreateTransactionConstructorSuite) TestParse() {
 	defaultGetTransaction := func() hiero.TransactionInterface {
-		return hiero.NewAccountCreateTransaction().
+		return *hiero.NewAccountCreateTransaction().
 			SetAccountMemo(memo).
 			SetAutoRenewPeriod(time.Second * time.Duration(autoRenewPeriod)).
 			SetInitialBalance(hiero.HbarFromTinybar(initialBalance)).
@@ -180,9 +180,9 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestParse() {
 			name: "KeyNotSet",
 			getTransaction: func() hiero.TransactionInterface {
 				tx := defaultGetTransaction()
-				accountCreateTx, _ := tx.(*hiero.AccountCreateTransaction)
+				accountCreateTx, _ := tx.(hiero.AccountCreateTransaction)
 				accountCreateTx.SetKey(nil)
-				return tx
+				return accountCreateTx
 			},
 			expectError: true,
 		},

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
@@ -4,7 +4,6 @@ package construction
 
 import (
 	"context"
-
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/domain/types"
 	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/errors"

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
@@ -57,7 +57,7 @@ func (c *cryptoTransferTransactionConstructor) Parse(_ context.Context, transact
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	transferTransaction, ok := transaction.(*hiero.TransferTransaction)
+	transferTransaction, ok := transaction.(hiero.TransferTransaction)
 	if !ok {
 		return nil, nil, errors.ErrTransactionInvalidType
 	}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
@@ -102,7 +102,7 @@ func (suite *cryptoTransferTransactionConstructorSuite) TestConstruct() {
 
 func (suite *cryptoTransferTransactionConstructorSuite) TestParse() {
 	defaultGetTransaction := func() hiero.TransactionInterface {
-		return hiero.NewTransferTransaction().
+		return *hiero.NewTransferTransaction().
 			AddHbarTransfer(sdkAccountIdA, hiero.HbarFromTinybar(-15)).
 			AddHbarTransfer(sdkAccountIdB, hiero.HbarFromTinybar(15)).
 			SetTransactionID(hiero.TransactionIDGenerate(sdkAccountIdA))


### PR DESCRIPTION
**Description**:

This PR fixes rosetta `/construction/parse` error

- Change transaction type from pointer to struct

**Related issue(s)**:

Fixes #10507 

**Notes for reviewer**:

Tested construction flow against integration with bdd e2e tests.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
