### PR TITLE
Use configured shard and realm in balance snapshot generation and querying

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -29,6 +29,7 @@ import lombok.Value;
 public final class EntityId implements Serializable, Comparable<EntityId> {
 
     public static final EntityId EMPTY = new EntityId(0L);
+    public static final long TREASURY_NUM = 2;
 
     /*
      * Indicates a domain entity ID is not being set (to null or non-null) in the current operation and that

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -29,7 +29,6 @@ import lombok.Value;
 public final class EntityId implements Serializable, Comparable<EntityId> {
 
     public static final EntityId EMPTY = new EntityId(0L);
-    public static final long TREASURY_NUM = 2;
 
     /*
      * Indicates a domain entity ID is not being set (to null or non-null) in the current operation and that

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/SystemEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/SystemEntity.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.common.domain.entity;
+
+import com.hedera.mirror.common.CommonProperties;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SystemEntity {
+    FEE_COLLECTOR(98),
+    NODE_REWARD_ACCOUNT(801),
+    STAKING_REWARD_ACCOUNT(800),
+    TREASURY_ACCOUNT(2);
+
+    private final long num;
+
+    public EntityId getScopedEntityId(CommonProperties commonProperties) {
+        return EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), num);
+    }
+}

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -411,8 +411,7 @@ public class DomainBuilder {
         return new DomainWrapperImpl<>(builder, builder::build);
     }
 
-    public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> entity(long id, long createdTimestamp) {
-        var entityId = EntityId.of(id);
+    public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> entity(EntityId entityId, long createdTimestamp) {
         var builder = Entity.builder()
                 .alias(key())
                 .autoRenewAccountId(id())
@@ -425,7 +424,7 @@ public class DomainBuilder {
                 .ethereumNonce(1L)
                 .evmAddress(evmAddress())
                 .expirationTimestamp(createdTimestamp + 30_000_000L)
-                .id(id)
+                .id(entityId.getId())
                 .key(key())
                 .maxAutomaticTokenAssociations(1)
                 .memo(text(16))
@@ -442,6 +441,14 @@ public class DomainBuilder {
                 .type(ACCOUNT);
 
         return new DomainWrapperImpl<>(builder, builder::build);
+    }
+
+    public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> entity(long id, long createdTimestamp) {
+        return entity(EntityId.of(id), createdTimestamp);
+    }
+
+    public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> entity(EntityId entityId) {
+        return entity(entityId, timestamp());
     }
 
     public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> entity() {
@@ -856,10 +863,10 @@ public class DomainBuilder {
         return new DomainWrapperImpl<>(builder, builder::build);
     }
 
-    public DomainWrapper<TokenAccount, TokenAccount.TokenAccountBuilder<?, ?>> tokenAccount() {
+    public DomainWrapper<TokenAccount, TokenAccount.TokenAccountBuilder<?, ?>> tokenAccount(long shard, long realm) {
         long timestamp = timestamp();
         var builder = TokenAccount.builder()
-                .accountId(id())
+                .accountId(EntityId.of(shard, realm, id()).getId())
                 .automaticAssociation(false)
                 .associated(true)
                 .balance(number())
@@ -868,8 +875,12 @@ public class DomainBuilder {
                 .freezeStatus(null)
                 .kycStatus(null)
                 .timestampRange(Range.atLeast(timestamp))
-                .tokenId(id());
+                .tokenId(EntityId.of(shard, realm, id()).getId());
         return new DomainWrapperImpl<>(builder, builder::build);
+    }
+
+    public DomainWrapper<TokenAccount, TokenAccount.TokenAccountBuilder<?, ?>> tokenAccount() {
+        return tokenAccount(0, 0);
     }
 
     public DomainWrapper<TokenAccountHistory, TokenAccountHistory.TokenAccountHistoryBuilder<?, ?>>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceService.java
@@ -3,14 +3,13 @@
 package com.hedera.mirror.importer.parser.record.historicalbalance;
 
 import static com.hedera.mirror.common.domain.balance.AccountBalanceFile.INVALID_NODE_ID;
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.importer.parser.AbstractStreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
-import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.db.TimePartitionService;
 import com.hedera.mirror.importer.domain.StreamFilename;
@@ -78,7 +77,8 @@ public class HistoricalBalanceService {
         this.recordFileRepository = recordFileRepository;
         this.timePartitionService = timePartitionService;
         this.tokenBalanceRepository = tokenBalanceRepository;
-        this.treasuryAccountId = EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+        this.treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                .getScopedEntityId(commonProperties)
                 .getId();
 
         // Set repeatable read isolation level and transaction timeout

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/BalanceSnapshotRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/BalanceSnapshotRepository.java
@@ -8,19 +8,21 @@ interface BalanceSnapshotRepository {
      * Generates a balance snapshot from state in database.
      *
      * @param consensusTimestamp The consensus timestamp of the balance snapshot.
+     * @param treasuryAccountId The treasury account id
      * @return The number of balance rows inserted
      */
-    int balanceSnapshot(long consensusTimestamp);
+    int balanceSnapshot(long consensusTimestamp, long treasuryAccountId);
 
     /**
      * Generates a balance snapshot from state in database.
-     * Only adds entries for items with a balance_timestamp that is greater or equal to the maxConsensusTimestamp.
-     *
+     * Only adds entries for items with a balance_timestamp that is greater than the minConsensusTimestamp.
      * For performant results the caller should guarantee that the table state is at the time of consensusTimestamp.
      *
-     * @param maxConsensusTimestamp
-     * @param consensusTimestamp  The consensus timestamp of the balance snapshot.
+     * @param minConsensusTimestamp The exclusive floor balance timestamp for a token balance to be included in the
+     *                              snapshot
+     * @param consensusTimestamp  The consensus timestamp of the balance snapshot
+     * @param treasuryAccountId The treasury account id
      * @return The number of balance rows inserted
      */
-    int balanceSnapshotDeduplicate(long maxConsensusTimestamp, long consensusTimestamp);
+    int balanceSnapshotDeduplicate(long minConsensusTimestamp, long consensusTimestamp, long treasuryAccountId);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
@@ -127,7 +127,7 @@ class EntityStakeRepositoryCustomImpl implements EntityStakeRepositoryCustom {
         long upperTimestamp = endPeriodTimestamp.get() + 1;
         long lowerTimestamp = upperTimestamp - ONE_MONTH_IN_NS;
         var balanceSnapshotTimestamp =
-                accountBalanceRepository.getMaxConsensusTimestampInRange(lowerTimestamp, upperTimestamp);
+                accountBalanceRepository.getMaxConsensusTimestampInRange(lowerTimestamp, upperTimestamp, 2L);
         if (balanceSnapshotTimestamp.isEmpty()) {
             return;
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
@@ -23,14 +23,14 @@ public interface TokenBalanceRepository
         where associated is true or balance_timestamp > (
             select coalesce(max(consensus_timestamp), 0)
             from account_balance
-            where account_id = 2 and
+            where account_id = :treasuryAccountId and
               consensus_timestamp > :consensusTimestamp - 2592000000000000 and
               consensus_timestamp < :consensusTimestamp
         )
         order by account_id, token_id
         """)
     @Transactional
-    int balanceSnapshot(long consensusTimestamp);
+    int balanceSnapshot(long consensusTimestamp, long treasuryAccountId);
 
     @Override
     @Modifying
@@ -41,9 +41,9 @@ public interface TokenBalanceRepository
         insert into token_balance (account_id, balance, consensus_timestamp, token_id)
         select account_id, balance, :consensusTimestamp, token_id
         from token_account
-        where balance_timestamp > :maxConsensusTimestamp
+        where balance_timestamp > :minConsensusTimestamp
         order by account_id, token_id
         """)
     @Transactional
-    int balanceSnapshotDeduplicate(long maxConsensusTimestamp, long consensusTimestamp);
+    int balanceSnapshotDeduplicate(long minConsensusTimestamp, long consensusTimestamp, long treasuryAccountId);
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
@@ -10,6 +10,7 @@ import com.hedera.mirror.common.config.CommonIntegrationTest;
 import com.hedera.mirror.common.config.RedisTestConfiguration;
 import com.hedera.mirror.common.converter.EntityIdConverter;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.importer.config.DateRangeCalculator;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.converter.JsonbToListConverter;
@@ -60,6 +61,8 @@ import org.springframework.jdbc.core.RowMapper;
 public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
 
     private static final Map<Class<?>, String> DEFAULT_DOMAIN_CLASS_IDS = new ConcurrentHashMap<>();
+
+    protected static final long TREASURY_NUM = SystemEntity.TREASURY_ACCOUNT.getNum();
 
     @Resource
     protected Flyway flyway;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
@@ -2,7 +2,7 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,11 +94,11 @@ class BackfillAndDeduplicateBalanceMigrationTest
     void migrate() {
         // given
         // based on partitionTimeInterval of '10 years' in test application config
-        var treasury = EntityId.of(TREASURY);
-        var account2 = EntityId.of(domainBuilder.id() + TREASURY);
-        var account3 = EntityId.of(domainBuilder.id() + TREASURY);
-        var account4 = EntityId.of(domainBuilder.id() + TREASURY);
-        var token = EntityId.of(domainBuilder.id() + TREASURY);
+        var treasury = EntityId.of(TREASURY_NUM);
+        var account2 = EntityId.of(domainBuilder.id() + TREASURY_NUM);
+        var account3 = EntityId.of(domainBuilder.id() + TREASURY_NUM);
+        var account4 = EntityId.of(domainBuilder.id() + TREASURY_NUM);
+        var token = EntityId.of(domainBuilder.id() + TREASURY_NUM);
 
         // The balance snapshot already in db, processed by V1.89.2
         long sentinelTimestamp = LocalDate.now(UTC).toEpochSecond(LocalTime.of(22, 0), UTC) * 1_000_000_000L;
@@ -408,9 +408,9 @@ class BackfillAndDeduplicateBalanceMigrationTest
         // given
         // there is no balance info before the portion already handled by V1.89.2, for simplicity, no data is populated
         // for account_balance_old and token_balance_old
-        var treasury = EntityId.of(TREASURY);
-        var account = EntityId.of(domainBuilder.id() + TREASURY);
-        var token = EntityId.of(domainBuilder.id() + TREASURY);
+        var treasury = EntityId.of(TREASURY_NUM);
+        var account = EntityId.of(domainBuilder.id() + TREASURY_NUM);
+        var token = EntityId.of(domainBuilder.id() + TREASURY_NUM);
         long timestamp = domainBuilder.timestamp();
         setSentinelTimestamp(timestamp);
         domainBuilder
@@ -446,9 +446,9 @@ class BackfillAndDeduplicateBalanceMigrationTest
         // given min frequency is set to 6 minutes
         migration.migrationProperties.getParams().put("minFrequency", "6m");
 
-        var treasury = EntityId.of(TREASURY);
-        var account = EntityId.of(domainBuilder.id() + TREASURY);
-        var token = EntityId.of(domainBuilder.id() + TREASURY);
+        var treasury = EntityId.of(TREASURY_NUM);
+        var account = EntityId.of(domainBuilder.id() + TREASURY_NUM);
+        var token = EntityId.of(domainBuilder.id() + TREASURY_NUM);
         long sentinelTimestamp = domainBuilder.timestamp();
         setSentinelTimestamp(sentinelTimestamp);
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
@@ -2,7 +2,7 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
@@ -103,7 +103,7 @@ class TimePartitionBalanceTablesMigrationTest extends ImporterIntegrationTest {
     @Test
     void migrate() {
         // given
-        var treasury = EntityId.of(TREASURY);
+        var treasury = EntityId.of(TREASURY_NUM);
         var account2 = domainBuilder.entityId();
         var account3 = domainBuilder.entityId();
         var account4 = domainBuilder.entityId();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -166,6 +166,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.Value;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -185,7 +186,6 @@ public class RecordItemBuilder {
     public static final byte[] LONDON_RAW_TX = Hex.decode(
             "02f87082012a022f2f83018000947e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181880de0b6b3a764000083123456c001a0df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479a01aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66");
     public static final long STAKING_REWARD_ACCOUNT = 800L;
-    public static final long TREASURY = 2L;
 
     private static final AccountID FEE_COLLECTOR =
             AccountID.newBuilder().setAccountNum(98).build();
@@ -207,6 +207,7 @@ public class RecordItemBuilder {
     @Getter
     private final PersistProperties persistProperties = new PersistProperties();
 
+    @Setter
     private Instant now = Instant.now();
 
     {
@@ -818,10 +819,6 @@ public class RecordItemBuilder {
         id.set(0L);
         now = Instant.now();
         state.clear();
-    }
-
-    public void setNow(Instant now) {
-        this.now = now;
     }
 
     public Builder<ScheduleCreateTransactionBody.Builder> scheduleCreate() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.importer.parser.record.entity.staking;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.util.DomainUtils.TINYBARS_IN_ONE_HBAR;
 import static com.hedera.mirror.importer.domain.StreamFilename.FileType.DATA;
 import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.STAKING_REWARD_ACCOUNT;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
@@ -2,10 +2,10 @@
 
 package com.hedera.mirror.importer.parser.record.entity.staking;
 
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.util.DomainUtils.TINYBARS_IN_ONE_HBAR;
 import static com.hedera.mirror.importer.domain.StreamFilename.FileType.DATA;
 import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.STAKING_REWARD_ACCOUNT;
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -82,7 +82,8 @@ class EntityStakeCalculatorIntegrationTest extends ImporterIntegrationTest {
                         .stakeTotalStart(0L)
                         .timestampRange(Range.atLeast(entityStakeLowerTimestamp)))
                 .persist();
-        var treasury = domainBuilder.entity(TREASURY, domainBuilder.timestamp()).persist();
+        var treasury =
+                domainBuilder.entity(TREASURY_NUM, domainBuilder.timestamp()).persist();
 
         // account1 was created two staking periods ago, there should be a row in entity_stake
         var account1 = domainBuilder
@@ -294,24 +295,24 @@ class EntityStakeCalculatorIntegrationTest extends ImporterIntegrationTest {
         var treasury = domainBuilder
                 .entity()
                 .customize(e -> e.createdTimestamp(balanceTimestamp - 6000)
-                        .id(TREASURY)
+                        .id(TREASURY_NUM)
                         .stakedNodeId(1L)
                         .timestampRange(Range.atLeast(secondLastNodeStakeTimestamp)))
                 .persist();
         var entityStakeTreasury = domainBuilder
                 .entityStake()
                 .customize(e -> e.endStakePeriod(epochDay - 2)
-                        .id(TREASURY)
+                        .id(TREASURY_NUM)
                         .timestampRange(Range.atLeast(secondLastNodeStakeTimestamp)))
                 .persist();
         // account balance
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new Id(balanceTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new Id(balanceTimestamp, EntityId.of(TREASURY_NUM))))
                 .persist();
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new Id(previousBalanceTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new Id(previousBalanceTimestamp, EntityId.of(TREASURY_NUM))))
                 .persist();
         domainBuilder
                 .accountBalance()

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.importer.db.TimePartitionService;
 import com.hedera.mirror.importer.downloader.balance.BalanceDownloaderProperties;
@@ -31,70 +32,72 @@ class HistoricalBalanceServiceTest {
 
     @Test
     void concurrentOnRecordFileParsed() {
-        // given
-        var accountBalanceFileRepository = mock(AccountBalanceFileRepository.class);
-        var accountBalanceRepository = mock(AccountBalanceRepository.class);
-        var balanceDownloaderProperties = mock(BalanceDownloaderProperties.class);
-        var platformTransactionManager = mock(PlatformTransactionManager.class);
-        var recordFileRepository = mock(RecordFileRepository.class);
-        var timePartitionService = mock(TimePartitionService.class);
-        var tokenBalanceRepository = mock(TokenBalanceRepository.class);
-        var pool = Executors.newFixedThreadPool(2);
+        try (var pool = Executors.newFixedThreadPool(2)) {
+            // given
+            var accountBalanceFileRepository = mock(AccountBalanceFileRepository.class);
+            var accountBalanceRepository = mock(AccountBalanceRepository.class);
+            var balanceDownloaderProperties = mock(BalanceDownloaderProperties.class);
+            var platformTransactionManager = mock(PlatformTransactionManager.class);
+            var recordFileRepository = mock(RecordFileRepository.class);
+            var timePartitionService = mock(TimePartitionService.class);
+            var tokenBalanceRepository = mock(TokenBalanceRepository.class);
 
-        long lastBalanceTimestamp = 100;
-        when(accountBalanceFileRepository.findLatest())
-                .thenReturn(Optional.of(AccountBalanceFile.builder()
-                        .consensusTimestamp(lastBalanceTimestamp)
-                        .build()));
-        var semaphore = new Semaphore(0);
-        when(recordFileRepository.findLatest()).thenAnswer(invocation -> {
-            semaphore.acquire();
-            return Optional.empty();
-        });
-        var historicalBalanceProperties = new HistoricalBalanceProperties(balanceDownloaderProperties);
-        var service = new HistoricalBalanceService(
-                accountBalanceFileRepository,
-                accountBalanceRepository,
-                new SimpleMeterRegistry(),
-                platformTransactionManager,
-                historicalBalanceProperties,
-                recordFileRepository,
-                timePartitionService,
-                tokenBalanceRepository);
+            long lastBalanceTimestamp = 100;
+            when(accountBalanceFileRepository.findLatest())
+                    .thenReturn(Optional.of(AccountBalanceFile.builder()
+                            .consensusTimestamp(lastBalanceTimestamp)
+                            .build()));
+            var semaphore = new Semaphore(0);
+            when(recordFileRepository.findLatest()).thenAnswer(invocation -> {
+                semaphore.acquire();
+                return Optional.empty();
+            });
+            var historicalBalanceProperties = new HistoricalBalanceProperties(balanceDownloaderProperties);
+            var service = new HistoricalBalanceService(
+                    accountBalanceFileRepository,
+                    accountBalanceRepository,
+                    new CommonProperties(),
+                    new SimpleMeterRegistry(),
+                    platformTransactionManager,
+                    historicalBalanceProperties,
+                    recordFileRepository,
+                    timePartitionService,
+                    tokenBalanceRepository);
 
-        // when
-        var event = new RecordFileParsedEvent(
-                this,
-                lastBalanceTimestamp
-                        + historicalBalanceProperties.getMinFrequency().toNanos());
-        Runnable runnable = () -> service.onRecordFileParsed(event);
-        var task1 = pool.submit(runnable);
-        var task2 = pool.submit(runnable);
+            // when
+            var event = new RecordFileParsedEvent(
+                    this,
+                    lastBalanceTimestamp
+                            + historicalBalanceProperties.getMinFrequency().toNanos());
+            Runnable runnable = () -> service.onRecordFileParsed(event);
+            var task1 = pool.submit(runnable);
+            var task2 = pool.submit(runnable);
 
-        // then
-        // verify that only one task is done
-        await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-                .atMost(Durations.TWO_SECONDS)
-                .until(() -> task1.isDone() ^ task2.isDone());
-        // unblock the remaining task
-        semaphore.release();
+            // then
+            // verify that only one task is done
+            await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+                    .atMost(Durations.TWO_SECONDS)
+                    .until(() -> task1.isDone() ^ task2.isDone());
+            // unblock the remaining task
+            semaphore.release();
 
-        // then
-        await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-                .atMost(Durations.TWO_SECONDS)
-                .until(() -> task1.isDone() && task2.isDone());
-        // only one findLatest call
-        verify(recordFileRepository).findLatest();
+            // then
+            await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+                    .atMost(Durations.TWO_SECONDS)
+                    .until(() -> task1.isDone() && task2.isDone());
+            // only one findLatest call
+            verify(recordFileRepository).findLatest();
 
-        // when
-        // run it again
-        var task3 = pool.submit(runnable);
-        semaphore.release();
+            // when
+            // run it again
+            var task3 = pool.submit(runnable);
+            semaphore.release();
 
-        // then
-        await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
-                .atMost(Durations.TWO_SECONDS)
-                .until(task3::isDone);
-        verify(recordFileRepository, times(2)).findLatest();
+            // then
+            await().pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+                    .atMost(Durations.TWO_SECONDS)
+                    .until(task3::isDone);
+            verify(recordFileRepository, times(2)).findLatest();
+        }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -2,7 +2,7 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @RequiredArgsConstructor
 class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
@@ -28,7 +30,8 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
     @Test
     void balanceSnapshot() {
         long timestamp = 100;
-        assertThat(accountBalanceRepository.balanceSnapshot(timestamp)).isZero();
+        assertThat(accountBalanceRepository.balanceSnapshot(timestamp, TREASURY_NUM))
+                .isZero();
         assertThat(accountBalanceRepository.findAll()).isEmpty();
 
         var account = domainBuilder.entity().persist();
@@ -58,27 +61,35 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
                         .id(new AccountBalance.Id(timestamp, e.toEntityId()))
                         .build())
                 .toList();
-        assertThat(accountBalanceRepository.balanceSnapshot(timestamp)).isEqualTo(expected.size());
+        assertThat(accountBalanceRepository.balanceSnapshot(timestamp, TREASURY_NUM))
+                .isEqualTo(expected.size());
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @Test
-    void balanceSnapshotWithDeletedAccounts() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1023, 100
+            """)
+    void balanceSnapshotWithDeletedAccounts(long shard, long realm) {
         // given
         long lastSnapshotTimestamp = domainBuilder.timestamp();
+        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
         var treasuryAccountBalance = domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(lastSnapshotTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new AccountBalance.Id(lastSnapshotTimestamp, treasury)))
                 .persist();
         // deleted before last snapshot, will not appear in full snapshot
         domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balance(0L)
                         .balanceTimestamp(lastSnapshotTimestamp - 1)
                         .deleted(true)
                         .timestampRange(Range.atLeast(lastSnapshotTimestamp - 1)))
                 .persist();
-        var account = domainBuilder.entity().persist();
+        var account = domainBuilder
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
+                .persist();
         var deletedAccount = domainBuilder
                 .entity()
                 .customize(e -> e.balance(0L).deleted(true))
@@ -90,45 +101,53 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
                 buildAccountBalance(deletedAccount, newSnapshotTimestamp));
 
         // when
-        accountBalanceRepository.balanceSnapshot(newSnapshotTimestamp);
+        accountBalanceRepository.balanceSnapshot(newSnapshotTimestamp, treasury.getId());
 
         // then
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @Test
-    void balanceSnapshotDeduplicate() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1023, 100
+            """)
+    void balanceSnapshotDeduplicate(long shard, long realm) {
         long lowerRangeTimestamp = 0L;
         long timestamp = 100;
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp))
+        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(
+                        lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isZero();
         assertThat(accountBalanceRepository.findAll()).isEmpty();
 
         // 0.0.2 is always included in the balance snapshot regardless of balance timestamp
         var treasuryAccount = domainBuilder
-                .entity()
-                .customize(e -> e.id(2L).num(2L).balanceTimestamp(1L))
+                .entity(treasury)
+                .customize(e -> e.balanceTimestamp(1L))
                 .persist();
-        var account =
-                domainBuilder.entity().customize(e -> e.balanceTimestamp(1L)).persist();
+        var account = domainBuilder
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
+                .customize(e -> e.balanceTimestamp(1L))
+                .persist();
         var contract = domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balanceTimestamp(1L).deleted(null).type(EntityType.CONTRACT))
                 .persist();
         domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balance(null).balanceTimestamp(null))
                 .persist();
         var fileWithBalance = domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balanceTimestamp(1L).type(EntityType.FILE))
                 .persist();
         var unknownWithBalance = domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balanceTimestamp(1L).type(EntityType.UNKNOWN))
                 .persist();
         domainBuilder
-                .entity()
+                .entity(EntityId.of(shard, realm, domainBuilder.id()))
                 .customize(e -> e.balance(null).balanceTimestamp(null).type(EntityType.TOPIC))
                 .persist();
 
@@ -137,13 +156,14 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
                 .collect(Collectors.toList());
 
         // Update Balance Snapshot includes all balances
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp))
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(
+                        lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isEqualTo(expected.size());
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
         expected.add(buildAccountBalance(treasuryAccount, timestamp + 1));
         // Update will always insert an entry for the treasuryAccount
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp + 1))
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp + 1, treasury.getId()))
                 .isOne();
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -155,7 +175,7 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
         expected.add(buildAccountBalance(treasuryAccount, timestamp2));
 
         // Insert the new entry for account and also insert an entry for the treasuryAccount
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp2))
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp2, treasury.getId()))
                 .isEqualTo(2);
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -170,7 +190,7 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
         entityRepository.save(treasuryAccount);
         expected.add(buildAccountBalance(treasuryAccount, timestamp3));
         // Updates only account2 and treasuryAccount
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp2, timestamp3))
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp2, timestamp3, treasury.getId()))
                 .isEqualTo(2);
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -180,50 +200,51 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
         entityRepository.save(account);
         expected.add(buildAccountBalance(treasuryAccount, timestamp4));
         // Update with timestamp equal to the max consensus timestamp, only the treasury account will be updated
-        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp4, timestamp4))
+        assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(timestamp4, timestamp4, treasury.getId()))
                 .isOne();
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @Test
-    void getMaxConsensusTimestampInRange() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1023, 100
+            """)
+    void getMaxConsensusTimestampInRange(long shard, long realm) {
         // With no account balances present the max consensus timestamp is 0
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L))
+        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L, treasury.getId()))
                 .isEmpty();
 
         domainBuilder
                 .accountBalance()
-                .customize(a -> a.id(new AccountBalance.Id(5L, EntityId.of(1))))
+                .customize(a -> a.id(new AccountBalance.Id(5L, EntityId.of(shard, realm, 1))))
                 .persist();
         // With no treasury account present the max consensus timestamp is empty
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L))
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L, treasury.getId()))
                 .isEmpty();
 
-        var treasuryId = EntityId.of(2);
         domainBuilder
                 .accountBalance()
-                .customize(a -> a.id(new AccountBalance.Id(3L, treasuryId)))
+                .customize(a -> a.id(new AccountBalance.Id(3L, treasury)))
                 .persist();
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L))
-                .get()
-                .isEqualTo(3L);
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L, treasury.getId()))
+                .contains(3L);
 
         // Only the max timestamp is returned
         domainBuilder
                 .accountBalance()
-                .customize(a -> a.id(new AccountBalance.Id(5L, treasuryId)))
+                .customize(a -> a.id(new AccountBalance.Id(5L, treasury)))
                 .persist();
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L))
-                .get()
-                .isEqualTo(5L);
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L, treasury.getId()))
+                .contains(5L);
 
         // Only the timestamp within the range is returned, also verifies lower is inclusive and upper is exclusive
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(3L, 5L))
-                .get()
-                .isEqualTo(3L);
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(3L, 5L, treasury.getId()))
+                .contains(3L);
 
         // Outside the lower range
-        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(10L, 20L))
+        assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(10L, 20L, treasury.getId()))
                 .isEmpty();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -2,15 +2,16 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
 import java.util.ArrayList;
 import java.util.List;
@@ -73,8 +74,11 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
             """)
     void balanceSnapshotWithDeletedAccounts(long shard, long realm) {
         // given
+        var commonProperties = new CommonProperties();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
         long lastSnapshotTimestamp = domainBuilder.timestamp();
-        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         var treasuryAccountBalance = domainBuilder
                 .accountBalance()
                 .customize(ab -> ab.id(new AccountBalance.Id(lastSnapshotTimestamp, treasury)))
@@ -113,9 +117,12 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
             1023, 100
             """)
     void balanceSnapshotDeduplicate(long shard, long realm) {
+        var commonProperties = new CommonProperties();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
         long lowerRangeTimestamp = 0L;
         long timestamp = 100;
-        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         assertThat(accountBalanceRepository.balanceSnapshotDeduplicate(
                         lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isZero();
@@ -212,7 +219,10 @@ class AccountBalanceRepositoryTest extends ImporterIntegrationTest {
             """)
     void getMaxConsensusTimestampInRange(long shard, long realm) {
         // With no account balances present the max consensus timestamp is 0
-        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var commonProperties = new CommonProperties();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
+        var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         assertThat(accountBalanceRepository.getMaxConsensusTimestampInRange(0L, 10L, treasury.getId()))
                 .isEmpty();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -2,12 +2,12 @@
 
 package com.hedera.mirror.importer.repository;
 
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOPIC;
 import static com.hedera.mirror.common.util.DomainUtils.TINYBARS_IN_ONE_HBAR;
 import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.STAKING_REWARD_ACCOUNT;
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -70,7 +70,8 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
         var stakingRewardAccount = domainBuilder
                 .entity(STAKING_REWARD_ACCOUNT, nodeStakeTimestamp - 10)
                 .persist();
-        var treasury = domainBuilder.entity(TREASURY, nodeStakeTimestamp - 20).persist();
+        var treasury =
+                domainBuilder.entity(TREASURY_NUM, nodeStakeTimestamp - 20).persist();
         var account1 = domainBuilder
                 .entity()
                 .customize(e -> e.stakedNodeId(1L).timestampRange(Range.atLeast(nodeStakeTimestamp - 1)))
@@ -237,7 +238,7 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
         long balanceTimestamp = timestamp - 1000L;
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(balanceTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new AccountBalance.Id(balanceTimestamp, EntityId.of(TREASURY_NUM))))
                 .persist();
         domainBuilder
                 .accountBalance()
@@ -281,7 +282,8 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
                 .entity()
                 .customize(e -> e.timestampRange(Range.atLeast(balanceTimestamp - 1000L)))
                 .persist();
-        var treasury = domainBuilder.entity(TREASURY, balanceTimestamp - 9000).persist();
+        var treasury =
+                domainBuilder.entity(TREASURY_NUM, balanceTimestamp - 9000).persist();
         domainBuilder
                 .accountBalance()
                 .customize(ab -> ab.balance(100L).id(new AccountBalance.Id(balanceTimestamp, account.toEntityId())))
@@ -314,7 +316,7 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
                 .entity(STAKING_REWARD_ACCOUNT, previousNodeStakeTimestamp - 8000)
                 .persist();
         var treasury = domainBuilder
-                .entity(TREASURY, previousNodeStakeTimestamp - 9000)
+                .entity(TREASURY_NUM, previousNodeStakeTimestamp - 9000)
                 .customize(e -> e.stakedNodeId(1L))
                 .persist();
         var aliceHistory1 = domainBuilder
@@ -432,7 +434,7 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
         var expectedTreasury = domainBuilder
                 .entity()
                 .customize(e -> e.balance(5000L)
-                        .id(TREASURY)
+                        .id(TREASURY_NUM)
                         .stakedAccountId(0L)
                         .stakedNodeId(1L)
                         .stakePeriodStart(-1L))
@@ -801,7 +803,7 @@ class EntityStakeRepositoryTest extends ImporterIntegrationTest {
                 .persist();
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(nodeStakeTimestamp - 1000, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new AccountBalance.Id(nodeStakeTimestamp - 1000, EntityId.of(TREASURY_NUM))))
                 .persist();
         // The following two are old NodeStake, which shouldn't be used in pending reward calculation
         domainBuilder

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOPIC;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
@@ -2,13 +2,14 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance.Id;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
 import java.util.List;
@@ -32,7 +33,10 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
             """)
     void balanceSnapshot(long shard, long realm) {
         // given
-        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var commonProperties = new CommonProperties();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
+        var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         var tokenAccount1 = domainBuilder.tokenAccount(shard, realm).persist();
         var tokenAccount2 = domainBuilder
                 .tokenAccount(shard, realm)
@@ -95,7 +99,10 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
     void balanceSnapshotDeduplicate(long shard, long realm) {
         long lowerRangeTimestamp = 0L;
         long timestamp = 100;
-        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var commonProperties = new CommonProperties();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
+        var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isZero();
         assertThat(tokenBalanceRepository.findAll()).isEmpty();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
@@ -2,7 +2,7 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TREASURY;
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.balance.AccountBalance;
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @RequiredArgsConstructor
 class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
@@ -23,18 +25,23 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
     private final TokenAccountRepository tokenAccountRepository;
     private final TokenBalanceRepository tokenBalanceRepository;
 
-    @Test
-    void balanceSnapshot() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1023, 100
+            """)
+    void balanceSnapshot(long shard, long realm) {
         // given
-        var tokenAccount1 = domainBuilder.tokenAccount().persist();
+        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        var tokenAccount1 = domainBuilder.tokenAccount(shard, realm).persist();
         var tokenAccount2 = domainBuilder
-                .tokenAccount()
+                .tokenAccount(shard, realm)
                 .customize(ta -> ta.associated(false).balance(0))
                 .persist();
 
         // when
         long snapshotTimestamp = domainBuilder.timestamp();
-        tokenBalanceRepository.balanceSnapshot(snapshotTimestamp);
+        tokenBalanceRepository.balanceSnapshot(snapshotTimestamp, treasury.getId());
 
         // then
         var expected = List.of(
@@ -49,7 +56,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         long lastSnapshotTimestamp = domainBuilder.timestamp();
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(lastSnapshotTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new AccountBalance.Id(lastSnapshotTimestamp, EntityId.of(TREASURY_NUM))))
                 .persist();
         // dissociated before last snapshot, will not appear in full snapshot
         domainBuilder
@@ -67,33 +74,38 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         // newSnapshotTimestamp
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(newSnapshotTimestamp, EntityId.of(TREASURY))))
+                .customize(ab -> ab.id(new AccountBalance.Id(newSnapshotTimestamp, EntityId.of(TREASURY_NUM))))
                 .persist();
         var expected = List.of(
                 buildTokenBalance(tokenAccount1, newSnapshotTimestamp),
                 buildTokenBalance(tokenAccount2, newSnapshotTimestamp));
 
         // when
-        tokenBalanceRepository.balanceSnapshot(newSnapshotTimestamp);
+        tokenBalanceRepository.balanceSnapshot(newSnapshotTimestamp, TREASURY_NUM);
 
         // then
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @Test
-    void balanceSnapshotDeduplicate() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1023, 100
+            """)
+    void balanceSnapshotDeduplicate(long shard, long realm) {
         long lowerRangeTimestamp = 0L;
         long timestamp = 100;
-        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp))
+        var treasury = EntityId.of(shard, realm, TREASURY_NUM);
+        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isZero();
         assertThat(tokenBalanceRepository.findAll()).isEmpty();
 
         var tokenAccount = domainBuilder
-                .tokenAccount()
+                .tokenAccount(shard, realm)
                 .customize(t -> t.balanceTimestamp(1L))
                 .persist();
         var tokenAccount2 = domainBuilder
-                .tokenAccount()
+                .tokenAccount(shard, realm)
                 .customize(t -> t.balanceTimestamp(1L))
                 .persist();
 
@@ -102,7 +114,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
                 .collect(Collectors.toList());
 
         // Update Balance Snapshot includes all balances
-        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp))
+        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(lowerRangeTimestamp, timestamp, treasury.getId()))
                 .isEqualTo(expected.size());
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -113,7 +125,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         expected.add(buildTokenBalance(tokenAccount, timestamp2));
 
         // Update includes only the updated token account
-        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp2))
+        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp, timestamp2, treasury.getId()))
                 .isOne();
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -123,13 +135,13 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         tokenAccountRepository.save(tokenAccount2);
         expected.add(buildTokenBalance(tokenAccount2, timestamp3));
         var tokenAccount3 = domainBuilder
-                .tokenAccount()
+                .tokenAccount(shard, realm)
                 .customize(t -> t.balanceTimestamp(timestamp3))
                 .persist();
         expected.add(buildTokenBalance(tokenAccount3, timestamp3));
 
         // Update includes only the token accounts with a balance timestamp greater than the max timestamp
-        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp2, timestamp3))
+        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp2, timestamp3, treasury.getId()))
                 .isEqualTo(2);
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
@@ -138,7 +150,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         tokenAccount.setBalanceTimestamp(timestamp4);
         tokenAccountRepository.save(tokenAccount);
         // Update with no change as the update happens at a timestamp equal to the max consensus timestamp
-        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp4, timestamp4))
+        assertThat(tokenBalanceRepository.balanceSnapshotDeduplicate(timestamp4, timestamp4, treasury.getId()))
                 .isZero();
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
     }
@@ -150,7 +162,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         var tokenBalance3 = domainBuilder.tokenBalance().get();
 
         tokenBalanceRepository.saveAll(List.of(tokenBalance1, tokenBalance2, tokenBalance3));
-        assertThat(tokenBalanceRepository.findById(tokenBalance1.getId())).get().isEqualTo(tokenBalance1);
+        assertThat(tokenBalanceRepository.findById(tokenBalance1.getId())).contains(tokenBalance1);
         assertThat(tokenBalanceRepository.findAll())
                 .containsExactlyInAnyOrder(tokenBalance1, tokenBalance2, tokenBalance3);
     }

--- a/hedera-mirror-rest/__tests__/specs/balances/timestamp-shard-realm.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/timestamp-shard-realm.json
@@ -1,0 +1,150 @@
+{
+  "description": "Balance api calls using snapshot and non-default shard and realm",
+  "setup": {
+    "commonConfig": {
+      "shard": 1,
+      "realm": 5
+    },
+    "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 2,
+        "balance": 2
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 4,
+        "balance": 40,
+        "tokens": [
+          {
+            "token_num": 90000,
+            "balance": 300
+          }
+        ]
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 5,
+        "balance": 50
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 6,
+        "balance": 60
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 7,
+        "balance": 770
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 2
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 4,
+        "balance": 444,
+        "tokens": [
+          {
+            "token_num": 90000,
+            "balance": 1000
+          }
+        ]
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 5,
+        "balance": 555
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 6,
+        "balance": 666
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 2,
+        "balance": 2
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 5,
+        "balance": 5
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 6,
+        "balance": 6,
+        "tokens": [
+          {
+            "token_num": 90000,
+            "balance": 662
+          }
+        ]
+      }
+    ]
+  },
+  "tests": [
+    {
+      "url": "/api/v1/balances?timestamp=1566560004.000000000",
+      "responseStatus": 200,
+      "responseJson": {
+        "timestamp": "1566560003.000000000",
+        "balances": [
+          {
+            "account": "1.5.7",
+            "balance": 770,
+            "tokens": []
+          },
+          {
+            "account": "1.5.6",
+            "balance": 666,
+            "tokens": []
+          },
+          {
+            "account": "1.5.5",
+            "balance": 555,
+            "tokens": []
+          },
+          {
+            "account": "1.5.4",
+            "balance": 444,
+            "tokens": [
+              {
+                "token_id": "1.5.90000",
+                "balance": 1000
+              }
+            ]
+          },
+          {
+            "account": "1.5.2",
+            "balance": 2,
+            "tokens": []
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      }
+    },
+    {
+      "url": "/api/v1/balances?timestamp=1566560004.000000000&limit=1",
+      "responseStatus": 200,
+      "responseJson": {
+        "timestamp": "1566560003.000000000",
+        "balances": [
+          {
+            "account": "1.5.7",
+            "balance": 770,
+            "tokens": []
+          }
+        ],
+        "links": {
+          "next": "/api/v1/balances?timestamp=1566560004.000000000&limit=1&account.id=lt:1.5.7"
+        }
+      }
+    }
+  ]
+}

--- a/hedera-mirror-rest/__tests__/systemEntity.test.js
+++ b/hedera-mirror-rest/__tests__/systemEntity.test.js
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+describe('treasuryAccount', () => {
+  const {common} = getMirrorConfig();
+  afterEach(() => {
+    common.realm = 0n;
+    common.shard = 0n;
+  });
+
+  test.each`
+    shard | realm | expected
+    ${0}  | ${0}  | ${'0.0.2'}
+    ${1}  | ${2}  | ${'1.2.2'}
+  `(`returns treasury account $expected given shard=$shard, realm=$realm`, ({shard, realm, expected}) => {
+    common.shard = BigInt(shard);
+    common.realm = BigInt(realm);
+    const expectedEntityId = EntityId.parse(expected);
+    expect(SystemEntity.treasuryAccount).toEqual(expectedEntityId);
+  });
+});

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import _ from 'lodash';
+
 import AccountAlias from './accountAlias';
-import {getResponseLimit} from './config';
+import {getResponseLimit, getMirrorConfig} from './config';
 import * as constants from './constants';
 import EntityId from './entityId';
-import {EntityService} from './service/index';
+import {EntityService} from './service';
 import {EvmAddressType} from './constants';
-import {InvalidArgumentError} from './errors/index';
+import {InvalidArgumentError} from './errors';
+import SystemEntity from './systemEntity';
 import * as utils from './utils';
-import _ from 'lodash';
 
 const {tokenBalance: tokenBalanceLimit} = getResponseLimit();
 
 const formatBalancesResult = (req, result, limit, order) => {
-  const {rows, sqlQuery} = result;
+  const {rows} = result;
   const ret = {
     timestamp: null,
     balances: [],
@@ -171,10 +173,10 @@ const getAccountBalanceTimestampRange = async (tsQuery, tsParams) => {
 
   // Add the treasury account to the query as it will always be in the balance snapshot and account_id is the first
   // column of the primary key
-  let condition = 'account_id = 2 and consensus_timestamp >= $1 and consensus_timestamp <= $2';
-  const params = [lowerBound, upperBound];
+  let condition = 'account_id = $1 and consensus_timestamp >= $2 and consensus_timestamp <= $3';
+  const params = [SystemEntity.treasuryAccount.getEncodedId(), lowerBound, upperBound];
   if (neParams.length) {
-    condition += ' and not consensus_timestamp = any ($3)';
+    condition += ' and not consensus_timestamp = any ($4)';
     params.push(neParams);
   }
 

--- a/hedera-mirror-rest/systemEntity.js
+++ b/hedera-mirror-rest/systemEntity.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const {common} = getMirrorConfig();
+
+class SystemEntity {
+  get treasuryAccount() {
+    return EntityId.of(common.shard, common.realm, 2);
+  }
+}
+
+export default new SystemEntity();

--- a/hedera-mirror-rosetta/app/config/config.go
+++ b/hedera-mirror-rosetta/app/config/config.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -22,29 +21,25 @@ import (
 var defaultConfig string
 
 const (
-	apiConfigEnvKey = "HEDERA_MIRROR_ROSETTA_API_CONFIG"
-	configName      = "application"
-	configTypeYaml  = "yml"
-	envKeyDelimiter = "_"
-	keyDelimiter    = "::"
-	nodesEnvKey     = "HEDERA_MIRROR_ROSETTA_NODES"
-	treasuryNum     = 2
+	apiConfigEnvKey          = "HEDERA_MIRROR_ROSETTA_API_CONFIG"
+	configName               = "application"
+	configTypeYaml           = "yml"
+	envKeyDelimiter          = "_"
+	keyDelimiter             = "::"
+	nodesEnvKey              = "HEDERA_MIRROR_ROSETTA_NODES"
+	stackingRewardAccountNum = 800
+	treasuryAccountNum       = 2
 )
 
 type Mirror struct {
-	Common           CommonConfig
-	Rosetta          Config
-	treasuryEntityId int64
+	Common  CommonConfig
+	Rosetta Config
 }
 
 type fullConfig struct {
 	Hedera struct {
 		Mirror Mirror
 	}
-}
-
-func (m *Mirror) GetTreasuryEntityId() int64 {
-	return m.treasuryEntityId
 }
 
 // LoadConfig loads configuration from yaml files and env variables
@@ -96,14 +91,6 @@ func LoadConfig() (*Mirror, error) {
 	if len(nodeMap) != 0 {
 		mirrorConfig.Rosetta.Nodes = nodeMap
 	}
-
-	common := mirrorConfig.Common
-	entityId, err := domain.EntityIdOf(common.Shard, common.Realm, treasuryNum)
-	if err != nil {
-		log.Errorf("Error encoding treasury entity id with shard=%d, realm=%d: %v", common.Shard, common.Realm, err)
-		return nil, err
-	}
-	mirrorConfig.treasuryEntityId = entityId.EncodedId
 
 	var password = mirrorConfig.Rosetta.Db.Password
 	mirrorConfig.Rosetta.Db.Password = "" // Don't print password

--- a/hedera-mirror-rosetta/app/config/config.go
+++ b/hedera-mirror-rosetta/app/config/config.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -27,17 +28,23 @@ const (
 	envKeyDelimiter = "_"
 	keyDelimiter    = "::"
 	nodesEnvKey     = "HEDERA_MIRROR_ROSETTA_NODES"
+	treasuryNum     = 2
 )
 
 type Mirror struct {
-	Common  CommonConfig
-	Rosetta Config
+	Common           CommonConfig
+	Rosetta          Config
+	treasuryEntityId int64
 }
 
 type fullConfig struct {
 	Hedera struct {
 		Mirror Mirror
 	}
+}
+
+func (m *Mirror) GetTreasuryEntityId() int64 {
+	return m.treasuryEntityId
 }
 
 // LoadConfig loads configuration from yaml files and env variables
@@ -89,6 +96,14 @@ func LoadConfig() (*Mirror, error) {
 	if len(nodeMap) != 0 {
 		mirrorConfig.Rosetta.Nodes = nodeMap
 	}
+
+	common := mirrorConfig.Common
+	entityId, err := domain.EntityIdOf(common.Shard, common.Realm, treasuryNum)
+	if err != nil {
+		log.Errorf("Error encoding treasury entity id with shard=%d, realm=%d: %v", common.Shard, common.Realm, err)
+		return nil, err
+	}
+	mirrorConfig.treasuryEntityId = entityId.EncodedId
 
 	var password = mirrorConfig.Rosetta.Db.Password
 	mirrorConfig.Rosetta.Db.Password = "" // Don't print password

--- a/hedera-mirror-rosetta/app/config/config_test.go
+++ b/hedera-mirror-rosetta/app/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -23,13 +22,6 @@ hedera:
     rosetta:
       nodes:
         "192.168.0.1:50211": 0.3`
-	invalidYamlShardRealm = `
-hedera:
-  mirror:
-    common:
-      shard: 1024
-      realm: 65537
-`
 	testConfigFilename = "application.yml"
 	yml1               = `
 hedera:
@@ -60,7 +52,6 @@ func TestLoadDefaultConfig(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, getDefaultConfig(), config)
-	assert.Equal(t, getDefaultConfig().GetTreasuryEntityId(), config.GetTreasuryEntityId())
 }
 
 func TestLoadDefaultConfigInvalidYamlString(t *testing.T) {
@@ -133,10 +124,8 @@ func TestLoadCustomConfigFromCwdAndEnvVar(t *testing.T) {
 	expected.Rosetta.Db.Username = "foobar"
 	expected.Rosetta.Network = "testnet"
 	expected.Rosetta.NodeRefreshInterval = expectedNodeRefreshInterval
-	expected.treasuryEntityId = domain.MustDecodeEntityId(18289276416425986).EncodedId
 	assert.NoError(t, err)
 	assert.Equal(t, expected, config)
-	assert.Equal(t, expected.treasuryEntityId, config.GetTreasuryEntityId())
 }
 
 func TestLoadCustomConfigFromEnvVar(t *testing.T) {
@@ -165,7 +154,6 @@ func TestLoadCustomConfigInvalidYaml(t *testing.T) {
 		{name: "invalid yaml", content: invalidYaml},
 		{name: "invalid yaml from cwd", content: invalidYaml, fromCwd: true},
 		{name: "incorrect account id", content: invalidYamlIncorrectAccountId},
-		{name: "invalid shard / realm", content: invalidYamlShardRealm},
 	}
 
 	for _, tt := range tests {
@@ -332,6 +320,5 @@ func (e *envManager) Cleanup() {
 func getDefaultConfig() *Mirror {
 	config := fullConfig{}
 	yaml.Unmarshal([]byte(defaultConfig), &config)
-	config.Hedera.Mirror.treasuryEntityId = 2
 	return &config.Hedera.Mirror
 }

--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/domain/types"
 	hErrors "github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/errors"
@@ -19,7 +18,7 @@ import (
 )
 
 const (
-	balanceChangeBetween = "with" + genesisTimestampCte + `select
+	balanceChangeBetween = `select
                               coalesce((
                                 select sum(amount) from crypto_transfer
                                 where
@@ -43,7 +42,7 @@ const (
                                     from (
                                       select consensus_timestamp
                                       from account_balance
-                                      where account_id = 2 and
+                                      where account_id = @treasury_entity_id and
                                         consensus_timestamp >= @lower_bound and
                                         consensus_timestamp <= @timestamp
                                       order by consensus_timestamp desc
@@ -90,12 +89,13 @@ type accountBalance struct {
 
 // accountRepository struct that has connection to the Database
 type accountRepository struct {
-	dbClient interfaces.DbClient
+	dbClient         interfaces.DbClient
+	treasuryEntityId int64
 }
 
 // NewAccountRepository creates an instance of a accountRepository struct
-func NewAccountRepository(dbClient interfaces.DbClient) interfaces.AccountRepository {
-	return &accountRepository{dbClient}
+func NewAccountRepository(dbClient interfaces.DbClient, treasuryEntityId int64) interfaces.AccountRepository {
+	return &accountRepository{dbClient, treasuryEntityId}
 }
 
 func (ar *accountRepository) GetAccountAlias(ctx context.Context, accountId types.AccountId) (
@@ -277,6 +277,7 @@ func (ar *accountRepository) getLatestBalanceSnapshot(ctx context.Context, accou
 		sql.Named("account_id", accountId),
 		sql.Named("lower_bound", partitionLowerBound),
 		sql.Named("timestamp", timestamp),
+		sql.Named("treasury_entity_id", ar.treasuryEntityId),
 	).First(ab).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 const (
-	account1 = int64(9000) + iota
-	account2
-	account3
-	account4
-	account5
-	account6
+	accountNum1 = int64(9000) + iota
+	accountNum2
+	accountNum3
+	accountNum4
+	accountNum5
+	accountNum6
 )
 
 const (
@@ -62,86 +62,104 @@ func TestAccountRepositorySuite(t *testing.T) {
 	suite.Run(t, new(accountRepositorySuite))
 }
 
+// run the suite
+func TestAccountRepositoryNonDefaultShardRealmSuite(t *testing.T) {
+	testSuite := accountRepositorySuite{
+		realm: 2,
+		shard: 1023,
+	}
+	suite.Run(t, &testSuite)
+}
+
 type accountRepositorySuite struct {
 	integrationTest
 	suite.Suite
-	accountId       types.AccountId
-	accountIdString string
-	accountAlias    []byte
-	account3Alias   []byte
-	account4Alias   []byte
-	account5Alias   []byte
-	account6Alias   []byte
+	accountId        types.AccountId
+	accountIdString  string
+	accountAlias     []byte
+	account3Alias    []byte
+	account4Alias    []byte
+	account5Alias    []byte
+	account6Alias    []byte
+	realm            int64
+	shard            int64
+	treasuryEntityId int64
+}
+
+func (s *accountRepositorySuite) getEntityId(num int64) domain.EntityId {
+	return MustEncodeEntityId(s.shard, s.realm, num)
 }
 
 func (suite *accountRepositorySuite) SetupSuite() {
-	suite.accountId = types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account1))
+	suite.accountId = types.NewAccountIdFromEntityId(suite.getEntityId(accountNum1))
 	suite.accountIdString = suite.accountId.String()
+	suite.treasuryEntityId = suite.getEntityId(2).EncodedId
 }
 
 func (suite *accountRepositorySuite) SetupTest() {
 	suite.integrationTest.SetupTest()
 
-	tdomain.NewEntityBuilder(dbClient, account1, account1CreatedTimestamp, domain.EntityTypeAccount).
+	accountId1 := suite.getEntityId(accountNum1).EncodedId
+	tdomain.NewEntityBuilder(dbClient, accountId1, account1CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.accountAlias).
 		Persist()
 
 	// account balance files, always add an account_balance row for treasury
 	tdomain.NewAccountBalanceSnapshotBuilder(dbClient, firstSnapshotTimestamp).
-		AddAccountBalance(treasuryAccountId.GetId(), 2_000_000_000).
-		AddAccountBalance(account1, initialAccountBalance).
+		AddAccountBalance(suite.treasuryEntityId, 2_000_000_000).
+		AddAccountBalance(accountId1, initialAccountBalance).
 		Persist()
 	tdomain.NewAccountBalanceSnapshotBuilder(dbClient, thirdSnapshotTimestamp).
-		AddAccountBalance(treasuryAccountId.GetId(), 2_000_000_000).
+		AddAccountBalance(suite.treasuryEntityId, 2_000_000_000).
 		Persist()
 
 	// crypto transfers happened at <= first snapshot timestamp
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(110).
-		EntityId(account1).
+		EntityId(accountId1).
 		Timestamp(firstSnapshotTimestamp - 1).
 		Persist()
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(170).
-		EntityId(account1).
+		EntityId(accountId1).
 		Timestamp(firstSnapshotTimestamp).
 		Persist()
 
 	// crypto transfers happened at > first snapshot timestamp
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(cryptoTransferAmounts[0]).
-		EntityId(account1).
+		EntityId(accountId1).
 		Errata(domain.ErrataTypeInsert).
 		Timestamp(firstSnapshotTimestamp + 1).
 		Persist()
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(12345).
-		EntityId(account1).
+		EntityId(accountId1).
 		Errata(domain.ErrataTypeDelete).
 		Timestamp(firstSnapshotTimestamp + 2).
 		Persist()
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(cryptoTransferAmounts[1]).
-		EntityId(account1).
+		EntityId(accountId1).
 		Timestamp(firstSnapshotTimestamp + 5).
 		Persist()
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(-(initialAccountBalance + sum(cryptoTransferAmounts))).
-		EntityId(account1).
+		EntityId(accountId1).
 		Timestamp(accountDeleteTimestamp).
 		Persist()
 
 	// accounts for GetAccountAlias tests
-	tdomain.NewEntityBuilder(dbClient, account3, account3CreatedTimestamp, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum3).EncodedId, account3CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.account3Alias).
 		Persist()
-	tdomain.NewEntityBuilder(dbClient, account4, account4CreatedTimestamp, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum4).EncodedId, account4CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.account4Alias).
 		Persist()
-	tdomain.NewEntityBuilder(dbClient, account5, account5CreatedTimestamp, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum5).EncodedId, account5CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.account5Alias).
 		Persist()
-	tdomain.NewEntityBuilder(dbClient, account6, account6CreatedTimestamp, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum6).EncodedId, account6CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.account6Alias).
 		Persist()
 }
@@ -151,11 +169,11 @@ func (suite *accountRepositorySuite) TestGetAccountAlias() {
 		encodedId int64
 		expected  string
 	}{
-		{encodedId: account3, expected: fmt.Sprintf("0.0.%d", account3)},
-		{encodedId: account4, expected: fmt.Sprintf("0.0.%d", account4)},
+		{encodedId: accountNum3, expected: fmt.Sprintf("0.0.%d", accountNum3)},
+		{encodedId: accountNum4, expected: fmt.Sprintf("0.0.%d", accountNum4)},
 	}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d", tt.encodedId)
@@ -170,8 +188,8 @@ func (suite *accountRepositorySuite) TestGetAccountAlias() {
 
 func (suite *accountRepositorySuite) TestGetAccountAliasDbConnectionError() {
 	// given
-	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account3))
-	repo := NewAccountRepository(invalidDbClient)
+	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(accountNum3))
+	repo := NewAccountRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.GetAccountAlias(defaultContext, accountId)
@@ -184,7 +202,7 @@ func (suite *accountRepositorySuite) TestGetAccountAliasDbConnectionError() {
 func (suite *accountRepositorySuite) TestGetAccountId() {
 	// given
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -196,8 +214,8 @@ func (suite *accountRepositorySuite) TestGetAccountId() {
 
 func (suite *accountRepositorySuite) TestGetAccountIdNumericAccount() {
 	// given
-	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account1))
-	repo := NewAccountRepository(dbClient)
+	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(accountNum1))
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, accountId)
@@ -210,7 +228,7 @@ func (suite *accountRepositorySuite) TestGetAccountIdNumericAccount() {
 func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
 	// given
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(invalidDbClient)
+	repo := NewAccountRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -223,15 +241,14 @@ func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
 	// given
 	// transfers before or at the snapshot timestamp should not affect balance calculation
-	accountId := suite.accountId
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
 	expectedAmounts := types.AmountSlice{hbarAmount}
 
 	// when
 	// query
-	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(defaultContext, accountId, consensusTimestamp)
+	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(defaultContext, suite.accountId, consensusTimestamp)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -243,21 +260,20 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterSecondSnapsh
 	// given
 	// remove any transfers in db. with the balance info in the second snapshot, this test verifies the account balance
 	// is directly read from the snapshot
-	accountId := suite.accountId
 	truncateTables(domain.CryptoTransfer{})
 	balance := initialAccountBalance + sum(cryptoTransferAmounts)
 	tdomain.NewAccountBalanceSnapshotBuilder(dbClient, secondSnapshotTimestamp).
-		AddAccountBalance(treasuryAccountId.GetId(), 2_000_000_000).
-		AddAccountBalance(account1, balance).
+		AddAccountBalance(suite.treasuryEntityId, 2_000_000_000).
+		AddAccountBalance(suite.getEntityId(accountNum1).EncodedId, balance).
 		Persist()
 	hbarAmount := &types.HbarAmount{Value: balance}
 	expectedAmount := types.AmountSlice{hbarAmount}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		secondSnapshotTimestamp+6,
 	)
 
@@ -269,33 +285,32 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterSecondSnapsh
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterThirdSnapshot() {
 	// given
-	accountId := suite.accountId
 	truncateTables(domain.CryptoTransfer{})
 	balance := initialAccountBalance + sum(cryptoTransferAmounts)
 	tdomain.NewAccountBalanceSnapshotBuilder(dbClient, secondSnapshotTimestamp).
-		AddAccountBalance(treasuryAccountId.GetId(), 2_000_000_000).
-		AddAccountBalance(account1, balance).
+		AddAccountBalance(suite.treasuryEntityId, 2_000_000_000).
+		AddAccountBalance(suite.getEntityId(accountNum1).EncodedId, balance).
 		Persist()
-	// No balance info for account1 in the third snapshot due to dedup, i.e., account1's balances at
+	// No balance info for accountNum1 in the third snapshot due to dedup, i.e., accountNum1's balances at
 	// thirdSnapshotTimestamp is the same as the balance at secondSnapshotTimestamp
 	tdomain.NewAccountBalanceSnapshotBuilder(dbClient, thirdSnapshotTimestamp).
-		AddAccountBalance(treasuryAccountId.GetId(), 2_000_000_000).
+		AddAccountBalance(suite.treasuryEntityId, 2_000_000_000).
 		Persist()
 	// Add a crypto transfer after the third snapshot timestamp
 	tdomain.NewCryptoTransferBuilder(dbClient).
 		Amount(10).
-		EntityId(account1).
+		EntityId(suite.getEntityId(accountNum1).EncodedId).
 		Timestamp(thirdSnapshotTimestamp + 1).
 		Persist()
 
 	hbarAmount := &types.HbarAmount{Value: balance}
 	expectedAmount := types.AmountSlice{hbarAmount}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		thirdSnapshotTimestamp,
 	)
 
@@ -307,7 +322,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterThirdSnapsho
 	// when
 	actualAmounts, accountIdString, err = repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		thirdSnapshotTimestamp+1,
 	)
 
@@ -320,15 +335,14 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterThirdSnapsho
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount() {
 	// given
-	accountId := suite.accountId
-	tdomain.NewEntityBuilder(dbClient, account1, 1, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum1).EncodedId, 1, domain.EntityTypeAccount).
 		Deleted(true).
 		ModifiedTimestamp(accountDeleteTimestamp).
 		Persist()
 	expectedAmounts := types.AmountSlice{
 		&types.HbarAmount{},
 	}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	// account is deleted before the third account balance file, so there is no balance info in the file. querying the
@@ -336,7 +350,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount
 	// the account is deleted
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		thirdSnapshotTimestamp+10,
 	)
 
@@ -348,20 +362,19 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletionTime() {
 	// given
-	accountId := suite.accountId
-	tdomain.NewEntityBuilder(dbClient, account1, 1, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, suite.getEntityId(accountNum1).EncodedId, 1, domain.EntityTypeAccount).
 		Deleted(true).
 		ModifiedTimestamp(accountDeleteTimestamp).
 		Persist()
 	expectedAmounts := types.AmountSlice{
 		&types.HbarAmount{},
 	}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		accountDeleteTimestamp,
 	)
 
@@ -373,16 +386,15 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletion
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountEntity() {
 	// given
-	accountId := suite.accountId
 	truncateTables(domain.Entity{})
 	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
 	expectedAmounts := types.AmountSlice{hbarAmount}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		consensusTimestamp,
 	)
 
@@ -394,18 +406,17 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountEntity()
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoInitialBalance() {
 	// given
-	accountId := suite.accountId
-	dbClient.GetDb().Where("account_id <> ?", treasuryAccountId.GetId()).Delete(&domain.AccountBalance{})
+	dbClient.GetDb().Where("account_id <> ?", suite.treasuryEntityId).Delete(&domain.AccountBalance{})
 
 	hbarAmount := &types.HbarAmount{Value: sum(cryptoTransferAmounts)}
 	expectedAmounts := types.AmountSlice{hbarAmount}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		consensusTimestamp,
 	)
 
@@ -418,13 +429,12 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoInitialBalance(
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	accountId := suite.accountId
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		consensusTimestamp,
 	)
 
@@ -436,13 +446,12 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountBalance(
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError() {
 	// given
-	accountId := suite.accountId
-	repo := NewAccountRepository(invalidDbClient)
+	repo := NewAccountRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
 		defaultContext,
-		accountId,
+		suite.accountId,
 		consensusTimestamp,
 	)
 
@@ -497,15 +506,16 @@ func (suite *accountRepositoryWithAliasSuite) SetupSuite() {
 func (suite *accountRepositoryWithAliasSuite) SetupTest() {
 	suite.accountRepositorySuite.SetupTest()
 
-	// add account2 with the same alias but was deleted before account1
+	// add accountNum2 with the same alias but was deleted before accountNum1
 	// the entity row with deleted = true in entity table
-	tdomain.NewEntityBuilder(dbClient, account2, account2CreatedTimestamp, domain.EntityTypeAccount).
+	accountId2 := MustEncodeEntityId(suite.shard, suite.realm, accountNum2).EncodedId
+	tdomain.NewEntityBuilder(dbClient, accountId2, account2CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.accountAlias).
 		Deleted(true).
 		ModifiedTimestamp(account2DeletedTimestamp).
 		Persist()
 	// the historical entry
-	tdomain.NewEntityBuilder(dbClient, account2, account2CreatedTimestamp, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, accountId2, account2CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.accountAlias).
 		TimestampRange(account2CreatedTimestamp, account2DeletedTimestamp).
 		Historical(true).
@@ -517,11 +527,11 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAlias() {
 		encodedId     int64
 		expectedAlias []byte
 	}{
-		{encodedId: account3, expectedAlias: account3Alias},
-		{encodedId: account4, expectedAlias: account4Alias},
+		{encodedId: accountNum3, expectedAlias: account3Alias},
+		{encodedId: accountNum4, expectedAlias: account4Alias},
 	}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d", tt.encodedId)
@@ -539,11 +549,11 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAliasWithInvalidAlia
 		encodedId int64
 		expected  string
 	}{
-		{encodedId: account5, expected: fmt.Sprintf("0.0.%d", account5)},
-		{encodedId: account6, expected: fmt.Sprintf("0.0.%d", account6)},
+		{encodedId: accountNum5, expected: fmt.Sprintf("0.0.%d", accountNum5)},
+		{encodedId: accountNum6, expected: fmt.Sprintf("0.0.%d", accountNum6)},
 	}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d", tt.encodedId)
@@ -560,8 +570,8 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountId() {
 	// given
 	aliasAccountId, err := types.NewAccountIdFromAlias(account4Alias, 0, 0)
 	assert.NoError(suite.T(), err)
-	repo := NewAccountRepository(dbClient)
-	expected := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account4))
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
+	expected := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(accountNum4))
 
 	// when
 	actual, rErr := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -573,12 +583,12 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountId() {
 
 func (suite *accountRepositoryWithAliasSuite) TestGetAccountIdDeleted() {
 	// given
-	tdomain.NewEntityBuilder(dbClient, account4, 1, domain.EntityTypeAccount).
+	tdomain.NewEntityBuilder(dbClient, accountNum4, 1, domain.EntityTypeAccount).
 		Deleted(true).
 		ModifiedTimestamp(accountDeleteTimestamp).
 		Persist()
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, rErr := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -591,7 +601,7 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountIdDeleted() {
 func (suite *accountRepositoryWithAliasSuite) TestRetrieveBalanceAtBlockNoAccountEntity() {
 	// whey querying by alias and the account is not found, expect 0 hbar balance returned
 	truncateTables(domain.Entity{})
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(

--- a/hedera-mirror-rosetta/app/persistence/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/persistence/address_book_entry_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 var (
-	accountId3   = mustEncode(1023, 0, 3)
-	accountId4   = mustEncode(1023, 0, 4)
-	accountId70  = mustEncode(1023, 0, 70)
-	accountId80  = mustEncode(1023, 0, 80)
+	accountId3   = MustEncodeEntityId(1023, 0, 3)
+	accountId4   = MustEncodeEntityId(1023, 0, 4)
+	accountId70  = MustEncodeEntityId(1023, 0, 70)
+	accountId80  = MustEncodeEntityId(1023, 0, 80)
 	addressBooks = []*domain.AddressBook{
 		getAddressBook(9, 0, 102),
 		getAddressBook(10, 19, 101),
@@ -147,6 +147,15 @@ func (suite *addressBookEntryRepositorySuite) TestEntriesDbConnectionError() {
 	assert.Nil(suite.T(), actual)
 }
 
+func MustEncodeEntityId(shard, realm, num int64) domain.EntityId {
+	encodedId, err := domain.EntityIdOf(shard, realm, num)
+	if err != nil {
+		panic(err)
+	}
+
+	return encodedId
+}
+
 func getAddressBook(start, end int64, fileId int64) *domain.AddressBook {
 	addressBook := domain.AddressBook{StartConsensusTimestamp: start, FileId: domain.MustDecodeEntityId(fileId)}
 	if end != 0 {
@@ -165,13 +174,4 @@ func getAddressBookEntry(
 		NodeId:             nodeId,
 		NodeAccountId:      nodeAccountId,
 	}
-}
-
-func mustEncode(shard, realm, num int64) domain.EntityId {
-	encodedId, err := domain.EntityIdOf(shard, realm, num)
-	if err != nil {
-		panic(err)
-	}
-
-	return encodedId
 }

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -21,7 +21,7 @@ var (
 	defaultAccountBalances = []*domain.AccountBalance{
 		// From the first account balance snapshot
 		{
-			AccountId:          treasuryEntityId,
+			AccountId:          defaultTreasuryEntityId,
 			Balance:            5_000_000_000,
 			ConsensusTimestamp: 90,
 		},
@@ -32,7 +32,7 @@ var (
 		},
 		// From the second account balance snapshot
 		{
-			AccountId:          treasuryEntityId,
+			AccountId:          defaultTreasuryEntityId,
 			Balance:            5_000_000_000,
 			ConsensusTimestamp: 10000,
 		},
@@ -43,7 +43,7 @@ var (
 		},
 		// From the third account balance snapshot
 		{
-			AccountId:          treasuryEntityId,
+			AccountId:          defaultTreasuryEntityId,
 			Balance:            5_000_000_000,
 			ConsensusTimestamp: 20000,
 		},

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -18,7 +18,7 @@ import (
 const genesisBlockIndex int64 = 3
 
 var (
-	accountBalances = []*domain.AccountBalance{
+	defaultAccountBalances = []*domain.AccountBalance{
 		// From the first account balance snapshot
 		{
 			AccountId:          treasuryEntityId,
@@ -120,19 +120,49 @@ func TestBlockRepositorySuite(t *testing.T) {
 	suite.Run(t, new(blockRepositorySuite))
 }
 
+// run the suite
+func TestBlockRepositoryNonDefaultShardRealmSuite(t *testing.T) {
+	testSuite := blockRepositorySuite{
+		shard: 1023,
+		realm: 2,
+	}
+	suite.Run(t, &testSuite)
+}
+
 type blockRepositorySuite struct {
 	integrationTest
 	suite.Suite
+	accountBalances  []*domain.AccountBalance
+	realm            int64
+	shard            int64
+	treasuryEntityId int64
+}
+
+func (suite *blockRepositorySuite) SetupSuite() {
+	suite.treasuryEntityId = MustEncodeEntityId(suite.shard, suite.realm, 2).EncodedId
+	if suite.shard == 0 && suite.realm == 0 {
+		suite.accountBalances = defaultAccountBalances
+	} else {
+		accountBalances := make([]*domain.AccountBalance, 0, len(defaultAccountBalances))
+		for _, balance := range defaultAccountBalances {
+			accountBalances = append(accountBalances, &domain.AccountBalance{
+				AccountId:          MustEncodeEntityId(suite.shard, suite.realm, balance.AccountId.EntityNum),
+				Balance:            balance.Balance,
+				ConsensusTimestamp: balance.ConsensusTimestamp,
+			})
+		}
+		suite.accountBalances = accountBalances
+	}
 }
 
 func (suite *blockRepositorySuite) SetupTest() {
 	suite.integrationTest.SetupTest()
-	db.CreateDbRecords(dbClient, accountBalances, recordFiles, recordFileBeforeGenesis)
+	db.CreateDbRecords(dbClient, suite.accountBalances, recordFiles, recordFileBeforeGenesis)
 }
 
 func (suite *blockRepositorySuite) TestFindByHashGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -144,7 +174,7 @@ func (suite *blockRepositorySuite) TestFindByHashGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByHashNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, expectedSecondBlock.Hash)
@@ -156,7 +186,7 @@ func (suite *blockRepositorySuite) TestFindByHashNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByHashBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, recordFileBeforeGenesis.Hash)
@@ -169,7 +199,7 @@ func (suite *blockRepositorySuite) TestFindByHashBlockBeforeGenesis() {
 func (suite *blockRepositorySuite) TestFindByHashNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -182,7 +212,7 @@ func (suite *blockRepositorySuite) TestFindByHashNoAccountBalance() {
 func (suite *blockRepositorySuite) TestFindByHashNoRecordFile() {
 	// given
 	truncateTables(domain.RecordFile{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -194,7 +224,7 @@ func (suite *blockRepositorySuite) TestFindByHashNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByHashEmptyHash() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, "")
@@ -206,7 +236,7 @@ func (suite *blockRepositorySuite) TestFindByHashEmptyHash() {
 
 func (suite *blockRepositorySuite) TestFindByHashDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -218,7 +248,7 @@ func (suite *blockRepositorySuite) TestFindByHashDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, genesisBlockIndex, expectedGenesisBlock.Hash)
@@ -230,7 +260,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, expectedSecondBlock.Index, expectedSecondBlock.Hash)
@@ -242,7 +272,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, recordFileBeforeGenesis.Index, recordFileBeforeGenesis.Hash)
@@ -270,7 +300,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierInvalidArgument() {
 			"",
 		},
 	}
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
@@ -286,7 +316,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierInvalidArgument() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierIndexHashMismatch() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, expectedGenesisBlock.Index, expectedSecondBlock.Hash)
@@ -299,7 +329,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierIndexHashMismatch() {
 func (suite *blockRepositorySuite) TestFindByIdentifierNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -312,7 +342,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNoAccountBalance() {
 func (suite *blockRepositorySuite) TestFindByIdentifierNoRecordFile() {
 	// given
 	truncateTables(domain.RecordFile{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -324,7 +354,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierNotFound() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 1000, "foobar")
@@ -336,7 +366,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNotFound() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -348,7 +378,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestFindByIndexGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, genesisBlockIndex)
@@ -360,7 +390,7 @@ func (suite *blockRepositorySuite) TestFindByIndexGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIndexNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, expectedSecondBlock.Index)
@@ -372,7 +402,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIndexBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, recordFileBeforeGenesis.Index)
@@ -384,7 +414,7 @@ func (suite *blockRepositorySuite) TestFindByIndexBlockBeforeGenesis() {
 
 func (suite *blockRepositorySuite) TestFindByIndexInvalidIndex() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, -1)
@@ -397,7 +427,7 @@ func (suite *blockRepositorySuite) TestFindByIndexInvalidIndex() {
 func (suite *blockRepositorySuite) TestFineByIndexNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -410,7 +440,7 @@ func (suite *blockRepositorySuite) TestFineByIndexNoAccountBalance() {
 func (suite *blockRepositorySuite) TestFindByIndexNoRecordFile() {
 	// given
 	truncateTables(domain.RecordFile{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -422,7 +452,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByIndexNotFound() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 1000)
@@ -434,7 +464,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNotFound() {
 
 func (suite *blockRepositorySuite) TestFindByIndexDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -446,7 +476,7 @@ func (suite *blockRepositorySuite) TestFindByIndexDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestRetrieveGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -480,7 +510,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisIndexOverflowInt4() {
 			expected := *expectedGenesisBlock
 			expected.Index = genesisIndex
 			expected.ParentIndex = genesisIndex
-			repo := NewBlockRepository(dbClient)
+			repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 			// when
 			actual, err := repo.RetrieveGenesis(defaultContext)
@@ -495,7 +525,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisIndexOverflowInt4() {
 func (suite *blockRepositorySuite) TestRetrieveGenesisNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -508,7 +538,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisNoAccountBalance() {
 func (suite *blockRepositorySuite) TestRetrieveGenesisNoRecordFile() {
 	// given
 	truncateTables(domain.RecordFile{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -520,7 +550,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -533,7 +563,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNonGenesisBlock() {
 	// given
 	expected := expectedThirdBlock
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -547,7 +577,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithOnlyGenesisBlock() {
 	// given
 	truncateTables(domain.RecordFile{})
 	db.CreateDbRecords(dbClient, genesisRecordFile)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 	expected := *expectedGenesisBlock
 	expected.ConsensusEndNanos = recordFiles[0].ConsensusEnd
 
@@ -563,7 +593,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithBlockBeforeGenesis() {
 	// given
 	truncateTables(domain.RecordFile{})
 	db.CreateDbRecords(dbClient, recordFileBeforeGenesis)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -576,7 +606,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithBlockBeforeGenesis() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNoAccountBalance() {
 	// given
 	truncateTables(domain.AccountBalance{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -589,7 +619,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestNoAccountBalance() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNoRecordFile() {
 	// given
 	truncateTables(domain.RecordFile{})
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -601,7 +631,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestRetrieveLatestRecordFileTableInconsistent() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -629,7 +659,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestRecordFileTableInconsistent
 
 func (suite *blockRepositorySuite) TestRetrieveLatestDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, suite.treasuryEntityId)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)

--- a/hedera-mirror-rosetta/app/persistence/common.go
+++ b/hedera-mirror-rosetta/app/persistence/common.go
@@ -4,15 +4,6 @@ package persistence
 
 import "github.com/jackc/pgtype"
 
-const (
-	genesisTimestampQuery = `select consensus_timestamp as timestamp
-                             from account_balance
-                             where account_id = 2
-                             order by consensus_timestamp
-                             limit 1`
-	genesisTimestampCte = " genesis as (" + genesisTimestampQuery + ") "
-)
-
 func getInclusiveInt8Range(lower, upper int64) pgtype.Int8range {
 	return pgtype.Int8range{
 		Lower:     pgtype.Int8{Int: lower, Status: pgtype.Present},

--- a/hedera-mirror-rosetta/app/persistence/domain/entity.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity.go
@@ -5,11 +5,7 @@ package domain
 import "github.com/jackc/pgtype"
 
 const (
-	EntityTypeAccount  = "ACCOUNT"
-	EntityTypeFile     = "FILE"
-	EntityTypeSchedule = "SCHEDULE"
-	EntityTypeToken    = "TOKEN"
-	EntityTypeTopic    = "TOPIC"
+	EntityTypeAccount = "ACCOUNT"
 
 	entityTableName        = "entity"
 	entityHistoryTableName = "entity_history"

--- a/hedera-mirror-rosetta/app/persistence/domain/system_entity.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/system_entity.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/config"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	stakingRewardAccountNum = 800
+	treasuryAccountNum      = 2
+)
+
+type SystemEntity interface {
+	GetStakingRewardAccount() EntityId
+	GetTreasuryAccount() EntityId
+}
+
+func NewSystemEntity(commonConfig config.CommonConfig) SystemEntity {
+	return &systemEntity{commonConfig}
+}
+
+type systemEntity struct {
+	commonConfig config.CommonConfig
+}
+
+func (s *systemEntity) GetStakingRewardAccount() EntityId {
+	entityId, err := EntityIdOf(s.commonConfig.Shard, s.commonConfig.Realm, stakingRewardAccountNum)
+	if err != nil {
+		log.Panicf("Failed to get staking reward account: %v", err)
+	}
+	return entityId
+}
+
+func (s *systemEntity) GetTreasuryAccount() EntityId {
+	entityId, err := EntityIdOf(s.commonConfig.Shard, s.commonConfig.Realm, treasuryAccountNum)
+	if err != nil {
+		log.Panicf("Failed to get treasury account: %v", err)
+	}
+	return entityId
+}

--- a/hedera-mirror-rosetta/app/persistence/domain/system_entity_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/system_entity_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package domain
+
+import (
+	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetStakingRewardAccount(t *testing.T) {
+	testSpecs := []struct {
+		commonConfig config.CommonConfig
+		expected     EntityId
+	}{
+		{
+			commonConfig: config.CommonConfig{},
+			expected:     MustDecodeEntityId(800),
+		},
+		{
+			commonConfig: config.CommonConfig{Shard: 1, Realm: 2},
+			expected:     MustDecodeEntityId(18014948265296672),
+		},
+	}
+
+	for _, tt := range testSpecs {
+		t.Run(tt.expected.String(), func(t *testing.T) {
+			subject := NewSystemEntity(tt.commonConfig)
+			assert.Equal(t, tt.expected, subject.GetStakingRewardAccount())
+		})
+	}
+}
+
+func TestGetStakingRewardAccountPanics(t *testing.T) {
+	subject := NewSystemEntity(config.CommonConfig{Realm: 65536, Shard: 1024})
+	assert.Panics(t, func() {
+		subject.GetStakingRewardAccount()
+	})
+}
+
+func TestGetTreasuryAccount(t *testing.T) {
+	testSpecs := []struct {
+		commonConfig config.CommonConfig
+		expected     EntityId
+	}{
+		{
+			commonConfig: config.CommonConfig{},
+			expected:     MustDecodeEntityId(2),
+		},
+		{
+			commonConfig: config.CommonConfig{Shard: 1, Realm: 2},
+			expected:     MustDecodeEntityId(18014948265295874),
+		},
+	}
+
+	for _, tt := range testSpecs {
+		t.Run(tt.expected.String(), func(t *testing.T) {
+			subject := NewSystemEntity(tt.commonConfig)
+			assert.Equal(t, tt.expected, subject.GetTreasuryAccount())
+		})
+	}
+}
+
+func TestGetTreasuryAccountPanics(t *testing.T) {
+	subject := NewSystemEntity(config.CommonConfig{Realm: 65536, Shard: 1024})
+	assert.Panics(t, func() {
+		subject.GetTreasuryAccount()
+	})
+}

--- a/hedera-mirror-rosetta/app/persistence/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction.go
@@ -29,7 +29,7 @@ const (
 	andTransactionHashFilter  = " and transaction_hash = @hash"
 	orderByConsensusTimestamp = " order by consensus_timestamp"
 	// selectTransactionsInTimestampRange selects the transactions with its crypto transfers in json.
-	selectTransactionsInTimestampRange = "with" + genesisTimestampCte + `select
+	selectTransactionsInTimestampRange = `select
                                             t.consensus_timestamp,
                                             t.entity_id,
                                             t.itemized_transfer,

--- a/hedera-mirror-rosetta/app/persistence/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction.go
@@ -59,8 +59,6 @@ const (
 	selectTransactionsInTimestampRangeOrdered = selectTransactionsInTimestampRange + orderByConsensusTimestamp
 )
 
-var stakingRewardAccountId = domain.MustDecodeEntityId(800)
-
 // transaction maps to the transaction query which returns the required transaction fields, CryptoTransfers json string,
 // and itemizedTransfers json string.
 type transaction struct {
@@ -100,14 +98,15 @@ func (t hbarTransfer) getAmount() types.Amount {
 
 // transactionRepository struct that has connection to the Database
 type transactionRepository struct {
-	once     sync.Once
-	dbClient interfaces.DbClient
-	types    map[int]string
+	once                  sync.Once
+	dbClient              interfaces.DbClient
+	stakingRewardEntityId domain.EntityId
+	types                 map[int]string
 }
 
 // NewTransactionRepository creates an instance of a TransactionRepository struct
-func NewTransactionRepository(dbClient interfaces.DbClient) interfaces.TransactionRepository {
-	return &transactionRepository{dbClient: dbClient}
+func NewTransactionRepository(dbClient interfaces.DbClient, stakingRewardEntityId domain.EntityId) interfaces.TransactionRepository {
+	return &transactionRepository{dbClient: dbClient, stakingRewardEntityId: stakingRewardEntityId}
 }
 
 func (tr *transactionRepository) FindBetween(ctx context.Context, start, end int64) (
@@ -236,6 +235,7 @@ func (tr *transactionRepository) constructTransaction(sameHashTransactions []*tr
 		feeHbarTransfers, itemizedTransfers, stakingRewardTransfers = categorizeHbarTransfers(
 			cryptoTransfers,
 			transaction.ItemizedTransfer,
+			tr.stakingRewardEntityId,
 			stakingRewardPayouts,
 		)
 
@@ -300,7 +300,7 @@ func (tr *transactionRepository) appendTransferOperations(
 	return operations
 }
 
-func categorizeHbarTransfers(hbarTransfers []hbarTransfer, itemizedTransfer domain.ItemizedTransferSlice, stakingRewardPayouts []hbarTransfer) (
+func categorizeHbarTransfers(hbarTransfers []hbarTransfer, itemizedTransfer domain.ItemizedTransferSlice, stackingRewardEntityId domain.EntityId, stakingRewardPayouts []hbarTransfer) (
 	feeHbarTransfers, adjustedItemizedTransfers, stakingRewardTransfers []hbarTransfer,
 ) {
 	entityIds := make(map[int64]struct{})
@@ -314,7 +314,7 @@ func categorizeHbarTransfers(hbarTransfers []hbarTransfer, itemizedTransfer doma
 		// skip itemized transfer whose entity id is not in the transaction record's transfer list. One exception is
 		// we always add itemized transfers to the staking reward account if there are staking reward payouts
 		_, exists := entityIds[entityId]
-		if exists || (entityId == stakingRewardAccountId.EncodedId && len(stakingRewardPayouts) != 0) {
+		if exists || (entityId == stackingRewardEntityId.EncodedId && len(stakingRewardPayouts) != 0) {
 			adjustedItemizedTransfers = append(adjustedItemizedTransfers, hbarTransfer{
 				AccountId: transfer.EntityId,
 				Amount:    transfer.Amount,
@@ -332,7 +332,7 @@ func categorizeHbarTransfers(hbarTransfers []hbarTransfer, itemizedTransfer doma
 
 	if rewardPayoutTotal != 0 {
 		stakingRewardTransfers = append(stakingRewardTransfers, hbarTransfer{
-			AccountId: stakingRewardAccountId,
+			AccountId: stackingRewardEntityId,
 			Amount:    rewardPayoutTotal,
 		})
 	}

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -65,9 +65,9 @@ func newBlockchainOnlineRouter(
 	serverContext context.Context,
 	version *rTypes.Version,
 ) (http.Handler, error) {
-	accountRepo := persistence.NewAccountRepository(dbClient)
+	accountRepo := persistence.NewAccountRepository(dbClient, mirrorConfig.GetTreasuryEntityId())
 	addressBookEntryRepo := persistence.NewAddressBookEntryRepository(dbClient)
-	blockRepo := persistence.NewBlockRepository(dbClient)
+	blockRepo := persistence.NewBlockRepository(dbClient, mirrorConfig.GetTreasuryEntityId())
 	transactionRepo := persistence.NewTransactionRepository(dbClient)
 
 	baseService := services.NewOnlineBaseService(blockRepo, transactionRepo)

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/hiero-ledger/hiero-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"net/http"
 	"os"
 	"os/signal"
@@ -65,10 +66,11 @@ func newBlockchainOnlineRouter(
 	serverContext context.Context,
 	version *rTypes.Version,
 ) (http.Handler, error) {
-	accountRepo := persistence.NewAccountRepository(dbClient, mirrorConfig.GetTreasuryEntityId())
+	systemEntity := domain.NewSystemEntity(mirrorConfig.Common)
+	accountRepo := persistence.NewAccountRepository(dbClient, systemEntity.GetTreasuryAccount().EncodedId)
 	addressBookEntryRepo := persistence.NewAddressBookEntryRepository(dbClient)
-	blockRepo := persistence.NewBlockRepository(dbClient, mirrorConfig.GetTreasuryEntityId())
-	transactionRepo := persistence.NewTransactionRepository(dbClient)
+	blockRepo := persistence.NewBlockRepository(dbClient, systemEntity.GetTreasuryAccount().EncodedId)
+	transactionRepo := persistence.NewTransactionRepository(dbClient, systemEntity.GetStakingRewardAccount())
 
 	baseService := services.NewOnlineBaseService(blockRepo, transactionRepo)
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
@@ -16,6 +16,7 @@ import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.web3.evm.exception.WrongTypeException;
 import com.hedera.mirror.web3.evm.store.DatabaseBackedStateFrame.DatabaseAccessIncorrectKeyTypeException;
 import com.hedera.mirror.web3.repository.AccountBalanceRepository;
@@ -130,8 +131,8 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
         return Suppliers.memoize(() -> timestamp
                 .map(t -> {
                     Long createdTimestamp = entity.getCreatedTimestamp();
-                    long treasuryAccountId = EntityId.of(
-                                    commonProperties.getShard(), commonProperties.getRealm(), EntityId.TREASURY_NUM)
+                    long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                            .getScopedEntityId(commonProperties)
                             .getId();
                     if (createdTimestamp == null || t >= createdTimestamp) {
                         return accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
@@ -10,6 +10,7 @@ import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.AbstractTokenAllowance;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -57,6 +58,7 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
         throw new IllegalStateException(String.format("Duplicate key for values %s and %s", v1, v2));
     };
 
+    private final CommonProperties commonProperties;
     private final EntityDatabaseAccessor entityDatabaseAccessor;
     private final NftAllowanceRepository nftAllowanceRepository;
     private final NftRepository nftRepository;
@@ -128,8 +130,12 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
         return Suppliers.memoize(() -> timestamp
                 .map(t -> {
                     Long createdTimestamp = entity.getCreatedTimestamp();
+                    long treasuryAccountId = EntityId.of(
+                                    commonProperties.getShard(), commonProperties.getRealm(), EntityId.TREASURY_NUM)
+                            .getId();
                     if (createdTimestamp == null || t >= createdTimestamp) {
-                        return accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), t);
+                        return accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
+                                entity.getId(), t, treasuryAccountId);
                     } else {
                         return ZERO_BALANCE;
                     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenDatabaseAccessor.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.web3.evm.store.accessor;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 
@@ -11,6 +10,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.common.util.DomainUtils;
@@ -117,7 +117,8 @@ public class TokenDatabaseAccessor extends DatabaseAccessor<Object, Token> {
 
     private Long getTotalSupplyHistorical(boolean isFungible, long tokenId, long timestamp) {
         if (isFungible) {
-            long treasuryAccountId = EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+            long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                    .getScopedEntityId(commonProperties)
                     .getId();
             return tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId, timestamp, treasuryAccountId);
         } else {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessor.java
@@ -2,10 +2,8 @@
 
 package com.hedera.mirror.web3.evm.store.accessor;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
-
 import com.hedera.mirror.common.CommonProperties;
-import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -110,8 +108,8 @@ public class TokenRelationshipDatabaseAccessor extends DatabaseAccessor<Object, 
         return timestamp
                 .map(t -> {
                     if (t >= accountCreatedTimestamp) {
-                        long treasuryAccountId = EntityId.of(
-                                        commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+                        long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                                .getScopedEntityId(commonProperties)
                                 .getId();
                         return tokenBalanceRepository.findHistoricalTokenBalanceUpToTimestamp(
                                 tokenAccount.getTokenId(), tokenAccount.getAccountId(), t, treasuryAccountId);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessor.java
@@ -2,6 +2,10 @@
 
 package com.hedera.mirror.web3.evm.store.accessor;
 
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
+
+import com.hedera.mirror.common.CommonProperties;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -27,6 +31,8 @@ import org.hyperledger.besu.datatypes.Address;
 @Named
 @RequiredArgsConstructor
 public class TokenRelationshipDatabaseAccessor extends DatabaseAccessor<Object, TokenRelationship> {
+
+    private final CommonProperties commonProperties;
     private final TokenDatabaseAccessor tokenDatabaseAccessor;
     private final AccountDatabaseAccessor accountDatabaseAccessor;
     private final TokenAccountRepository tokenAccountRepository;
@@ -104,8 +110,11 @@ public class TokenRelationshipDatabaseAccessor extends DatabaseAccessor<Object, 
         return timestamp
                 .map(t -> {
                     if (t >= accountCreatedTimestamp) {
+                        long treasuryAccountId = EntityId.of(
+                                        commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+                                .getId();
                         return tokenBalanceRepository.findHistoricalTokenBalanceUpToTimestamp(
-                                tokenAccount.getTokenId(), tokenAccount.getAccountId(), t);
+                                tokenAccount.getTokenId(), tokenAccount.getAccountId(), t, treasuryAccountId);
                     } else {
                         return ZERO_BALANCE;
                     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/AccountBalanceRepository.java
@@ -65,7 +65,7 @@ public interface AccountBalanceRepository extends CrudRepository<AccountBalance,
                     with balance_timestamp as (
                         select consensus_timestamp
                         from account_balance
-                        where account_id = 2 and
+                        where account_id = ?3 and
                             consensus_timestamp > ?2 - 2678400000000000 and
                             consensus_timestamp <= ?2
                         order by consensus_timestamp desc
@@ -89,5 +89,6 @@ public interface AccountBalanceRepository extends CrudRepository<AccountBalance,
                     select coalesce((select balance from balance_snapshot), 0) + coalesce((select amount from change), 0)
                     """,
             nativeQuery = true)
-    Optional<Long> findHistoricalAccountBalanceUpToTimestamp(long accountId, long blockTimestamp);
+    Optional<Long> findHistoricalAccountBalanceUpToTimestamp(
+            long accountId, long blockTimestamp, long treasuryAccountId);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenBalanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenBalanceRepository.java
@@ -55,7 +55,7 @@ public interface TokenBalanceRepository extends CrudRepository<TokenBalance, Tok
                     with balance_timestamp as (
                     select consensus_timestamp
                     from account_balance
-                    where account_id = 2 and
+                    where account_id = ?4 and
                         consensus_timestamp > ?3 - 2678400000000000 and consensus_timestamp <= ?3
                     order by consensus_timestamp desc
                     limit 1
@@ -81,5 +81,6 @@ public interface TokenBalanceRepository extends CrudRepository<TokenBalance, Tok
                     select coalesce((select balance from base), 0) + coalesce((select amount from change), 0)
                     """,
             nativeQuery = true)
-    Optional<Long> findHistoricalTokenBalanceUpToTimestamp(long tokenId, long accountId, long blockTimestamp);
+    Optional<Long> findHistoricalTokenBalanceUpToTimestamp(
+            long tokenId, long accountId, long blockTimestamp, long treasuryAccountId);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenRepository.java
@@ -81,7 +81,7 @@ public interface TokenRepository extends CrudRepository<Token, Long> {
                     with snapshot_timestamp as (
                       select consensus_timestamp
                       from account_balance
-                      where account_id = 2 and
+                      where account_id = ?3 and
                         consensus_timestamp <= ?2 and
                         consensus_timestamp > ?2 - 2678400000000000
                       order by consensus_timestamp desc
@@ -105,5 +105,5 @@ public interface TokenRepository extends CrudRepository<Token, Long> {
                     select coalesce((select sum(balance) from snapshot), 0) + coalesce((select sum(amount) from change), 0)
                     """,
             nativeQuery = true)
-    long findFungibleTotalSupplyByTokenIdAndTimestamp(long tokenId, long blockTimestamp);
+    long findFungibleTotalSupplyByTokenIdAndTimestamp(long tokenId, long blockTimestamp, long treasuryAccountId);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -2,6 +2,7 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
@@ -14,8 +15,10 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountApprovalForAllAllowance;
 import com.hedera.hapi.node.state.token.AccountCryptoAllowance;
 import com.hedera.hapi.node.state.token.AccountFungibleTokenAllowance;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.NftAllowance;
 import com.hedera.mirror.common.domain.entity.TokenAllowance;
 import com.hedera.mirror.web3.common.ContractCallContext;
@@ -47,8 +50,10 @@ import java.util.function.Supplier;
 public class AccountReadableKVState extends AbstractReadableKVState<AccountID, Account> {
 
     public static final String KEY = "ACCOUNTS";
-    private final AccountBalanceRepository accountBalanceRepository;
+
     private final CommonEntityAccessor commonEntityAccessor;
+    private final CommonProperties commonProperties;
+    private final AccountBalanceRepository accountBalanceRepository;
     private final CryptoAllowanceRepository cryptoAllowanceRepository;
     private final NftAllowanceRepository nftAllowanceRepository;
     private final NftRepository nftRepository;
@@ -57,6 +62,7 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
 
     public AccountReadableKVState(
             CommonEntityAccessor commonEntityAccessor,
+            CommonProperties commonProperties,
             NftAllowanceRepository nftAllowanceRepository,
             NftRepository nftRepository,
             TokenAllowanceRepository tokenAllowanceRepository,
@@ -64,8 +70,9 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
             TokenAccountRepository tokenAccountRepository,
             AccountBalanceRepository accountBalanceRepository) {
         super(KEY);
-        this.accountBalanceRepository = accountBalanceRepository;
         this.commonEntityAccessor = commonEntityAccessor;
+        this.commonProperties = commonProperties;
+        this.accountBalanceRepository = accountBalanceRepository;
         this.cryptoAllowanceRepository = cryptoAllowanceRepository;
         this.nftAllowanceRepository = nftAllowanceRepository;
         this.nftRepository = nftRepository;
@@ -136,8 +143,11 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
                 .map(t -> {
                     Long createdTimestamp = entity.getCreatedTimestamp();
                     if (createdTimestamp == null || t >= createdTimestamp) {
+                        long treasuryAccountId = EntityId.of(
+                                        commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+                                .getId();
                         return accountBalanceRepository
-                                .findHistoricalAccountBalanceUpToTimestamp(entity.getId(), t)
+                                .findHistoricalAccountBalanceUpToTimestamp(entity.getId(), t, treasuryAccountId)
                                 .orElse(0L);
                     } else {
                         return 0L;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
@@ -18,8 +17,8 @@ import com.hedera.hapi.node.state.token.AccountFungibleTokenAllowance;
 import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.NftAllowance;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.entity.TokenAllowance;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.repository.AccountBalanceRepository;
@@ -143,8 +142,8 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
                 .map(t -> {
                     Long createdTimestamp = entity.getCreatedTimestamp();
                     if (createdTimestamp == null || t >= createdTimestamp) {
-                        long treasuryAccountId = EntityId.of(
-                                        commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+                        long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                                .getScopedEntityId(commonProperties)
                                 .getId();
                         return accountBalanceRepository
                                 .findHistoricalAccountBalanceUpToTimestamp(entity.getId(), t, treasuryAccountId)

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
 import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toTokenId;
@@ -22,6 +21,7 @@ import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
@@ -141,7 +141,8 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
 
     private Long getTotalSupplyHistorical(boolean isFungible, long tokenId, long timestamp) {
         if (isFungible) {
-            long treasuryAccountId = EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+            long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                    .getScopedEntityId(commonProperties)
                     .getId();
             return tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId, timestamp, treasuryAccountId);
         } else {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVState.java
@@ -2,12 +2,15 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
+import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.services.utils.EntityIdUtils.toEntityId;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.TokenRelation;
+import com.hedera.mirror.common.CommonProperties;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -29,17 +32,21 @@ import java.util.function.Supplier;
 public class TokenRelationshipReadableKVState extends AbstractReadableKVState<EntityIDPair, TokenRelation> {
 
     public static final String KEY = "TOKEN_RELS";
+
+    private final CommonProperties commonProperties;
     private final NftRepository nftRepository;
     private final TokenAccountRepository tokenAccountRepository;
     private final TokenBalanceRepository tokenBalanceRepository;
     private final TokenRepository tokenRepository;
 
     protected TokenRelationshipReadableKVState(
+            final CommonProperties commonProperties,
             final NftRepository nftRepository,
             final TokenAccountRepository tokenAccountRepository,
             final TokenBalanceRepository tokenBalanceRepository,
             final TokenRepository tokenRepository) {
         super(KEY);
+        this.commonProperties = commonProperties;
         this.nftRepository = nftRepository;
         this.tokenAccountRepository = tokenAccountRepository;
         this.tokenBalanceRepository = tokenBalanceRepository;
@@ -112,9 +119,11 @@ public class TokenRelationshipReadableKVState extends AbstractReadableKVState<En
     }
 
     private Long getFungibleBalance(final TokenAccount tokenAccount, final long timestamp) {
+        long treasuryAccountId = EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+                .getId();
         return tokenBalanceRepository
                 .findHistoricalTokenBalanceUpToTimestamp(
-                        tokenAccount.getTokenId(), tokenAccount.getAccountId(), timestamp)
+                        tokenAccount.getTokenId(), tokenAccount.getAccountId(), timestamp, treasuryAccountId)
                 .orElse(0L);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVState.java
@@ -2,7 +2,6 @@
 
 package com.hedera.mirror.web3.state.keyvalue;
 
-import static com.hedera.mirror.common.domain.entity.EntityId.TREASURY_NUM;
 import static com.hedera.services.utils.EntityIdUtils.toEntityId;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -10,7 +9,7 @@ import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.mirror.common.CommonProperties;
-import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -119,7 +118,8 @@ public class TokenRelationshipReadableKVState extends AbstractReadableKVState<En
     }
 
     private Long getFungibleBalance(final TokenAccount tokenAccount, final long timestamp) {
-        long treasuryAccountId = EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), TREASURY_NUM)
+        long treasuryAccountId = SystemEntity.TREASURY_ACCOUNT
+                .getScopedEntityId(commonProperties)
                 .getId();
         return tokenBalanceRepository
                 .findHistoricalTokenBalanceUpToTimestamp(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.AbstractNft;
@@ -120,7 +121,9 @@ class StoreImplTest {
 
     @BeforeEach
     void setup() {
+        final var commonProperties = new CommonProperties();
         final var accountDatabaseAccessor = new AccountDatabaseAccessor(
+                commonProperties,
                 entityDatabaseAccessor,
                 nftAllowanceRepository,
                 nftRepository,
@@ -129,8 +132,14 @@ class StoreImplTest {
                 tokenAccountRepository,
                 accountBalanceRepository);
         final var tokenDatabaseAccessor = new TokenDatabaseAccessor(
-                tokenRepository, entityDatabaseAccessor, entityRepository, customFeeDatabaseAccessor, nftRepository);
+                commonProperties,
+                tokenRepository,
+                entityDatabaseAccessor,
+                entityRepository,
+                customFeeDatabaseAccessor,
+                nftRepository);
         final var tokenRelationshipDatabaseAccessor = new TokenRelationshipDatabaseAccessor(
+                commonProperties,
                 tokenDatabaseAccessor,
                 accountDatabaseAccessor,
                 tokenAccountRepository,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenRelationshipDatabaseAccessorTest.java
@@ -7,7 +7,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.web3.evm.store.accessor.model.TokenRelationshipKey;
@@ -31,6 +33,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TokenRelationshipDatabaseAccessorTest {
+
+    @Mock
+    private CommonProperties commonProperties;
+
     @InjectMocks
     TokenRelationshipDatabaseAccessor tokenRelationshipDatabaseAccessor;
 
@@ -50,6 +56,8 @@ class TokenRelationshipDatabaseAccessorTest {
     private NftRepository nftRepository;
 
     private final DomainBuilder domainBuilder = new DomainBuilder();
+
+    private static final long TREASURY_ACCOUNT_ID = SystemEntity.TREASURY_ACCOUNT.getNum();
 
     private static final Optional<Long> timestamp = Optional.of(1234L);
     private Account account;
@@ -197,7 +205,7 @@ class TokenRelationshipDatabaseAccessorTest {
                         tokenAccount.getAccountId(), tokenAccount.getTokenId(), timestamp.get()))
                 .thenReturn(Optional.of(tokenAccount));
         when(tokenBalanceRepository.findHistoricalTokenBalanceUpToTimestamp(
-                        tokenAccount.getTokenId(), tokenAccount.getAccountId(), timestamp.get()))
+                        tokenAccount.getTokenId(), tokenAccount.getAccountId(), timestamp.get(), TREASURY_ACCOUNT_ID))
                 .thenReturn(Optional.of(balance));
         when(token.getType()).thenReturn(TokenType.FUNGIBLE_COMMON);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
@@ -88,7 +89,8 @@ class HederaEvmStackedWorldStateUpdaterTest {
         final var entityDatabaseAccessor = new EntityDatabaseAccessor(entityRepository);
         final List<DatabaseAccessor<Object, ?>> accessors = List.of(
                 entityDatabaseAccessor,
-                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
+                new AccountDatabaseAccessor(
+                        new CommonProperties(), entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
         store = new StoreImpl(stackedStateFrames, validator);
         subject = new HederaEvmStackedWorldStateUpdater(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
@@ -102,11 +103,18 @@ class HederaEvmWorldStateTest {
 
     @BeforeEach
     void setUp() {
+        var commProperties = new CommonProperties();
         final var accountDatabaseAccessor =
-                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null);
+                new AccountDatabaseAccessor(commProperties, entityDatabaseAccessor, null, null, null, null, null, null);
         final var tokenDatabaseAccessor = new TokenDatabaseAccessor(
-                tokenRepository, entityDatabaseAccessor, entityRepository, customFeeDatabaseAccessor, nftRepository);
+                commProperties,
+                tokenRepository,
+                entityDatabaseAccessor,
+                entityRepository,
+                customFeeDatabaseAccessor,
+                nftRepository);
         final var tokenRelationshipDatabaseAccessor = new TokenRelationshipDatabaseAccessor(
+                commProperties,
                 tokenDatabaseAccessor,
                 accountDatabaseAccessor,
                 tokenAccountRepository,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -125,11 +126,13 @@ class TokenAccessorImplTest {
 
     @BeforeEach
     void setUp() {
+        final var commonProperties = new CommonProperties();
         final var entityAccessor = new EntityDatabaseAccessor(entityRepository);
         final var customFeeAccessor = new CustomFeeDatabaseAccessor(customFeeRepository, entityAccessor);
         final var tokenDatabaseAccessor = new TokenDatabaseAccessor(
-                tokenRepository, entityAccessor, entityRepository, customFeeAccessor, nftRepository);
+                commonProperties, tokenRepository, entityAccessor, entityRepository, customFeeAccessor, nftRepository);
         final var accountDatabaseAccessor = new AccountDatabaseAccessor(
+                commonProperties,
                 entityAccessor,
                 nftAllowanceRepository,
                 nftRepository,
@@ -143,6 +146,7 @@ class TokenAccessorImplTest {
                 accountDatabaseAccessor,
                 tokenDatabaseAccessor,
                 new TokenRelationshipDatabaseAccessor(
+                        commonProperties,
                         tokenDatabaseAccessor,
                         accountDatabaseAccessor,
                         tokenAccountRepository,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenRepositoryTest.java
@@ -5,20 +5,32 @@ package com.hedera.mirror.web3.repository;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @RequiredArgsConstructor
 class TokenRepositoryTest extends Web3IntegrationTest {
 
     private final TokenRepository tokenRepository;
+
+    private CommonProperties commonProperties;
+
+    @BeforeEach
+    void setup() {
+        commonProperties = new CommonProperties();
+    }
 
     @Test
     void findById() {
@@ -122,52 +134,67 @@ class TokenRepositoryTest extends Web3IntegrationTest {
                 .isEmpty();
     }
 
-    @Test
-    void findFungibleTotalSupplyByTokenIdAndTimestamp() {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            1, 5
+            """)
+    void findFungibleTotalSupplyByTokenIdAndTimestamp(long shard, long realm) {
         // given
-        var tokenId = domainBuilder.entityId();
+        var tokenId = EntityId.of(shard, realm, domainBuilder.id());
         long blockTimestamp = domainBuilder.timestamp();
         long snapshotTimestamp = blockTimestamp - Duration.ofMinutes(12).toNanos();
+        commonProperties.setShard(shard);
+        commonProperties.setRealm(realm);
+        var treasuryAccountId = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, EntityId.of(2))))
+                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, treasuryAccountId)))
                 .persist();
         var tokenBalance1 = domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(snapshotTimestamp, domainBuilder.entityId(), tokenId)))
+                .customize(tb -> tb.id(
+                        new TokenBalance.Id(snapshotTimestamp, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
                 .persist();
         var tokenBalance2 = domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(snapshotTimestamp - 1, domainBuilder.entityId(), tokenId)))
+                .customize(tb -> tb.id(new TokenBalance.Id(
+                        snapshotTimestamp - 1, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
                 .persist();
         // a token balance after the block timestamp
         domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(blockTimestamp + 1, domainBuilder.entityId(), tokenId)))
+                .customize(tb -> tb.id(new TokenBalance.Id(
+                        blockTimestamp + 1, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
                 .persist();
         domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 1, tokenId, domainBuilder.entityId()))
+                .customize(tt -> tt.id(new TokenTransfer.Id(
+                                snapshotTimestamp + 1, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
                         .amount(1L))
                 .persist();
         domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 1, tokenId, domainBuilder.entityId()))
+                .customize(tt -> tt.id(new TokenTransfer.Id(
+                                snapshotTimestamp + 1, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
                         .amount(-1L))
                 .persist();
         var tokenMintTransfer1 = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 2, tokenId, domainBuilder.entityId())))
+                .customize(tt -> tt.id(new TokenTransfer.Id(
+                        snapshotTimestamp + 2, tokenId, EntityId.of(shard, realm, domainBuilder.id()))))
                 .persist();
         var tokenBurnTransfer = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 3, tokenId, domainBuilder.entityId()))
+                .customize(tt -> tt.id(new TokenTransfer.Id(
+                                snapshotTimestamp + 3, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
                         .amount(-2L))
                 .persist();
         // A mint transfer at the block timestamp
         var tokenMintTransfer2 = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(blockTimestamp, tokenId, domainBuilder.entityId())))
+                .customize(tt -> tt.id(
+                        new TokenTransfer.Id(blockTimestamp, tokenId, EntityId.of(shard, realm, domainBuilder.id()))))
                 .persist();
 
         // when, then
@@ -176,14 +203,15 @@ class TokenRepositoryTest extends Web3IntegrationTest {
                 + tokenMintTransfer1.getAmount()
                 + tokenBurnTransfer.getAmount()
                 + tokenMintTransfer2.getAmount();
-        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId.getId(), blockTimestamp))
+        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(
+                        tokenId.getId(), blockTimestamp, treasuryAccountId.getId()))
                 .isEqualTo(expectedTotalSupply);
     }
 
     @Test
     void findFungibleTotalSupplyByTokenIdAndTimestampEmpty() {
         assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(
-                        domainBuilder.id(), domainBuilder.timestamp()))
+                        domainBuilder.id(), domainBuilder.timestamp(), SystemEntity.TREASURY_ACCOUNT.getNum()))
                 .isZero();
     }
 
@@ -193,9 +221,10 @@ class TokenRepositoryTest extends Web3IntegrationTest {
         var tokenId = domainBuilder.entityId();
         long blockTimestamp = domainBuilder.timestamp();
         long snapshotTimestamp = blockTimestamp - Duration.ofMinutes(12).toNanos();
+        var treasuryAccountId = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, EntityId.of(2))))
+                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, treasuryAccountId)))
                 .persist();
         domainBuilder
                 .tokenTransfer()
@@ -225,7 +254,8 @@ class TokenRepositoryTest extends Web3IntegrationTest {
         // when, then
         long expectedTotalSupply =
                 tokenMintTransfer1.getAmount() + tokenBurnTransfer.getAmount() + tokenMintTransfer2.getAmount();
-        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId.getId(), blockTimestamp))
+        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(
+                        tokenId.getId(), blockTimestamp, treasuryAccountId.getId()))
                 .isEqualTo(expectedTotalSupply);
     }
 
@@ -235,9 +265,10 @@ class TokenRepositoryTest extends Web3IntegrationTest {
         var tokenId = domainBuilder.entityId();
         long blockTimestamp = domainBuilder.timestamp();
         long snapshotTimestamp = blockTimestamp - Duration.ofMinutes(12).toNanos();
+        var treasuryAccountId = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, EntityId.of(2))))
+                .customize(ab -> ab.id(new AccountBalance.Id(snapshotTimestamp, treasuryAccountId)))
                 .persist();
         var tokenBalance1 = domainBuilder
                 .tokenBalance()
@@ -255,7 +286,8 @@ class TokenRepositoryTest extends Web3IntegrationTest {
 
         // when, then
         long expectedTotalSupply = tokenBalance1.getBalance() + tokenBalance2.getBalance();
-        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId.getId(), blockTimestamp))
+        assertThat(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(
+                        tokenId.getId(), blockTimestamp, treasuryAccountId.getId()))
                 .isEqualTo(expectedTotalSupply);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenRelationshipReadableKVStateTest.java
@@ -13,6 +13,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.token.TokenRelation;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -42,6 +43,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @SuppressWarnings("deprecation")
 class TokenRelationshipReadableKVStateTest {
 
+    private static final AccountID ACCOUNT_ID =
+            AccountID.newBuilder().shardNum(1L).realmNum(2L).accountNum(3L).build();
+    private static final TokenID TOKEN_ID =
+            TokenID.newBuilder().shardNum(4L).realmNum(5L).tokenNum(6L).build();
+    private static final Optional<Long> timestamp = Optional.of(1234L);
+    private static final long ACCOUNT_BALANCE = 3L;
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
+
+    @Mock
+    private CommonProperties commonProperties;
+
     @InjectMocks
     private TokenRelationshipReadableKVState tokenRelationshipReadableKVState;
 
@@ -59,17 +71,6 @@ class TokenRelationshipReadableKVStateTest {
 
     @Spy
     private ContractCallContext contractCallContext;
-
-    private static final AccountID ACCOUNT_ID =
-            AccountID.newBuilder().shardNum(1L).realmNum(2L).accountNum(3L).build();
-    private static final TokenID TOKEN_ID =
-            TokenID.newBuilder().shardNum(4L).realmNum(5L).tokenNum(6L).build();
-
-    private static final Optional<Long> timestamp = Optional.of(1234L);
-
-    private static final long ACCOUNT_BALANCE = 3L;
-
-    private static MockedStatic<ContractCallContext> contextMockedStatic;
 
     private DomainBuilder domainBuilder;
 
@@ -187,7 +188,7 @@ class TokenRelationshipReadableKVStateTest {
         when(tokenRepository.findTypeByTokenId(anyLong())).thenReturn(Optional.of(TokenTypeEnum.FUNGIBLE_COMMON));
         when(tokenAccountRepository.findByIdAndTimestamp(anyLong(), anyLong(), anyLong()))
                 .thenReturn(Optional.of(tokenAccount));
-        when(tokenBalanceRepository.findHistoricalTokenBalanceUpToTimestamp(anyLong(), anyLong(), anyLong()))
+        when(tokenBalanceRepository.findHistoricalTokenBalanceUpToTimestamp(anyLong(), anyLong(), anyLong(), anyLong()))
                 .thenReturn(Optional.of(ACCOUNT_BALANCE));
         assertThat(tokenRelationshipReadableKVState.get(entityIDPair)).isEqualTo(expected);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import com.google.protobuf.ByteString;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.ContextExtension;
@@ -114,8 +115,8 @@ class AutoCreationLogicTest {
 
     @BeforeEach
     void setUp() {
-        final List<DatabaseAccessor<Object, ?>> accessors =
-                List.of(new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
+        final List<DatabaseAccessor<Object, ?>> accessors = List.of(new AccountDatabaseAccessor(
+                new CommonProperties(), entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
         store = spy(new StoreImpl(stackedStateFrames, validator));
         subject = new AutoCreationLogic(feeCalculator, evmProperties, syntheticTxnFactory, aliasManager);


### PR DESCRIPTION
**Description**:

This PR changes modules to use treasury account with the configured shard and realm for snapshot generation and querying.

**Related issue(s)**:

Fixes #10415 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
