### PR TITLE
Disable deterministic throttle from hedera app

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
@@ -19,6 +19,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Set;
 import java.util.function.Predicate;
 
+// This class is an exact copy with the one from hedera-app. The only difference is that
+// ConsensusThrottling.OFF is passed by default instead of ConsensusThrottling.ON.
 /**
  * The options a {@link HandleContext} client can customize its dispatch with.
  */

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.node.app.spi.workflows;
+
+import static com.hedera.node.app.spi.workflows.HandleContext.DispatchMetadata.EMPTY_METADATA;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.TransactionCustomizer.NOOP_TRANSACTION_CUSTOMIZER;
+import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling;
+import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * The options a {@link HandleContext} client can customize its dispatch with.
+ */
+public record DispatchOptions<T extends StreamBuilder>(
+        @NonNull Commit commit,
+        @NonNull AccountID payerId,
+        @NonNull TransactionBody body,
+        @NonNull UsePresetTxnId usePresetTxnId,
+        @NonNull Predicate<Key> keyVerifier,
+        @NonNull Set<Key> authorizingKeys,
+        @NonNull TransactionCategory category,
+        @NonNull ConsensusThrottling throttling,
+        @NonNull Class<T> streamBuilderType,
+        @NonNull ReversingBehavior reversingBehavior,
+        @NonNull StreamBuilder.TransactionCustomizer transactionCustomizer,
+        @NonNull HandleContext.DispatchMetadata dispatchMetadata) {
+    private static final Predicate<Key> PREAUTHORIZED_KEYS = k -> true;
+
+    /**
+     * The choice of when to commit the dispatched transaction's effects on state.
+     */
+    public enum Commit {
+        /**
+         * Wait to commit the dispatched transaction's effects with its parent; hence, only commit these effects
+         * if the parent dispatch does not roll back.
+         */
+        WITH_PARENT,
+        /**
+         * Commit the transaction's effects immediately, along with any effects already accumulated by the parent
+         * dispatch. (But note the parent dispatch will generally have no pending effects when this option makes
+         * sense to use; i.e., to perform a preceding dispatch that sets up the parent dispatch state but does
+         * not depend on the parent's success.)
+         */
+        IMMEDIATELY,
+    }
+
+    /**
+     * Whether a dispatch can trigger staking rewards to involved accounts.
+     */
+    public enum StakingRewards {
+        /**
+         * The dispatch can trigger staking rewards.
+         */
+        ON,
+        /**
+         * The dispatch cannot trigger staking rewards.
+         */
+        OFF,
+    }
+
+    /**
+     * Whether the dispatch's {@link TransactionBody} should use a preset transaction ID
+     * instead of receiving one at the end of the dispatch.
+     */
+    public enum UsePresetTxnId {
+        /**
+         * The dispatch's {@link TransactionBody} should include the expected transaction ID.
+         */
+        YES,
+        /**
+         * The dispatch's {@link TransactionBody} should not include the expected transaction ID.
+         */
+        NO,
+    }
+
+    public DispatchOptions {
+        requireNonNull(commit);
+        requireNonNull(payerId);
+        requireNonNull(body);
+        requireNonNull(usePresetTxnId);
+        requireNonNull(keyVerifier);
+        requireNonNull(category);
+        requireNonNull(throttling);
+        requireNonNull(authorizingKeys);
+        requireNonNull(streamBuilderType);
+        requireNonNull(reversingBehavior);
+        requireNonNull(transactionCustomizer);
+        requireNonNull(dispatchMetadata);
+    }
+
+    /**
+     * Returns the effective key verifier for the dispatch ({@code null} if all keys should be treated as authorized).
+     */
+    public @Nullable Predicate<Key> effectiveKeyVerifier() {
+        return keyVerifier == PREAUTHORIZED_KEYS ? null : keyVerifier;
+    }
+
+    /**
+     * Returns whether the dispatch should commit immediately.
+     */
+    public boolean commitImmediately() {
+        return commit == Commit.IMMEDIATELY;
+    }
+
+    /**
+     * Returns options for a dispatch that is logically independent of the parent dispatch. Use cases include,
+     * <ul>
+     *     <li>Completing a hollow account whose public key was provided in the signature map of
+     *     a parent HAPI transaction.</li>
+     *     <li>Doing post-upgrade setup before the first transaction handled after the upgrade.</li>
+     * </ul>
+     * <b>Important:</b> Since such dispatches are not logically part of the parent dispatch, they should
+     * really be done as a separate top-level transaction. Prefer not introducing any further uses of this
+     * {@link DispatchOptions} factory.
+     *
+     * @param payerId the account to pay for the dispatch
+     * @param body the transaction to dispatch
+     * @param streamBuilderType the type of stream builder to use for the dispatch
+     * @return the options for the setup dispatch
+     * @param <T> the type of stream builder to use for the dispatch
+     */
+    public static <T extends StreamBuilder> DispatchOptions<T> independentDispatch(
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body,
+            @NonNull final Class<T> streamBuilderType) {
+        return new DispatchOptions<>(
+                Commit.IMMEDIATELY,
+                payerId,
+                body,
+                UsePresetTxnId.NO,
+                PREAUTHORIZED_KEYS,
+                emptySet(),
+                TransactionCategory.PRECEDING,
+                ConsensusThrottling.OFF,
+                streamBuilderType,
+                ReversingBehavior.IRREVERSIBLE,
+                NOOP_TRANSACTION_CUSTOMIZER,
+                EMPTY_METADATA);
+    }
+
+    /**
+     * Returns options for a dispatch that is part of the parent dispatch's transactional unit, but in a setup role
+     * that logically precedes the parent transaction's effects. Use cases include,
+     * <ul>
+     *     <li>Externalizing creation of a "hollow" account prior to a successful EVM transaction that
+     *     first sends value to its EVM address.</li>
+     *     <li>Externalizing auto-creation of an aliased account that receives value in a parent
+     *     {@link com.hedera.hapi.node.base.HederaFunctionality#CRYPTO_TRANSFER} transaction.</li>
+     * </ul>
+     * @param payerId the account to pay for the dispatch
+     * @param body the transaction to dispatch
+     * @param streamBuilderType the type of stream builder to use for the dispatch
+     * @return the options for the setup dispatch
+     * @param <T> the type of stream builder to use for the dispatch
+     */
+    public static <T extends StreamBuilder> DispatchOptions<T> setupDispatch(
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body,
+            @NonNull final Class<T> streamBuilderType) {
+        return new DispatchOptions<>(
+                Commit.WITH_PARENT,
+                payerId,
+                body,
+                UsePresetTxnId.NO,
+                PREAUTHORIZED_KEYS,
+                emptySet(),
+                TransactionCategory.PRECEDING,
+                ConsensusThrottling.OFF,
+                streamBuilderType,
+                ReversingBehavior.REMOVABLE,
+                NOOP_TRANSACTION_CUSTOMIZER,
+                EMPTY_METADATA);
+    }
+
+    /**
+     * Returns options for a dispatch that is part of the parent dispatch's transactional unit, as a sub-transaction
+     * that forms a logical step explaining the entirety of the parent transaction's effects; no matter if the parent
+     * transaction succeeds or fails. Use cases include,
+     * <ul>
+     *     <li>Triggering a scheduled transaction.</li>
+     *     <li>Dispatching a native Hedera transaction from within the EVM via a system contract.</li>
+     * </ul>
+     *
+     * @param <T> the type of stream builder to use for the dispatch
+     * @param payerId the account to pay for the dispatch
+     * @param body the transaction to dispatch
+     * @param keyVerifier the key verifier to use for the dispatch
+     * @param authorizingKeys the set of keys authorizing the dispatch
+     * @param streamBuilderType the type of stream builder to use for the dispatch
+     * @param stakingRewards whether the dispatch can trigger staking rewards
+     * @param usePresetTxnId whether the dispatch's {@link TransactionBody} should include the expected txn id
+     * @return the options for the sub-dispatch
+     */
+    public static <T extends StreamBuilder> DispatchOptions<T> subDispatch(
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body,
+            @NonNull final Predicate<Key> keyVerifier,
+            @NonNull final Set<Key> authorizingKeys,
+            @NonNull final Class<T> streamBuilderType,
+            @NonNull final StakingRewards stakingRewards,
+            @NonNull final UsePresetTxnId usePresetTxnId) {
+        final var category =
+                switch (requireNonNull(stakingRewards)) {
+                    case ON -> TransactionCategory.SCHEDULED;
+                    case OFF -> TransactionCategory.CHILD;
+                };
+        return new DispatchOptions<>(
+                Commit.WITH_PARENT,
+                payerId,
+                body,
+                usePresetTxnId,
+                keyVerifier,
+                authorizingKeys,
+                category,
+                ConsensusThrottling.OFF,
+                streamBuilderType,
+                ReversingBehavior.REVERSIBLE,
+                NOOP_TRANSACTION_CUSTOMIZER,
+                EMPTY_METADATA);
+    }
+
+    /**
+     * Returns options for a dispatch that is a step in the parent dispatch's business logic, but only appropriate
+     * to externalize if the parent succeeds.
+     * <ul>
+     *     <li>Dispatching an internal contract creation in the EVM.</li>
+     * </ul>
+     *
+     * @param payerId the account to pay for the dispatch
+     * @param body the transaction to dispatch
+     * @param streamBuilderType the type of stream builder to use for the dispatch
+     * @param transactionCustomizer the customizer for the transaction
+     * @return the options for the sub-dispatch
+     * @param <T> the type of stream builder to use for the dispatch
+     */
+    public static <T extends StreamBuilder> DispatchOptions<T> stepDispatch(
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body,
+            @NonNull final Class<T> streamBuilderType,
+            @NonNull final StreamBuilder.TransactionCustomizer transactionCustomizer) {
+        return new DispatchOptions<>(
+                Commit.WITH_PARENT,
+                payerId,
+                body,
+                UsePresetTxnId.NO,
+                PREAUTHORIZED_KEYS,
+                emptySet(),
+                TransactionCategory.CHILD,
+                ConsensusThrottling.OFF,
+                streamBuilderType,
+                ReversingBehavior.REMOVABLE,
+                transactionCustomizer,
+                EMPTY_METADATA);
+    }
+
+    /**
+     * Returns options for a dispatch that is a step in the parent dispatch's business logic, but only appropriate
+     * to externalize if the parent succeeds.
+     * <ul>
+     *     <li>Dispatching an internal contract creation in the EVM.</li>
+     * </ul>
+     *
+     * @param payerId the account to pay for the dispatch
+     * @param body the transaction to dispatch
+     * @param streamBuilderType the type of stream builder to use for the dispatch
+     * @param transactionCustomizer the customizer for the transaction
+     * @return the options for the sub-dispatch
+     * @param <T> the type of stream builder to use for the dispatch
+     */
+    public static <T extends StreamBuilder> DispatchOptions<T> stepDispatch(
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body,
+            @NonNull final Class<T> streamBuilderType,
+            @NonNull final StreamBuilder.TransactionCustomizer transactionCustomizer,
+            @NonNull final HandleContext.DispatchMetadata metaData) {
+        return new DispatchOptions<>(
+                Commit.WITH_PARENT,
+                payerId,
+                body,
+                UsePresetTxnId.NO,
+                PREAUTHORIZED_KEYS,
+                emptySet(),
+                TransactionCategory.CHILD,
+                ConsensusThrottling.OFF,
+                streamBuilderType,
+                ReversingBehavior.REMOVABLE,
+                transactionCustomizer,
+                metaData);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
@@ -78,6 +78,8 @@ import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+// This class is an exact copy with the one from hedera-app. The only difference is that
+// ConsensusThrottling.OFF is passed by default instead of ConsensusThrottling.ON.
 @Singleton
 public class UserTxnFactory {
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.node.app.workflows.handle.steps;
+
+import static com.hedera.hapi.node.base.HederaFunctionality.STATE_SIGNATURE_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.node.app.workflows.handle.TransactionType.GENESIS_TRANSACTION;
+import static com.hedera.node.app.workflows.handle.TransactionType.POST_UPGRADE_TRANSACTION;
+import static com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory.functionOfTxn;
+import static com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory.getKeyVerifier;
+import static com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory.getTxnInfoFrom;
+import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.PRE_HANDLE_FAILURE;
+import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.SO_FAR_SO_GOOD;
+import static com.hedera.node.app.workflows.standalone.impl.StandaloneDispatchFactory.getTxnCategory;
+import static com.hedera.node.config.types.StreamMode.RECORDS;
+import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.platform.event.StateSignatureTransaction;
+import com.hedera.node.app.blocks.BlockStreamManager;
+import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
+import com.hedera.node.app.blocks.impl.KVStateChangeListener;
+import com.hedera.node.app.fees.ExchangeRateManager;
+import com.hedera.node.app.fees.FeeAccumulator;
+import com.hedera.node.app.fees.FeeManager;
+import com.hedera.node.app.fees.ResourcePriceCalculatorImpl;
+import com.hedera.node.app.ids.EntityIdService;
+import com.hedera.node.app.ids.EntityNumGeneratorImpl;
+import com.hedera.node.app.ids.WritableEntityIdStore;
+import com.hedera.node.app.records.BlockRecordManager;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
+import com.hedera.node.app.service.token.api.TokenServiceApi;
+import com.hedera.node.app.services.ServiceScopeLookup;
+import com.hedera.node.app.signature.AppKeyVerifier;
+import com.hedera.node.app.signature.DefaultKeyVerifier;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.metrics.StoreMetricsService;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.PreCheckException;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.store.ReadableStoreFactory;
+import com.hedera.node.app.store.ServiceApiFactory;
+import com.hedera.node.app.store.StoreFactoryImpl;
+import com.hedera.node.app.store.WritableStoreFactory;
+import com.hedera.node.app.throttle.AppThrottleAdviser;
+import com.hedera.node.app.throttle.NetworkUtilizationManager;
+import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
+import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.app.workflows.handle.DispatchHandleContext;
+import com.hedera.node.app.workflows.handle.DispatchProcessor;
+import com.hedera.node.app.workflows.handle.RecordDispatch;
+import com.hedera.node.app.workflows.handle.TransactionType;
+import com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory;
+import com.hedera.node.app.workflows.handle.record.TokenContextImpl;
+import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
+import com.hedera.node.app.workflows.prehandle.PreHandleContextImpl;
+import com.hedera.node.app.workflows.prehandle.PreHandleResult;
+import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.data.ConsensusConfig;
+import com.hedera.node.config.data.HederaConfig;
+import com.hedera.node.config.types.StreamMode;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import com.swirlds.state.State;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
+import com.swirlds.state.lifecycle.info.NodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class UserTxnFactory {
+
+    private final ConfigProvider configProvider;
+    private final StoreMetricsService storeMetricsService;
+    private final KVStateChangeListener kvStateChangeListener;
+    private final BoundaryStateChangeListener boundaryStateChangeListener;
+    private final PreHandleWorkflow preHandleWorkflow;
+    private final Authorizer authorizer;
+    private final NetworkInfo networkInfo;
+    private final FeeManager feeManager;
+    private final DispatchProcessor dispatchProcessor;
+    private final ServiceScopeLookup serviceScopeLookup;
+    private final ExchangeRateManager exchangeRateManager;
+    private final TransactionDispatcher dispatcher;
+    private final NetworkUtilizationManager networkUtilizationManager;
+    private final StreamMode streamMode;
+    private final BlockRecordManager blockRecordManager;
+    private final BlockStreamManager blockStreamManager;
+    private final ChildDispatchFactory childDispatchFactory;
+
+    @Inject
+    public UserTxnFactory(
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final StoreMetricsService storeMetricsService,
+            @NonNull final KVStateChangeListener kvStateChangeListener,
+            @NonNull final BoundaryStateChangeListener boundaryStateChangeListener,
+            @NonNull final PreHandleWorkflow preHandleWorkflow,
+            @NonNull final Authorizer authorizer,
+            @NonNull final NetworkInfo networkInfo,
+            @NonNull final FeeManager feeManager,
+            @NonNull final DispatchProcessor dispatchProcessor,
+            @NonNull final ServiceScopeLookup serviceScopeLookup,
+            @NonNull final ExchangeRateManager exchangeRateManager,
+            @NonNull final TransactionDispatcher dispatcher,
+            @NonNull final NetworkUtilizationManager networkUtilizationManager,
+            @NonNull final BlockRecordManager blockRecordManager,
+            @NonNull final BlockStreamManager blockStreamManager,
+            @NonNull final ChildDispatchFactory childDispatchFactory) {
+        this.configProvider = requireNonNull(configProvider);
+        this.storeMetricsService = requireNonNull(storeMetricsService);
+        this.kvStateChangeListener = requireNonNull(kvStateChangeListener);
+        this.boundaryStateChangeListener = requireNonNull(boundaryStateChangeListener);
+        this.preHandleWorkflow = requireNonNull(preHandleWorkflow);
+        this.authorizer = requireNonNull(authorizer);
+        this.networkInfo = requireNonNull(networkInfo);
+        this.feeManager = requireNonNull(feeManager);
+        this.dispatcher = requireNonNull(dispatcher);
+        this.networkUtilizationManager = requireNonNull(networkUtilizationManager);
+        this.dispatchProcessor = requireNonNull(dispatchProcessor);
+        this.serviceScopeLookup = requireNonNull(serviceScopeLookup);
+        this.exchangeRateManager = requireNonNull(exchangeRateManager);
+        this.blockStreamManager = requireNonNull(blockStreamManager);
+        this.blockRecordManager = requireNonNull(blockRecordManager);
+        this.childDispatchFactory = requireNonNull(childDispatchFactory);
+        this.streamMode = configProvider
+                .getConfiguration()
+                .getConfigData(BlockStreamConfig.class)
+                .streamMode();
+    }
+
+    /**
+     * Creates a new {@link UserTxn} instance from the given parameters.
+     *
+     * @param state the state the transaction will be applied to
+     * @param creatorInfo the node information of the creator
+     * @param platformTxn the transaction itself
+     * @param consensusNow the current consensus time
+     * @param type the type of the transaction
+     * @param stateSignatureTxnCallback a callback to be called when encountering a {@link StateSignatureTransaction}
+     * @return the new user transaction, or {@code null} if the transaction is not a user transaction
+     */
+    public @Nullable UserTxn createUserTxn(
+            @NonNull final State state,
+            @NonNull final NodeInfo creatorInfo,
+            @NonNull final ConsensusTransaction platformTxn,
+            @NonNull final Instant consensusNow,
+            @NonNull final TransactionType type,
+            @NonNull final Consumer<StateSignatureTransaction> stateSignatureTxnCallback) {
+        requireNonNull(state);
+        requireNonNull(creatorInfo);
+        requireNonNull(platformTxn);
+        requireNonNull(consensusNow);
+        requireNonNull(type);
+        final var config = configProvider.getConfiguration();
+        final var stack = createRootSavepointStack(state, type);
+        final var readableStoreFactory = new ReadableStoreFactory(stack);
+        final var preHandleResult = preHandleWorkflow.getCurrentPreHandleResult(
+                creatorInfo, platformTxn, readableStoreFactory, stateSignatureTxnCallback);
+        final var txnInfo = requireNonNull(preHandleResult.txInfo());
+        if (txnInfo.functionality() == STATE_SIGNATURE_TRANSACTION) {
+            return null;
+        }
+        final var tokenContext = new TokenContextImpl(config, storeMetricsService, stack, consensusNow);
+        return new UserTxn(
+                type,
+                txnInfo.functionality(),
+                consensusNow,
+                state,
+                txnInfo,
+                tokenContext,
+                stack,
+                preHandleResult,
+                readableStoreFactory,
+                config,
+                creatorInfo);
+    }
+
+    /**
+     * Creates a new {@link UserTxn} for synthetic transaction body.
+     *
+     * @param state the state the transaction will be applied to
+     * @param creatorInfo the node information of the creator
+     * @param consensusNow the current consensus time
+     * @param type the type of the transaction
+     * @param body synthetic transaction body
+     * @return the new user transaction
+     */
+    public UserTxn createUserTxn(
+            @NonNull final State state,
+            @NonNull final NodeInfo creatorInfo,
+            @NonNull final Instant consensusNow,
+            @NonNull final TransactionType type,
+            @NonNull final AccountID payerId,
+            @NonNull final TransactionBody body) {
+        requireNonNull(state);
+        requireNonNull(creatorInfo);
+        requireNonNull(consensusNow);
+        requireNonNull(type);
+        requireNonNull(payerId);
+        requireNonNull(body);
+        final var config = configProvider.getConfiguration();
+        final var stack = createRootSavepointStack(state, type);
+        final var readableStoreFactory = new ReadableStoreFactory(stack);
+        final var functionality = functionOfTxn(body);
+        final var preHandleResult = preHandleSyntheticTransaction(body, payerId, config, readableStoreFactory);
+        final var tokenContext = new TokenContextImpl(config, storeMetricsService, stack, consensusNow);
+        return new UserTxn(
+                type,
+                functionality,
+                consensusNow,
+                state,
+                preHandleResult.txInfo(),
+                tokenContext,
+                stack,
+                preHandleResult,
+                readableStoreFactory,
+                config,
+                creatorInfo);
+    }
+
+    /**
+     * Creates a new {@link Dispatch} instance for this user transaction in the given context.
+     *
+     * @param userTxn user transaction
+     * @param exchangeRates the exchange rates to use
+     * @return the new dispatch instance
+     */
+    public Dispatch createDispatch(@NonNull final UserTxn userTxn, @NonNull final ExchangeRateSet exchangeRates) {
+        requireNonNull(userTxn);
+        requireNonNull(exchangeRates);
+        final var preHandleResult = userTxn.preHandleResult();
+        final var keyVerifier = new DefaultKeyVerifier(
+                userTxn.txnInfo().signatureMap().sigPair().size(),
+                userTxn.config().getConfigData(HederaConfig.class),
+                preHandleResult.getVerificationResults());
+        final var category = getTxnCategory(preHandleResult);
+        final var baseBuilder = userTxn.initBaseBuilder(exchangeRates);
+        return createDispatch(userTxn, baseBuilder, keyVerifier, category);
+    }
+
+    /**
+     * Creates a new {@link Dispatch} instance for this user transaction in the given context.
+     *
+     * @param userTxn user transaction
+     * @param baseBuilder the base record builder
+     * @param keyVerifierCallback key verifier callback
+     * @param category transaction category
+     * @return the new dispatch instance
+     */
+    public Dispatch createDispatch(
+            @NonNull final UserTxn userTxn,
+            @NonNull final StreamBuilder baseBuilder,
+            @NonNull final Predicate<Key> keyVerifierCallback,
+            @NonNull final HandleContext.TransactionCategory category) {
+        final var config = userTxn.config();
+        final var keyVerifier = getKeyVerifier(keyVerifierCallback, config, emptySet());
+        return createDispatch(userTxn, baseBuilder, keyVerifier, category);
+    }
+
+    private Dispatch createDispatch(
+            @NonNull final UserTxn userTxn,
+            @NonNull final StreamBuilder baseBuilder,
+            @NonNull final AppKeyVerifier keyVerifier,
+            @NonNull final HandleContext.TransactionCategory transactionCategory) {
+        final var config = userTxn.config();
+        final var txnInfo = userTxn.txnInfo();
+        final var preHandleResult = userTxn.preHandleResult();
+        final var stack = userTxn.stack();
+        final var consensusNow = userTxn.consensusNow();
+        final var creatorInfo = userTxn.creatorInfo();
+        final var tokenContextImpl = userTxn.tokenContextImpl();
+
+        final var readableStoreFactory = new ReadableStoreFactory(stack);
+        final var writableStoreFactory = new WritableStoreFactory(
+                stack, serviceScopeLookup.getServiceName(txnInfo.txBody()), config, storeMetricsService);
+        final var serviceApiFactory = new ServiceApiFactory(stack, config, storeMetricsService);
+        final var priceCalculator =
+                new ResourcePriceCalculatorImpl(consensusNow, txnInfo, feeManager, readableStoreFactory);
+        final var storeFactory = new StoreFactoryImpl(readableStoreFactory, writableStoreFactory, serviceApiFactory);
+        final var entityNumGenerator = new EntityNumGeneratorImpl(
+                new WritableStoreFactory(stack, EntityIdService.NAME, config, storeMetricsService)
+                        .getStore(WritableEntityIdStore.class));
+        final var throttleAdvisor = new AppThrottleAdviser(networkUtilizationManager, consensusNow);
+        final var feeAccumulator =
+                new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (FeeStreamBuilder) baseBuilder);
+        final var dispatchHandleContext = new DispatchHandleContext(
+                consensusNow,
+                creatorInfo,
+                txnInfo,
+                config,
+                authorizer,
+                streamMode != RECORDS ? blockStreamManager : blockRecordManager,
+                priceCalculator,
+                feeManager,
+                storeFactory,
+                requireNonNull(txnInfo.payerID()),
+                keyVerifier,
+                txnInfo.functionality(),
+                preHandleResult.payerKey() == null ? Key.DEFAULT : preHandleResult.payerKey(),
+                exchangeRateManager,
+                stack,
+                entityNumGenerator,
+                dispatcher,
+                networkInfo,
+                childDispatchFactory,
+                dispatchProcessor,
+                throttleAdvisor,
+                feeAccumulator,
+                HandleContext.DispatchMetadata.EMPTY_METADATA);
+        final var fees = dispatcher.dispatchComputeFees(dispatchHandleContext);
+        if (streamMode != RECORDS) {
+            final var congestionMultiplier = feeManager.congestionMultiplierFor(
+                    txnInfo.txBody(), txnInfo.functionality(), storeFactory.asReadOnly());
+            if (congestionMultiplier > 1) {
+                baseBuilder.congestionMultiplier(congestionMultiplier);
+            }
+        }
+        return new RecordDispatch(
+                baseBuilder,
+                config,
+                fees,
+                txnInfo,
+                requireNonNull(txnInfo.payerID()),
+                readableStoreFactory,
+                feeAccumulator,
+                keyVerifier,
+                creatorInfo,
+                consensusNow,
+                preHandleResult.getRequiredKeys(),
+                preHandleResult.getHollowAccounts(),
+                dispatchHandleContext,
+                stack,
+                transactionCategory,
+                tokenContextImpl,
+                preHandleResult,
+                HandleContext.ConsensusThrottling.OFF);
+    }
+
+    /**
+     * Creates a new root savepoint stack for the given state and transaction type, where genesis and
+     * post-upgrade transactions have the maximum number of preceding records; and other transaction
+     * types only support the number of preceding records specified in the network configuration.
+     * @param state the state the stack is based on
+     * @param type the type of the transaction
+     * @return the new root savepoint stack
+     */
+    public SavepointStackImpl createRootSavepointStack(
+            @NonNull final State state, @NonNull final TransactionType type) {
+        final var config = configProvider.getConfiguration();
+        final var consensusConfig = config.getConfigData(ConsensusConfig.class);
+        final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
+        final var maxPrecedingRecords = (type == GENESIS_TRANSACTION || type == POST_UPGRADE_TRANSACTION)
+                ? Integer.MAX_VALUE
+                : consensusConfig.handleMaxPrecedingRecords();
+        return SavepointStackImpl.newRootStack(
+                state,
+                maxPrecedingRecords,
+                consensusConfig.handleMaxFollowingRecords(),
+                boundaryStateChangeListener,
+                kvStateChangeListener,
+                blockStreamConfig.streamMode());
+    }
+
+    private PreHandleResult preHandleSyntheticTransaction(
+            @NonNull final TransactionBody body,
+            @NonNull final AccountID syntheticPayerId,
+            @NonNull final Configuration config,
+            @NonNull final ReadableStoreFactory readableStoreFactory) {
+        try {
+            dispatcher.dispatchPureChecks(body);
+            final var preHandleContext =
+                    new PreHandleContextImpl(readableStoreFactory, body, syntheticPayerId, config, dispatcher);
+            dispatcher.dispatchPreHandle(preHandleContext);
+            final var txInfo = getTxnInfoFrom(syntheticPayerId, body);
+            return new PreHandleResult(
+                    null,
+                    null,
+                    SO_FAR_SO_GOOD,
+                    OK,
+                    txInfo,
+                    preHandleContext.requiredNonPayerKeys(),
+                    null,
+                    preHandleContext.requiredHollowAccounts(),
+                    null,
+                    null,
+                    0);
+        } catch (final PreCheckException e) {
+            return new PreHandleResult(
+                    null,
+                    null,
+                    PRE_HANDLE_FAILURE,
+                    e.responseCode(),
+                    null,
+                    emptySet(),
+                    null,
+                    emptySet(),
+                    null,
+                    null,
+                    0);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
@@ -66,6 +66,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+// This class is an exact copy with the one from hedera-app. The only difference is that
+// ConsensusThrottling.OFF is passed by default instead of ConsensusThrottling.ON.
 /**
  * Constructs a {@link Dispatch} appropriate for a standalone transaction executor that does not want to enforce
  * normal signing requirements but simply execute one or more transactions.

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.node.app.workflows.standalone.impl;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.node.app.spi.workflows.HandleContext.DispatchMetadata.EMPTY_METADATA;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.NODE;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.workflows.handle.HandleWorkflow.initializeBuilderInfo;
+import static com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory.NO_OP_KEY_VERIFIER;
+import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.UNKNOWN_FAILURE;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
+import com.hedera.node.app.blocks.impl.KVStateChangeListener;
+import com.hedera.node.app.fees.ExchangeRateManager;
+import com.hedera.node.app.fees.FeeAccumulator;
+import com.hedera.node.app.fees.FeeManager;
+import com.hedera.node.app.fees.ResourcePriceCalculatorImpl;
+import com.hedera.node.app.ids.EntityIdService;
+import com.hedera.node.app.ids.EntityNumGeneratorImpl;
+import com.hedera.node.app.ids.WritableEntityIdStore;
+import com.hedera.node.app.info.NodeInfoImpl;
+import com.hedera.node.app.records.impl.BlockRecordInfoImpl;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
+import com.hedera.node.app.service.token.api.TokenServiceApi;
+import com.hedera.node.app.services.ServiceScopeLookup;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.metrics.StoreMetricsService;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.store.ReadableStoreFactory;
+import com.hedera.node.app.store.ServiceApiFactory;
+import com.hedera.node.app.store.StoreFactoryImpl;
+import com.hedera.node.app.store.WritableStoreFactory;
+import com.hedera.node.app.throttle.AppThrottleAdviser;
+import com.hedera.node.app.throttle.NetworkUtilizationManager;
+import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
+import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.app.workflows.handle.DispatchHandleContext;
+import com.hedera.node.app.workflows.handle.DispatchProcessor;
+import com.hedera.node.app.workflows.handle.RecordDispatch;
+import com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory;
+import com.hedera.node.app.workflows.handle.record.TokenContextImpl;
+import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
+import com.hedera.node.app.workflows.prehandle.PreHandleResult;
+import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.data.ConsensusConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import com.swirlds.platform.system.transaction.TransactionWrapper;
+import com.swirlds.state.State;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
+import com.swirlds.state.lifecycle.info.NodeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Constructs a {@link Dispatch} appropriate for a standalone transaction executor that does not want to enforce
+ * normal signing requirements but simply execute one or more transactions.
+ */
+@Singleton
+public class StandaloneDispatchFactory {
+    private final FeeManager feeManager;
+    private final Authorizer authorizer;
+    private final NetworkInfo networkInfo;
+    private final ConfigProvider configProvider;
+    private final DispatchProcessor dispatchProcessor;
+    private final PreHandleWorkflow preHandleWorkflow;
+    private final ServiceScopeLookup serviceScopeLookup;
+    private final ExchangeRateManager exchangeRateManager;
+    private final StoreMetricsService storeMetricsService;
+    private final ChildDispatchFactory childDispatchFactory;
+    private final TransactionDispatcher transactionDispatcher;
+    private final NetworkUtilizationManager networkUtilizationManager;
+
+    @Inject
+    public StandaloneDispatchFactory(
+            @NonNull final FeeManager feeManager,
+            @NonNull final Authorizer authorizer,
+            @NonNull final NetworkInfo networkInfo,
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final DispatchProcessor dispatchProcessor,
+            @NonNull final PreHandleWorkflow preHandleWorkflow,
+            @NonNull final ServiceScopeLookup serviceScopeLookup,
+            @NonNull final ExchangeRateManager exchangeRateManager,
+            @NonNull final StoreMetricsService storeMetricsService,
+            @NonNull final ChildDispatchFactory childDispatchFactory,
+            @NonNull final TransactionDispatcher transactionDispatcher,
+            @NonNull final NetworkUtilizationManager networkUtilizationManager) {
+        this.feeManager = requireNonNull(feeManager);
+        this.authorizer = requireNonNull(authorizer);
+        this.networkInfo = requireNonNull(networkInfo);
+        this.configProvider = requireNonNull(configProvider);
+        this.dispatchProcessor = requireNonNull(dispatchProcessor);
+        this.preHandleWorkflow = requireNonNull(preHandleWorkflow);
+        this.childDispatchFactory = requireNonNull(childDispatchFactory);
+        this.transactionDispatcher = requireNonNull(transactionDispatcher);
+        this.serviceScopeLookup = requireNonNull(serviceScopeLookup);
+        this.exchangeRateManager = requireNonNull(exchangeRateManager);
+        this.storeMetricsService = requireNonNull(storeMetricsService);
+        this.networkUtilizationManager = requireNonNull(networkUtilizationManager);
+    }
+
+    /**
+     * Constructs a new {@link Dispatch} for the given transaction body, state, and consensus time. When the
+     * dispatch is processed with the {@link DispatchProcessor}, its side effects will be committed to the
+     * {@link State} provided.
+     *
+     * @param state the state to use
+     * @param transactionBody the transaction body to use
+     * @param consensusNow the consensus time to use
+     * @return a new dispatch
+     */
+    public Dispatch newDispatch(
+            @NonNull final State state,
+            @NonNull final TransactionBody transactionBody,
+            @NonNull final Instant consensusNow) {
+        final var config = configProvider.getConfiguration();
+        final var consensusConfig = config.getConfigData(ConsensusConfig.class);
+        final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
+        final var stack = SavepointStackImpl.newRootStack(
+                state,
+                consensusConfig.handleMaxPrecedingRecords(),
+                consensusConfig.handleMaxFollowingRecords(),
+                new BoundaryStateChangeListener(),
+                new KVStateChangeListener(),
+                blockStreamConfig.streamMode());
+        final var readableStoreFactory = new ReadableStoreFactory(stack);
+        final var consensusTransaction = consensusTransactionFor(transactionBody);
+        final var creatorInfo = creatorInfoFor(transactionBody);
+        final var preHandleResult = preHandleWorkflow.getCurrentPreHandleResult(
+                creatorInfo, consensusTransaction, readableStoreFactory, ignore -> {});
+        final var tokenContext = new TokenContextImpl(config, storeMetricsService, stack, consensusNow);
+        final var txnInfo = requireNonNull(preHandleResult.txInfo());
+        final var writableStoreFactory = new WritableStoreFactory(
+                stack, serviceScopeLookup.getServiceName(txnInfo.txBody()), config, storeMetricsService);
+        final var serviceApiFactory = new ServiceApiFactory(stack, config, storeMetricsService);
+        final var priceCalculator =
+                new ResourcePriceCalculatorImpl(consensusNow, txnInfo, feeManager, readableStoreFactory);
+        final var storeFactory = new StoreFactoryImpl(readableStoreFactory, writableStoreFactory, serviceApiFactory);
+        final var entityNumGenerator = new EntityNumGeneratorImpl(
+                new WritableStoreFactory(stack, EntityIdService.NAME, config, storeMetricsService)
+                        .getStore(WritableEntityIdStore.class));
+        final var throttleAdvisor = new AppThrottleAdviser(networkUtilizationManager, consensusNow);
+        final var baseBuilder = initializeBuilderInfo(
+                stack.getBaseBuilder(StreamBuilder.class), txnInfo, exchangeRateManager.exchangeRates());
+        final var feeAccumulator =
+                new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (FeeStreamBuilder) baseBuilder);
+        final var blockRecordInfo = BlockRecordInfoImpl.from(state);
+        final var dispatchHandleContext = new DispatchHandleContext(
+                consensusNow,
+                creatorInfo,
+                txnInfo,
+                config,
+                authorizer,
+                blockRecordInfo,
+                priceCalculator,
+                feeManager,
+                storeFactory,
+                requireNonNull(txnInfo.payerID()),
+                NO_OP_KEY_VERIFIER,
+                txnInfo.functionality(),
+                preHandleResult.payerKey() == null ? Key.DEFAULT : preHandleResult.payerKey(),
+                exchangeRateManager,
+                stack,
+                entityNumGenerator,
+                transactionDispatcher,
+                networkInfo,
+                childDispatchFactory,
+                dispatchProcessor,
+                throttleAdvisor,
+                feeAccumulator,
+                EMPTY_METADATA);
+        final var fees = transactionDispatcher.dispatchComputeFees(dispatchHandleContext);
+        return new RecordDispatch(
+                baseBuilder,
+                config,
+                fees,
+                txnInfo,
+                requireNonNull(txnInfo.payerID()),
+                readableStoreFactory,
+                feeAccumulator,
+                NO_OP_KEY_VERIFIER,
+                creatorInfo,
+                consensusNow,
+                preHandleResult.getRequiredKeys(),
+                preHandleResult.getHollowAccounts(),
+                dispatchHandleContext,
+                stack,
+                getTxnCategory(preHandleResult),
+                tokenContext,
+                preHandleResult,
+                ConsensusThrottling.OFF);
+    }
+
+    public static HandleContext.TransactionCategory getTxnCategory(final PreHandleResult preHandleResult) {
+        return requireNonNull(preHandleResult.txInfo()).signatureMap().sigPair().isEmpty() ? NODE : USER;
+    }
+
+    private ConsensusTransaction consensusTransactionFor(@NonNull final TransactionBody transactionBody) {
+        final var signedTransaction =
+                new SignedTransaction(TransactionBody.PROTOBUF.toBytes(transactionBody), SignatureMap.DEFAULT);
+        final var transaction = Transaction.newBuilder()
+                .signedTransactionBytes(SignedTransaction.PROTOBUF.toBytes(signedTransaction))
+                .build();
+        final var transactionBytes = Transaction.PROTOBUF.toBytes(transaction);
+        final var consensusTransaction = new TransactionWrapper(transactionBytes);
+        consensusTransaction.setMetadata(temporaryPreHandleResult());
+        return consensusTransaction;
+    }
+
+    private NodeInfo creatorInfoFor(@NonNull final TransactionBody transactionBody) {
+        return new NodeInfoImpl(0, transactionBody.nodeAccountIDOrThrow(), 0, List.of(), Bytes.EMPTY);
+    }
+
+    private PreHandleResult temporaryPreHandleResult() {
+        return new PreHandleResult(null, null, UNKNOWN_FAILURE, OK, null, null, null, null, null, null, -1);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/node/app/spi/workflows/DispatchOptionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/node/app/spi/workflows/DispatchOptionsTest.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.node.app.spi.workflows;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.spi.workflows.DispatchOptions.StakingRewards;
+import com.hedera.node.app.spi.workflows.DispatchOptions.UsePresetTxnId;
+import com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DispatchOptionsTest {
+
+    @Mock
+    private AccountID accountID;
+
+    @Mock
+    private TransactionBody transactionBody;
+
+    @Mock
+    private Predicate<Key> predicate;
+
+    @Mock
+    private Set<Key> authorizingKeys;
+
+    @Mock
+    private StakingRewards stakingRewards;
+
+    @Mock
+    private UsePresetTxnId usePresetTxnId;
+
+    @Mock
+    private StreamBuilder.TransactionCustomizer transactionCustomizer;
+
+    @Mock
+    private HandleContext.DispatchMetadata metadata;
+
+    @Test
+    void testSubDispatchReturnsDisabledConsensusThrottle() {
+        final var dispatchOptions = DispatchOptions.subDispatch(
+                accountID,
+                transactionBody,
+                predicate,
+                authorizingKeys,
+                StreamBuilder.class,
+                stakingRewards,
+                usePresetTxnId);
+        assertThat(dispatchOptions.throttling()).isEqualTo(ConsensusThrottling.OFF);
+    }
+
+    @Test
+    void testStepDispatchWithMetadataReturnsDisabledConsensusThrottle() {
+        final var dispatchOptions = DispatchOptions.stepDispatch(
+                accountID, transactionBody, StreamBuilder.class, transactionCustomizer, metadata);
+        assertThat(dispatchOptions.throttling()).isEqualTo(ConsensusThrottling.OFF);
+    }
+
+    @Test
+    void testStepDispatchReturnsDisabledConsensusThrottle() {
+        final var dispatchOptions =
+                DispatchOptions.stepDispatch(accountID, transactionBody, StreamBuilder.class, transactionCustomizer);
+        assertThat(dispatchOptions.throttling()).isEqualTo(ConsensusThrottling.OFF);
+    }
+
+    @Test
+    void testSetupDispatchReturnsDisabledConsensusThrottle() {
+        final var dispatchOptions = DispatchOptions.setupDispatch(accountID, transactionBody, StreamBuilder.class);
+        assertThat(dispatchOptions.throttling()).isEqualTo(ConsensusThrottling.OFF);
+    }
+
+    @Test
+    void testIndependentDispatchReturnsDisabledConsensusThrottle() {
+        final var dispatchOptions =
+                DispatchOptions.independentDispatch(accountID, transactionBody, StreamBuilder.class);
+        assertThat(dispatchOptions.throttling()).isEqualTo(ConsensusThrottling.OFF);
+    }
+
+    @Test
+    void testEffectiveKeyVerifierWithPreauthorizedKeys() {
+        final var dispatchOptions = DispatchOptions.setupDispatch(accountID, transactionBody, StreamBuilder.class);
+        assertThat(dispatchOptions.effectiveKeyVerifier()).isNull();
+    }
+
+    @Test
+    void testEffectiveKeyVerifierWithCustomKeys() {
+        final var dispatchOptions = DispatchOptions.subDispatch(
+                accountID,
+                transactionBody,
+                predicate,
+                authorizingKeys,
+                StreamBuilder.class,
+                stakingRewards,
+                usePresetTxnId);
+        assertThat(dispatchOptions.effectiveKeyVerifier()).isEqualTo(predicate);
+    }
+
+    @Test
+    void testCommitImmediately() {
+        final var dispatchOptions =
+                DispatchOptions.independentDispatch(accountID, transactionBody, StreamBuilder.class);
+        assertThat(dispatchOptions.commitImmediately()).isTrue();
+    }
+
+    @Test
+    void testCommitImmediatelyWithParent() {
+        final var dispatchOptions = DispatchOptions.setupDispatch(accountID, transactionBody, StreamBuilder.class);
+        assertThat(dispatchOptions.commitImmediately()).isFalse();
+    }
+}


### PR DESCRIPTION
**Description**:
In concurrent requests some race conditions occur and we get the following error log:
`Throttle timeline must advance, but 2025-02-28T13:11:16.913753632Z is not after 2025-02-28T13:11:18.272133175Z`

As a temporary workaround this PR copies some classes from the hedera-app dependency and overrides the throttle mechanism in a way that it is not invoked at all. This way the mirror node will only use its own custom gas limit and rate limit throttle. _The only change is passing `ConsensusThrottling.OFF` in the places where it was `ConsensusThrottling.ON`._

The code coverage is currently not passing but no more tests will be added for now since the official fix is on its way and the changes from this PR will be reverted soon - https://github.com/hiero-ledger/hiero-consensus-node/pull/18263.

**Related issue(s)**: #10378