### PR TITLE
Add global config and env variable to helm chart

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -97,7 +97,6 @@ jobs:
 
       - name: Execute Gradle using transaction executor
         if: ${{ matrix.project == 'web3' && matrix.schema == 'v1'}}
-        continue-on-error: true
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
           SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}

--- a/charts/hedera-mirror-graphql/templates/deployment.yaml
+++ b/charts/hedera-mirror-graphql/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-graphql/templates/secret.yaml
+++ b/charts/hedera-mirror-graphql/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -80,6 +80,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror-grpc/templates/deployment.yaml
+++ b/charts/hedera-mirror-grpc/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-grpc/templates/secret.yaml
+++ b/charts/hedera-mirror-grpc/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -96,6 +96,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror-importer/templates/deployment.yaml
+++ b/charts/hedera-mirror-importer/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-importer/templates/secret.yaml
+++ b/charts/hedera-mirror-importer/templates/secret.yaml
@@ -14,4 +14,4 @@ data:
   {{- $config = merge $config $addressBookConfig }}
   addressbook.bin: {{ .Values.addressBook }}
   {{- end }}
-  application.yaml: {{ toYaml $config | b64enc }}
+  application.yaml: {{ toYaml (mergeOverwrite $config .Values.global.config) | b64enc }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -127,6 +127,8 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  config: {}
+  env: {}
   image: {}
   namespaceOverride: ""
   podAnnotations: {}

--- a/charts/hedera-mirror-monitor/templates/deployment.yaml
+++ b/charts/hedera-mirror-monitor/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-monitor/templates/secret.yaml
+++ b/charts/hedera-mirror-monitor/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -74,6 +74,8 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  config: {}
+  env: {}
   image: {}
   namespaceOverride: ""
   podAnnotations: {}

--- a/charts/hedera-mirror-rest-java/templates/deployment.yaml
+++ b/charts/hedera-mirror-rest-java/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-rest-java/templates/secret.yaml
+++ b/charts/hedera-mirror-rest-java/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -89,6 +89,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror-rest/templates/deployment.yaml
+++ b/charts/hedera-mirror-rest/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-rest/templates/secret.yaml
+++ b/charts/hedera-mirror-rest/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -80,6 +80,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror-rosetta/templates/deployment.yaml
+++ b/charts/hedera-mirror-rosetta/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-rosetta/templates/secret.yaml
+++ b/charts/hedera-mirror-rosetta/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -86,6 +86,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror-web3/templates/deployment.yaml
+++ b/charts/hedera-mirror-web3/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
-            {{- range $name, $value := .Values.env }}
+            {{- range $name, $value := mergeOverwrite .Values.env .Values.global.env }}
             - name: {{ $name }}
             {{- if kindIs "string" $value }}
               value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror-web3/templates/secret.yaml
+++ b/charts/hedera-mirror-web3/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml (mergeOverwrite .Values.config .Values.global.config) | nindent 4 }}

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -83,6 +83,8 @@ gateway:
     kind: Service
 
 global:
+  config: {}
+  env: {}
   gateway:
     enabled: false
     hostnames: []

--- a/charts/hedera-mirror/templates/tests/pod.yaml
+++ b/charts/hedera-mirror/templates/tests/pod.yaml
@@ -19,7 +19,7 @@ spec:
       env:
         - name: SPRING_CONFIG_ADDITIONALLOCATION
           value: /etc/secrets/
-        {{- range $name, $value := .Values.test.env }}
+        {{- range $name, $value := mergeOverwrite .Values.test.env .Values.global.env }}
         - name: {{ $name }}
         {{- if kindIs "string" $value }}
           value: {{ tpl $value $ | quote }}

--- a/charts/hedera-mirror/templates/tests/secret.yaml
+++ b/charts/hedera-mirror/templates/tests/secret.yaml
@@ -11,5 +11,5 @@ metadata:
 type: Opaque
 stringData:
   application.yml: |-
-    {{- tpl (toYaml .Values.test.config) $ | nindent 4 }}
+    {{- tpl (toYaml (mergeOverwrite .Values.test.config .Values.global.config)) $ | nindent 4 }}
 {{- end -}}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -74,6 +74,8 @@ db:
 fullnameOverride: ""
 
 global:
+  config: {}
+  env: {}
   gateway:
     annotations: {}
     className: "gke-l7-global-external-managed"

--- a/tools/mirror-report/package.json
+++ b/tools/mirror-report/package.json
@@ -34,7 +34,6 @@
   },
   "scripts": {
     "start": "node ./index.js",
-    "lint": "eslint --ignore-pattern node_modules/ --fix .",
     "test": "node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "type": "module",


### PR DESCRIPTION
**Description**:

* Add a `global.config={}` that is merged with each child chart's config
* Add a `global.env={}` that is merged with each child chart's env
* Change modularized web3 tests to fail on error
* Remove invalid lint command from `mirror-report`

**Related issue(s)**:

Fixes #10512

**Notes for reviewer**:

This allows us to set `global.env.HEDERA_MIRROR_COMMON_REALM=1000` in one place.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
