### PR TITLE
Fix rosetta construction parse error (0.124)

### DIFF
--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
@@ -67,7 +67,7 @@ func (c *compositeTransactionConstructor) Parse(ctx context.Context, transaction
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	name := reflect.TypeOf(transaction).Elem().Name()
+	name := reflect.TypeOf(transaction).Name()
 	h, ok := c.constructorsByTransactionType[name]
 	if !ok {
 		log.Errorf("No constructor to parse constructed transaction %s", name)

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	cryptoTransferTransaction = hiero.NewTransferTransaction()
-	tokenCreateTransaction    = hiero.NewTokenCreateTransaction()
+	cryptoTransferTransaction = *hiero.NewTransferTransaction()
+	tokenCreateTransaction    = *hiero.NewTokenCreateTransaction()
 	cryptoTransferOperations  = types.OperationSlice{{Type: types.OperationTypeCryptoTransfer}}
 	mixedOperations           = types.OperationSlice{
 		{Type: types.OperationTypeCryptoTransfer},

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
@@ -79,7 +79,7 @@ func (c *cryptoCreateTransactionConstructor) Parse(_ context.Context, transactio
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	cryptoCreateTransaction, ok := transaction.(*hiero.AccountCreateTransaction)
+	cryptoCreateTransaction, ok := transaction.(hiero.AccountCreateTransaction)
 	if !ok {
 		return nil, nil, errors.ErrTransactionInvalidType
 	}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -164,7 +164,7 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestConstruct() {
 
 func (suite *cryptoCreateTransactionConstructorSuite) TestParse() {
 	defaultGetTransaction := func() hiero.TransactionInterface {
-		return hiero.NewAccountCreateTransaction().
+		return *hiero.NewAccountCreateTransaction().
 			SetAccountMemo(memo).
 			SetAutoRenewPeriod(time.Second * time.Duration(autoRenewPeriod)).
 			SetInitialBalance(hiero.HbarFromTinybar(initialBalance)).
@@ -194,9 +194,9 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestParse() {
 			name: "KeyNotSet",
 			getTransaction: func() hiero.TransactionInterface {
 				tx := defaultGetTransaction()
-				accountCreateTx, _ := tx.(*hiero.AccountCreateTransaction)
+				accountCreateTx, _ := tx.(hiero.AccountCreateTransaction)
 				accountCreateTx.SetKey(nil)
-				return tx
+				return accountCreateTx
 			},
 			expectError: true,
 		},

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
@@ -18,7 +18,6 @@ package construction
 
 import (
 	"context"
-
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/domain/types"
 	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/errors"
@@ -71,7 +70,7 @@ func (c *cryptoTransferTransactionConstructor) Parse(_ context.Context, transact
 	[]types.AccountId,
 	*rTypes.Error,
 ) {
-	transferTransaction, ok := transaction.(*hiero.TransferTransaction)
+	transferTransaction, ok := transaction.(hiero.TransferTransaction)
 	if !ok {
 		return nil, nil, errors.ErrTransactionInvalidType
 	}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
@@ -116,7 +116,7 @@ func (suite *cryptoTransferTransactionConstructorSuite) TestConstruct() {
 
 func (suite *cryptoTransferTransactionConstructorSuite) TestParse() {
 	defaultGetTransaction := func() hiero.TransactionInterface {
-		return hiero.NewTransferTransaction().
+		return *hiero.NewTransferTransaction().
 			AddHbarTransfer(sdkAccountIdA, hiero.HbarFromTinybar(-15)).
 			AddHbarTransfer(sdkAccountIdB, hiero.HbarFromTinybar(15)).
 			SetTransactionID(hiero.TransactionIDGenerate(sdkAccountIdA))

--- a/hedera-mirror-rosetta/app/services/construction_service_test.go
+++ b/hedera-mirror-rosetta/app/services/construction_service_test.go
@@ -75,7 +75,7 @@ var (
 	privateKey, _               = hiero.PrivateKeyFromString("302e020100300506032b6570042204207904b9687878e08e101723f7b724cd61a42bbff93923177bf3fcc2240b0dd3bc")
 	aliasStr                    = ed25519AliasPrefix + publicKeyStr
 	aliasAccount, _             = types.NewAccountIdFromString(aliasStr, 0, 0)
-	unsignedTransactionWithMemo = "0x0a332a310a2d0a0f0a0708959aef3a107b120418d8c307120218031880c2d72f220308b40132087472616e7366657272020a001200"
+	unsignedTransactionWithMemo = "0x0a4522430a140a0c08d2ec84be0610e5a2eef602120418d8c3071880c2d72f2202087832087472616e7366657272180a160a090a0418d8c30710cf0f0a090a0418fec40710d00f"
 	validSignedTransaction      = "0x0aaa012aa7010a3d0a140a0c08feafcb840610ae86c0db03120418d8c307120218041880c2d72f2202087872180a160a090a0418d8c30710cf0f0a090a0418fec40710d00f12660a640a20eba8cc093a83a4ca5e813e30d8c503babb35c22d57d34b6ec5ac0303a6aaba771a40793de745bc19dd8fe8e817891f51b8fe1e259c2e6428bd7fa075b181585a2d40e3666a7c9a1873abb5433ffe1414502836d8d37082eaf94a648b530e9fa78108"
 )
 
@@ -750,24 +750,31 @@ func TestConstructionParse(t *testing.T) {
 				getOperation(0, types.OperationTypeCryptoTransfer, defaultCryptoAccountId1, defaultSendAmount),
 				getOperation(1, types.OperationTypeCryptoTransfer, defaultCryptoAccountId2, defaultReceiveAmount),
 			}
+			operationsReversed := types.OperationSlice{
+				getOperation(0, types.OperationTypeCryptoTransfer, defaultCryptoAccountId2, defaultReceiveAmount),
+				getOperation(1, types.OperationTypeCryptoTransfer, defaultCryptoAccountId1, defaultSendAmount),
+			}
 			expected := &rTypes.ConstructionParseResponse{
 				Operations:               operations.ToRosetta(),
 				AccountIdentifierSigners: tt.signers,
 				Metadata:                 tt.metadata,
 			}
-			mockConstructor := &mocks.MockTransactionConstructor{}
-			mockConstructor.
-				On("Parse", defaultContext, mock.IsType(hiero.TransferTransaction{})).
-				Return(operations, []types.AccountId{defaultCryptoAccountId1}, mocks.NilError)
-			service, _ := NewConstructionAPIService(nil, onlineBaseService, defaultConfig, mockConstructor)
+			expectedReversed := &rTypes.ConstructionParseResponse{
+				Operations:               operationsReversed.ToRosetta(),
+				AccountIdentifierSigners: tt.signers,
+				Metadata:                 tt.metadata,
+			}
+
+			service, _ := NewConstructionAPIService(nil, onlineBaseService, defaultConfig, construction.NewTransactionConstructor())
 
 			// when:
 			actual, e := service.ConstructionParse(defaultContext, tt.request)
 
 			// then:
-			assert.Equal(t, expected, actual)
+			// SDK returns transfers as a map, there's no guarantee of the keys' order when iterating, thus
+			// check both orders here
+			assert.True(t, reflect.DeepEqual(actual, expected) != reflect.DeepEqual(actual, expectedReversed))
 			assert.Nil(t, e)
-			mockConstructor.AssertExpectations(t)
 		})
 	}
 }


### PR DESCRIPTION
**Description**:
This PR backports the fix to `release/0.124`

- Change transaction type from pointer to struct

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
