### PR TITLE
Add missing singletons

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/CongestionLevelStartsSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/CongestionLevelStartsSingleton.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema.CONGESTION_LEVEL_STARTS_STATE_KEY;
+
+import com.hedera.hapi.node.state.congestion.CongestionLevelStarts;
+import jakarta.inject.Named;
+
+@Named
+public class CongestionLevelStartsSingleton implements SingletonState<CongestionLevelStarts> {
+
+    @Override
+    public String getKey() {
+        return CONGESTION_LEVEL_STARTS_STATE_KEY;
+    }
+
+    @Override
+    public CongestionLevelStarts get() {
+        return CongestionLevelStarts.DEFAULT;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.fees.schemas.V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY;
+
+import com.hedera.hapi.node.base.TimestampSeconds;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.node.app.config.BootstrapConfigProviderImpl;
+import com.hedera.node.config.data.BootstrapConfig;
+import jakarta.inject.Named;
+
+@Named
+public class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
+    @Override
+    public String getKey() {
+        return MIDNIGHT_RATES_STATE_KEY;
+    }
+
+    @Override
+    public ExchangeRateSet get() {
+        final var bootstrapConfig =
+                new BootstrapConfigProviderImpl().getConfiguration().getConfigData(BootstrapConfig.class);
+        return com.hedera.hapi.node.transaction.ExchangeRateSet.newBuilder()
+                .currentRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesCurrentCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesCurrentHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesCurrentExpiry()))
+                        .build())
+                .nextRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesNextCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesNextHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesNextExpiry()))
+                        .build())
+                .build();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
@@ -8,16 +8,19 @@ import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import jakarta.inject.Named;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
 @Named
-@RequiredArgsConstructor
 public class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
 
-    private final V0490FileSchema fileSchema = new V0490FileSchema();
+    private final ExchangeRateSet cachedExchangeRateSet;
 
-    private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
+    @SneakyThrows
+    public MidnightRatesSingleton(final MirrorNodeEvmProperties mirrorNodeEvmProperties) {
+        V0490FileSchema fileSchema = new V0490FileSchema();
+        this.cachedExchangeRateSet = ExchangeRateSet.PROTOBUF.parse(
+                fileSchema.genesisExchangeRates(mirrorNodeEvmProperties.getVersionedConfiguration()));
+    }
 
     @Override
     public String getKey() {
@@ -27,7 +30,6 @@ public class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
     @SneakyThrows
     @Override
     public ExchangeRateSet get() {
-        return ExchangeRateSet.PROTOBUF.parse(
-                fileSchema.genesisExchangeRates(mirrorNodeEvmProperties.getVersionedConfiguration()));
+        return cachedExchangeRateSet;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingleton.java
@@ -13,6 +13,7 @@ import jakarta.inject.Named;
 
 @Named
 public class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
+
     @Override
     public String getKey() {
         return MIDNIGHT_RATES_STATE_KEY;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingleton.java
@@ -9,6 +9,7 @@ import jakarta.inject.Named;
 
 @Named
 public class ThrottleUsageSingleton implements SingletonState<ThrottleUsageSnapshots> {
+
     @Override
     public String getKey() {
         return THROTTLE_USAGE_SNAPSHOTS_STATE_KEY;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingleton.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema.THROTTLE_USAGE_SNAPSHOTS_STATE_KEY;
+
+import com.hedera.hapi.node.state.throttles.ThrottleUsageSnapshots;
+import jakarta.inject.Named;
+
+@Named
+public class ThrottleUsageSingleton implements SingletonState<ThrottleUsageSnapshots> {
+    @Override
+    public String getKey() {
+        return THROTTLE_USAGE_SNAPSHOTS_STATE_KEY;
+    }
+
+    @Override
+    public ThrottleUsageSnapshots get() {
+        return ThrottleUsageSnapshots.DEFAULT;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
@@ -15,9 +15,11 @@ import com.hedera.mirror.web3.state.keyvalue.NftReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.TokenReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.TokenRelationshipReadableKVState;
 import com.hedera.mirror.web3.state.singleton.BlockInfoSingleton;
-import com.hedera.mirror.web3.state.singleton.DefaultSingleton;
+import com.hedera.mirror.web3.state.singleton.CongestionLevelStartsSingleton;
 import com.hedera.mirror.web3.state.singleton.EntityIdSingleton;
+import com.hedera.mirror.web3.state.singleton.MidnightRatesSingleton;
 import com.hedera.mirror.web3.state.singleton.RunningHashesSingleton;
+import com.hedera.mirror.web3.state.singleton.ThrottleUsageSingleton;
 import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.records.BlockRecordService;
@@ -96,12 +98,12 @@ public class MirrorNodeStateIntegrationTest extends Web3IntegrationTest {
 
         // CongestionThrottleService
         Map<String, Class<?>> congestionThrottleServiceDataSources = Map.of(
-                "THROTTLE_USAGE_SNAPSHOTS", DefaultSingleton.class,
-                "CONGESTION_LEVEL_STARTS", DefaultSingleton.class);
+                "THROTTLE_USAGE_SNAPSHOTS", ThrottleUsageSingleton.class,
+                "CONGESTION_LEVEL_STARTS", CongestionLevelStartsSingleton.class);
         verifyServiceDataSources(states, CongestionThrottleService.NAME, congestionThrottleServiceDataSources);
 
         // FeeService
-        Map<String, Class<?>> feeServiceDataSources = Map.of("MIDNIGHT_RATES", DefaultSingleton.class);
+        Map<String, Class<?>> feeServiceDataSources = Map.of("MIDNIGHT_RATES", MidnightRatesSingleton.class);
         verifyServiceDataSources(states, FeeService.NAME, feeServiceDataSources);
 
         // ContractService

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/CongestionLevelStartsSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/CongestionLevelStartsSingletonTest.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema.CONGESTION_LEVEL_STARTS_STATE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.state.congestion.CongestionLevelStarts;
+import org.junit.jupiter.api.Test;
+
+class CongestionLevelStartsSingletonTest {
+
+    private final CongestionLevelStartsSingleton congestionLevelStartsSingleton = new CongestionLevelStartsSingleton();
+
+    @Test
+    void get() {
+        assertThat(congestionLevelStartsSingleton.get()).isEqualTo(CongestionLevelStarts.DEFAULT);
+    }
+
+    @Test
+    void key() {
+        assertThat(congestionLevelStartsSingleton.getKey()).isEqualTo(CONGESTION_LEVEL_STARTS_STATE_KEY);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.fees.schemas.V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.TimestampSeconds;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.node.app.config.BootstrapConfigProviderImpl;
+import com.hedera.node.config.data.BootstrapConfig;
+import org.junit.jupiter.api.Test;
+
+class MidnightRatesSingletonTest {
+
+    private final MidnightRatesSingleton midnightRatesSingleton = new MidnightRatesSingleton();
+
+    @Test
+    void get() {
+        final var bootstrapConfig =
+                new BootstrapConfigProviderImpl().getConfiguration().getConfigData(BootstrapConfig.class);
+
+        final var expected = ExchangeRateSet.newBuilder()
+                .currentRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesCurrentCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesCurrentHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesCurrentExpiry()))
+                        .build())
+                .nextRate(ExchangeRate.newBuilder()
+                        .centEquiv(bootstrapConfig.ratesNextCentEquiv())
+                        .hbarEquiv(bootstrapConfig.ratesNextHbarEquiv())
+                        .expirationTime(TimestampSeconds.newBuilder().seconds(bootstrapConfig.ratesNextExpiry()))
+                        .build())
+                .build();
+        assertThat(midnightRatesSingleton.get()).isEqualTo(expected);
+    }
+
+    @Test
+    void key() {
+        assertThat(midnightRatesSingleton.getKey()).isEqualTo(MIDNIGHT_RATES_STATE_KEY);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
@@ -8,18 +8,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.hapi.node.base.TimestampSeconds;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
-import com.hedera.node.app.config.BootstrapConfigProviderImpl;
+import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.node.config.data.BootstrapConfig;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 
-class MidnightRatesSingletonTest {
+@RequiredArgsConstructor
+class MidnightRatesSingletonTest extends Web3IntegrationTest {
 
-    private final MidnightRatesSingleton midnightRatesSingleton = new MidnightRatesSingleton();
+    private final MidnightRatesSingleton midnightRatesSingleton;
+    private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
 
     @Test
     void get() {
         final var bootstrapConfig =
-                new BootstrapConfigProviderImpl().getConfiguration().getConfigData(BootstrapConfig.class);
+                mirrorNodeEvmProperties.getVersionedConfiguration().getConfigData(BootstrapConfig.class);
 
         final var expected = ExchangeRateSet.newBuilder()
                 .currentRate(ExchangeRate.newBuilder()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/ThrottleUsageSingletonTest.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema.THROTTLE_USAGE_SNAPSHOTS_STATE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.state.throttles.ThrottleUsageSnapshots;
+import org.junit.jupiter.api.Test;
+
+class ThrottleUsageSingletonTest {
+
+    private final ThrottleUsageSingleton throttleUsageSingleton = new ThrottleUsageSingleton();
+
+    @Test
+    void get() {
+        assertThat(throttleUsageSingleton.get()).isEqualTo(ThrottleUsageSnapshots.DEFAULT);
+    }
+
+    @Test
+    void key() {
+        assertThat(throttleUsageSingleton.getKey()).isEqualTo(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY);
+    }
+}


### PR DESCRIPTION
**Description**:
To adapt the web3 to be able to start with non genesis state setup we need to add the following singletons 
`MidnightRates`, `CongestionLevelStartsSingleton`, `ThrottleUsage`.

Previously when we were working with genesis setup the following logic was applied during schema migrate:

```
if (ctx.previousVersion() == null) {. // is genesis
            // At genesis we put empty throttle usage snapshots and
            // congestion level starts into their respective singleton
            // states just to ensure they exist
            final var throttleSnapshots = ctx.newStates().getSingleton(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY);
            throttleSnapshots.put(ThrottleUsageSnapshots.DEFAULT);
            final var congestionLevelStarts = ctx.newStates().getSingleton(CONGESTION_LEVEL_STARTS_STATE_KEY);
            congestionLevelStarts.put(CongestionLevelStarts.DEFAULT);
}
```
If we were in genesis then default values were set into default singleton during migrate method.
For non genesis startup this is skipped. (then we get into missing setup and null pointers)
Now that we do not start with genesis we need to implement the singletons and return the default values.

Changes

`ThrottleUsageSingleton` - add singleton implementation and return default value + test
`MidnightRatesSingleton` - add singleton implementation and return default `ExchangeRateSet` value + test
`CongestionLevelStartsSingleton`- add singleton implementation and return default value + test

**Related issue(s)**:

Fixes #10587

**Notes for reviewer**:
After getting this PR in we can proceed with https://github.com/hiero-ledger/hiero-mirror-node/pull/10588

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
