### PR TITLE
Update Contract Create Transformer for failed transaction with result

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/ContractCreateTransformer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/block/transformer/ContractCreateTransformer.java
@@ -26,7 +26,7 @@ final class ContractCreateTransformer extends AbstractBlockItemTransformer {
 
         var recordBuilder = recordItemBuilder.transactionRecordBuilder();
         recordBuilder.setContractCreateResult(contractCreate.getContractCreateResult());
-        if (contractCreate.getContractCreateResult().hasContractID()) {
+        if (contractCreate.getContractCreateResult().hasContractID() && blockItem.isSuccessful()) {
             recordBuilder
                     .getReceiptBuilder()
                     .setContractID(contractCreate.getContractCreateResult().getContractID());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/ContractTransformerTest.java
@@ -140,6 +140,26 @@ class ContractTransformerTest extends AbstractTransformerTest {
         assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expectedRecordItem));
     }
 
+    @Test
+    void contractCreateUnsuccessfulWithContractCreateResult() {
+        // given
+        var expectedRecordItem = recordItemBuilder
+                .contractCreate()
+                .receipt(Builder::clearContractID)
+                .sidecarRecords(List::clear)
+                .status(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
+                .customize(this::finalize)
+                .build();
+        var blockItem = blockItemBuilder.contractCreate(expectedRecordItem).build();
+        var blockFile = blockFileBuilder.items(List.of(blockItem)).build();
+
+        // when
+        var recordFile = blockFileTransformer.transform(blockFile);
+
+        // then
+        assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expectedRecordItem));
+    }
+
     @MethodSource("provideContractIds")
     @ParameterizedTest(name = "delete contract with {0} contract id")
     void contractDelete(String type, ContractID contractIdInBody, ContractID contractIdInReceipt) {


### PR DESCRIPTION
**Description**:
Updates the transformer to not populated the contract id in the receipt if the transaction is unsucessful.

**Related issue(s)**:

Fixes #10590 

**Notes for reviewer**:
Tested with testnet block that exhibited this problem. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
