### PR TITLE
Add Receipt ContractId to Ethereum Transformer

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
@@ -40,7 +40,7 @@ final class EthereumTransactionTransformer extends AbstractBlockItemTransformer 
     }
 
     private void setReceipt(ContractFunctionResult result, TransactionReceipt.Builder receiptBuilder) {
-        if(result.getGasUsed() > 0) {
+        if (result.getGasUsed() > 0) {
             receiptBuilder.setContractID(result.getContractID());
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
@@ -4,6 +4,8 @@ package com.hedera.mirror.importer.downloader.block.transformer;
 
 import com.hedera.hapi.block.stream.output.protoc.TransactionOutput.TransactionCase;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
+import com.hederahashgraph.api.proto.java.ContractFunctionResult;
+import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import jakarta.inject.Named;
 
 @Named
@@ -23,14 +25,28 @@ final class EthereumTransactionTransformer extends AbstractBlockItemTransformer 
         recordBuilder.setEthereumHash(ethereumCall.getEthereumHash());
         recordItemBuilder.sidecarRecords(ethereumCall.getSidecarsList());
 
+        var receiptBuilder = recordBuilder.getReceiptBuilder();
         switch (ethereumCall.getEthResultCase()) {
-            case ETHEREUM_CALL_RESULT -> recordBuilder.setContractCallResult(ethereumCall.getEthereumCallResult());
-            case ETHEREUM_CREATE_RESULT -> recordBuilder.setContractCreateResult(
-                    ethereumCall.getEthereumCreateResult());
+            case ETHEREUM_CALL_RESULT -> {
+                var result = ethereumCall.getEthereumCallResult();
+                recordBuilder.setContractCallResult(result);
+                setReceipt(result, receiptBuilder);
+            }
+            case ETHEREUM_CREATE_RESULT -> {
+                var result = ethereumCall.getEthereumCreateResult();
+                recordBuilder.setContractCreateResult(result);
+                setReceipt(result, receiptBuilder);
+            }
             default -> log.warn(
                     "Unhandled eth_result case {} for transaction at {}",
                     ethereumCall.getEthResultCase(),
                     blockItem.getConsensusTimestamp());
+        }
+    }
+
+    private void setReceipt(ContractFunctionResult result, TransactionReceipt.Builder receiptBuilder) {
+        if(result.getGasUsed() > 0) {
+            receiptBuilder.setContractID(result.getContractID());
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
@@ -25,17 +25,12 @@ final class EthereumTransactionTransformer extends AbstractBlockItemTransformer 
         recordBuilder.setEthereumHash(ethereumCall.getEthereumHash());
         recordItemBuilder.sidecarRecords(ethereumCall.getSidecarsList());
 
-        var receiptBuilder = recordBuilder.getReceiptBuilder();
         switch (ethereumCall.getEthResultCase()) {
-            case ETHEREUM_CALL_RESULT -> {
-                var result = ethereumCall.getEthereumCallResult();
-                recordBuilder.setContractCallResult(result);
-                setReceipt(result, receiptBuilder);
-            }
+            case ETHEREUM_CALL_RESULT -> recordBuilder.setContractCallResult(ethereumCall.getEthereumCallResult());
             case ETHEREUM_CREATE_RESULT -> {
                 var result = ethereumCall.getEthereumCreateResult();
                 recordBuilder.setContractCreateResult(result);
-                setReceipt(result, receiptBuilder);
+                setReceipt(result, recordBuilder.getReceiptBuilder());
             }
             default -> log.warn(
                     "Unhandled eth_result case {} for transaction at {}",

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/EthereumTransactionTransformer.java
@@ -25,12 +25,17 @@ final class EthereumTransactionTransformer extends AbstractBlockItemTransformer 
         recordBuilder.setEthereumHash(ethereumCall.getEthereumHash());
         recordItemBuilder.sidecarRecords(ethereumCall.getSidecarsList());
 
+        var receiptBuilder = recordBuilder.getReceiptBuilder();
         switch (ethereumCall.getEthResultCase()) {
-            case ETHEREUM_CALL_RESULT -> recordBuilder.setContractCallResult(ethereumCall.getEthereumCallResult());
+            case ETHEREUM_CALL_RESULT -> {
+                var result = ethereumCall.getEthereumCallResult();
+                recordBuilder.setContractCallResult(result);
+                setReceipt(result, receiptBuilder);
+            }
             case ETHEREUM_CREATE_RESULT -> {
                 var result = ethereumCall.getEthereumCreateResult();
                 recordBuilder.setContractCreateResult(result);
-                setReceipt(result, recordBuilder.getReceiptBuilder());
+                setReceipt(result, receiptBuilder);
             }
             default -> log.warn(
                     "Unhandled eth_result case {} for transaction at {}",

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
@@ -245,7 +245,8 @@ class ContractTransformerTest extends AbstractTransformerTest {
         // given
         var expectedRecordItem = recordItemBuilder
                 .ethereumTransaction(true)
-                .record(r -> r.setContractCreateResult(recordItemBuilder.contractFunctionResult().setGasUsed(0L)))
+                .record(r -> r.setContractCreateResult(
+                        recordItemBuilder.contractFunctionResult().setGasUsed(0L)))
                 .receipt(Builder::clearContractID)
                 .customize(this::finalize)
                 .build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
@@ -241,6 +241,25 @@ class ContractTransformerTest extends AbstractTransformerTest {
     }
 
     @Test
+    void ethereumNoUsedGas() {
+        // given
+        var expectedRecordItem = recordItemBuilder
+                .ethereumTransaction(true)
+                .record(r -> r.setContractCreateResult(recordItemBuilder.contractFunctionResult().setGasUsed(0L)))
+                .receipt(Builder::clearContractID)
+                .customize(this::finalize)
+                .build();
+        var blockItem = blockItemBuilder.ethereum(expectedRecordItem).build();
+        var blockFile = blockFileBuilder.items(List.of(blockItem)).build();
+
+        // when
+        var recordFile = blockFileTransformer.transform(blockFile);
+
+        // then
+        assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expectedRecordItem));
+    }
+
+    @Test
     void ethereumUnsuccessful() {
         // given
         var expectedRecordItem = recordItemBuilder

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
@@ -240,11 +240,12 @@ class ContractTransformerTest extends AbstractTransformerTest {
         assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expectedRecordItem));
     }
 
-    @Test
-    void ethereumNoUsedGas() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void ethereumNoUsedGas(boolean create) {
         // given
         var expectedRecordItem = recordItemBuilder
-                .ethereumTransaction(true)
+                .ethereumTransaction(create)
                 .record(r -> r.setContractCreateResult(
                         recordItemBuilder.contractFunctionResult().setGasUsed(0L)))
                 .receipt(Builder::clearContractID)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
@@ -246,8 +246,15 @@ class ContractTransformerTest extends AbstractTransformerTest {
         // given
         var expectedRecordItem = recordItemBuilder
                 .ethereumTransaction(create)
-                .record(r -> r.setContractCreateResult(
-                        recordItemBuilder.contractFunctionResult().setGasUsed(0L)))
+                .record(r -> {
+                    if (r.hasContractCallResult()) {
+                        r.setContractCallResult(
+                                recordItemBuilder.contractFunctionResult().setGasUsed(0L));
+                    } else {
+                        r.setContractCreateResult(
+                                recordItemBuilder.contractFunctionResult().setGasUsed(0L));
+                    }
+                })
                 .receipt(Builder::clearContractID)
                 .customize(this::finalize)
                 .build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -678,7 +678,9 @@ public class RecordItemBuilder {
         var digestedHash = bytes(32);
         var functionResult = contractFunctionResult(contractId);
         var builder = new Builder<>(TransactionType.ETHEREUMTRANSACTION, transactionBody)
-                .record(r -> r.setContractCallResult(functionResult).setEthereumHash(digestedHash))
+                .record(r -> r.setContractCallResult(functionResult)
+                        .setEthereumHash(digestedHash)
+                        .getReceiptBuilder().setContractID(contractId))
                 .recordItem(r -> r.hapiVersion(new Version(0, 47, 0)))
                 .sidecarRecords(r -> r.add(contractStateChanges(contractId)))
                 .sidecarRecords(r -> r.add(contractActions()));

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -678,8 +678,7 @@ public class RecordItemBuilder {
         var digestedHash = bytes(32);
         var functionResult = contractFunctionResult(contractId);
         var builder = new Builder<>(TransactionType.ETHEREUMTRANSACTION, transactionBody)
-                .record(r -> r.setContractCallResult(functionResult)
-                        .setEthereumHash(digestedHash))
+                .record(r -> r.setContractCallResult(functionResult).setEthereumHash(digestedHash))
                 .recordItem(r -> r.hapiVersion(new Version(0, 47, 0)))
                 .sidecarRecords(r -> r.add(contractStateChanges(contractId)))
                 .sidecarRecords(r -> r.add(contractActions()));
@@ -691,9 +690,9 @@ public class RecordItemBuilder {
                     .getActionsBuilder()
                     .getContractActionsBuilder(0)
                     .setCallType(ContractActionType.CREATE);
-            builder.record(r -> r
-                    .setContractCreateResult(functionResult)
-                    .getReceiptBuilder().setContractID(contractId));
+            builder.record(r -> r.setContractCreateResult(functionResult)
+                    .getReceiptBuilder()
+                    .setContractID(contractId));
         }
 
         return builder;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -678,7 +678,10 @@ public class RecordItemBuilder {
         var digestedHash = bytes(32);
         var functionResult = contractFunctionResult(contractId);
         var builder = new Builder<>(TransactionType.ETHEREUMTRANSACTION, transactionBody)
-                .record(r -> r.setContractCallResult(functionResult).setEthereumHash(digestedHash))
+                .record(r -> r.setContractCallResult(functionResult)
+                        .setEthereumHash(digestedHash)
+                        .getReceiptBuilder()
+                        .setContractID(contractId))
                 .recordItem(r -> r.hapiVersion(new Version(0, 47, 0)))
                 .sidecarRecords(r -> r.add(contractStateChanges(contractId)))
                 .sidecarRecords(r -> r.add(contractActions()));
@@ -690,9 +693,7 @@ public class RecordItemBuilder {
                     .getActionsBuilder()
                     .getContractActionsBuilder(0)
                     .setCallType(ContractActionType.CREATE);
-            builder.record(r -> r.setContractCreateResult(functionResult)
-                    .getReceiptBuilder()
-                    .setContractID(contractId));
+            builder.record(r -> r.setContractCreateResult(functionResult));
         }
 
         return builder;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -679,8 +679,7 @@ public class RecordItemBuilder {
         var functionResult = contractFunctionResult(contractId);
         var builder = new Builder<>(TransactionType.ETHEREUMTRANSACTION, transactionBody)
                 .record(r -> r.setContractCallResult(functionResult)
-                        .setEthereumHash(digestedHash)
-                        .getReceiptBuilder().setContractID(contractId))
+                        .setEthereumHash(digestedHash))
                 .recordItem(r -> r.hapiVersion(new Version(0, 47, 0)))
                 .sidecarRecords(r -> r.add(contractStateChanges(contractId)))
                 .sidecarRecords(r -> r.add(contractActions()));
@@ -692,7 +691,9 @@ public class RecordItemBuilder {
                     .getActionsBuilder()
                     .getContractActionsBuilder(0)
                     .setCallType(ContractActionType.CREATE);
-            builder.record(r -> r.setContractCreateResult(functionResult));
+            builder.record(r -> r
+                    .setContractCreateResult(functionResult)
+                    .getReceiptBuilder().setContractID(contractId));
         }
 
         return builder;


### PR DESCRIPTION
**Description**:
Adds the contract id to the transformed record item for Ethereum Transactions.

**Related issue(s)**:

Fixes #10596 

**Notes for reviewer**:
Tested with acceptance test blocks from testnet.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
