### PR TITLE
Fix token null metadata issue

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -107,7 +107,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
                 .kycKey(Utils.parseKey(token.getKycKey()))
                 .maxSupply(token.getMaxSupply())
                 .memo(entity.getMemo())
-                .metadata(Bytes.wrap(token.getMetadata()))
+                .metadata(token.getMetadata() == null ? Bytes.EMPTY : Bytes.wrap(token.getMetadata()))
                 .metadataKey(Utils.parseKey(token.getMetadataKey()))
                 .name(token.getName())
                 .paused(token.getPauseStatus().equals(TokenPauseStatusEnum.PAUSED))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
@@ -388,8 +388,30 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     }
 
     @Test
+    void ethCallNameStaticNullMetadata() throws Exception {
+        final var token = fungibleTokenCustomizable(e -> e.metadata(null));
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var result = contract.call_name(tokenAddress).send();
+        final var functionCall = contract.send_name(tokenAddress);
+        assertThat(result).isEqualTo(token.getName());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
     void ethCallNameNonStatic() throws Exception {
         final var token = fungibleTokenPersist();
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var result = contract.call_nameNonStatic(tokenAddress).send();
+        final var functionCall = contract.send_nameNonStatic(tokenAddress);
+        assertThat(result).isEqualTo(token.getName());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallNameNonStaticNullMetadata() throws Exception {
+        final var token = fungibleTokenCustomizable(e -> e.metadata(null));
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
         final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
         final var result = contract.call_nameNonStatic(tokenAddress).send();


### PR DESCRIPTION
**Description**:
Fix null token metadata error in TokenReadableKVState
Add check if metadata is null set Bytes.Empty

**Related issue(s)**:

Fixes #10607 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
