### PR TITLE
Fix historical.feature failing acceptance tests against modularized EVM

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -142,7 +142,6 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var fungibleToken = tokenClient.getToken(fungibleTokenName);
         networkTransactionResponse = fungibleToken.response();
         verifyMirrorTransactionsResponse(mirrorClient, 200);
-        ExpandedAccountId admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         CustomFixedFee customFixedFee = new CustomFixedFee();
         customFixedFee.setAmount(CUSTOM_FIXED_FEE_AMOUNT);
         customFixedFee.setFeeCollectorAccountId(admin.getAccountId());
@@ -169,7 +168,6 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var fungibleToken = tokenClient.getToken(TokenNameEnum.FUNGIBLEHISTORICAL);
         networkTransactionResponse = fungibleToken.response();
         verifyMirrorTransactionsResponse(mirrorClient, 200);
-        ExpandedAccountId admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         CustomFixedFee customFixedFee = new CustomFixedFee();
         customFixedFee.setAmount(CUSTOM_FIXED_FEE_AMOUNT);
         customFixedFee.setFeeCollectorAccountId(admin.getAccountId());

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -139,6 +139,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         // Create Fungible token to be usedd as a denominating token for custom fees
         var fungibleToken = tokenClient.getToken(fungibleTokenName);
         networkTransactionResponse = fungibleToken.response();
+        verifyMirrorTransactionsResponse(mirrorClient, 200);
         ExpandedAccountId admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         CustomFixedFee customFixedFee = new CustomFixedFee();
         customFixedFee.setAmount(10);
@@ -269,7 +270,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
                 callContract(initialBlock, data, estimateContractSolidityAddress, ADDRESS_BALANCE.getActualGas());
         assertThat(initialResponse).isEqualTo(historicalResponse);
     }
-
+@RetryAsserts
     @Then("I verify that historical data for {token} is returned via getTokenInfo")
     public void getHistoricalDataForTokenSymbol(TokenNameEnum tokenName) {
         var tokenId = tokenClient.getToken(tokenName).tokenId();

--- a/hedera-mirror-test/src/test/resources/features/contract/historical.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/historical.feature
@@ -9,7 +9,7 @@ Feature: Historical Feature
     Given I successfully create estimate precompile contract
     Then the mirror node REST API should return status 200 for the contracts creation
     Then I verify the estimate precompile contract bytecode is deployed
-    Given I create fungible and non-fungible token
+    Given I create "FUNGIBLEHISTORICAL" and "NFTHISTORICAL" token with custom fees
 
     Then I successfully update the contract storage and get the initial value via historical data
     Then I successfully update the balance of an account and get the initial balance via historical data

--- a/hedera-mirror-test/src/test/resources/features/contract/historical.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/historical.feature
@@ -9,7 +9,8 @@ Feature: Historical Feature
     Given I successfully create estimate precompile contract
     Then the mirror node REST API should return status 200 for the contracts creation
     Then I verify the estimate precompile contract bytecode is deployed
-    Given I create "FUNGIBLEHISTORICAL" and "NFTHISTORICAL" token with custom fees
+    Given I create Fungible "FUNGIBLEHISTORICAL" token with custom fees
+    Given I create NFT "NFTHISTORICAL" token with custom fees
 
     Then I successfully update the contract storage and get the initial value via historical data
     Then I successfully update the balance of an account and get the initial balance via historical data

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVState.java
@@ -36,7 +36,8 @@ public class ContractStorageReadableKVState extends AbstractReadableKVState<Slot
         final var entityId = EntityIdUtils.entityIdFromContractId(contractID).getId();
         final var keyBytes = slotKey.key().toByteArray();
         return timestamp
-                .map(t -> contractStateRepository.findStorageByBlockTimestamp(entityId, keyBytes, t))
+                .map(t -> contractStateRepository.findStorageByBlockTimestamp(
+                        entityId, Bytes32.wrap(keyBytes).trimLeadingZeros().toArrayUnsafe(), t))
                 .orElse(contractStateRepository.findStorage(entityId, keyBytes))
                 .map(byteArr ->
                         new SlotValue(Bytes.wrap(leftPadBytes(byteArr, Bytes32.SIZE)), Bytes.EMPTY, Bytes.EMPTY))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractStorageReadableKVStateTest.java
@@ -81,7 +81,9 @@ class ContractStorageReadableKVStateTest {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
         when(contractStateRepository.findStorageByBlockTimestamp(
-                        ENTITY_ID.getId(), BYTES.toByteArray(), blockTimestamp))
+                        ENTITY_ID.getId(),
+                        Bytes32.wrap(BYTES.toByteArray()).trimLeadingZeros().toArrayUnsafe(),
+                        blockTimestamp))
                 .thenReturn(Optional.of(BYTES.toByteArray()));
         assertThat(contractStorageReadableKVState.get(SLOT_KEY))
                 .satisfies(slotValue -> assertThat(slotValue).returns(BYTES, SlotValue::value));


### PR DESCRIPTION
This PR fixes the failing acceptance tests from historical.feature branch
- Two of the tests were failing because of the missing fees upon token creation
-  `Then I successfully update the contract storage and get the initial value via historical data` was failing because of wrong input for slotKey in `ContractStorageReadableKVState` -> `findStorageByBlockTimestamp()`. In order to execute the query correctly the slotKey bytes have to be without leading zeros

**Related issue(s)**:

Fixes #10497 

Note: There are few flaky tests in that suite e.g. `Then I verify that historical data for "FUNGIBLEHISTORICAL" is returned via getTokenInfo`  - The flakiness is not caused by this PR it also occurs in the not modularized EVM flow. Will be fixed in future

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
