### PR TITLE
Fix block stream pathPrefix support

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -110,7 +110,7 @@ public final class S3StreamFileProvider extends AbstractStreamFileProvider {
     protected String getBlockStreamFilePath(long shard, long nodeId, String filename) {
         String filePath = TEMPLATE_BLOCK_STREAM_FILE_PATH.formatted(shard, nodeId, filename);
         return StringUtils.isNotBlank(downloaderProperties.getPathPrefix())
-                ? downloaderProperties.getPathType() + SEPARATOR + filePath
+                ? downloaderProperties.getPathPrefix() + SEPARATOR + filePath
                 : filePath;
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractHip679S3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractHip679S3StreamFileProviderTest.java
@@ -4,28 +4,22 @@ package com.hedera.mirror.importer.downloader.provider;
 
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties.PathType;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 abstract class AbstractHip679S3StreamFileProviderTest extends S3StreamFileProviderTest {
 
-    @SuppressWarnings("java:S2699")
     @Disabled("Doesn't apply to HIP-679")
     @Override
-    @Test
     void getBlockFile() {}
 
-    @SuppressWarnings("java:S2699")
     @Disabled("Doesn't apply to HIP-679")
     @Override
-    @Test
+    void getBlockFileWithPathPrefix() {}
+
+    @Disabled("Doesn't apply to HIP-679")
+    @Override
     void getBlockFileNotFound() {}
 
-    @SuppressWarnings("java:S2699")
     @Disabled("Doesn't apply to HIP-679")
     @Override
-    @ParameterizedTest
-    @EnumSource(PathType.class)
     void getBlockFileIncorrectPathType(PathType pathType) {}
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -138,6 +138,12 @@ abstract class AbstractStreamFileProviderTest {
     }
 
     @Test
+    void getBlockFileWithPathPrefix() {
+        properties.setPathPrefix("prefix");
+        getBlockFile();
+    }
+
+    @Test
     void getBlockFileNotFound() {
         // given
         properties.setPathType(PathType.NODE_ID);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -42,6 +42,12 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
         streamFileProvider = new LocalStreamFileProvider(commonProperties, properties, localProperties);
     }
 
+    @Disabled("PathPrefix not supported")
+    @Override
+    void getBlockFileWithPathPrefix() {
+        // empty
+    }
+
     @Test
     void listAll() {
         var node = node("0.0.3");
@@ -165,18 +171,14 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
                 .verify(Duration.ofSeconds(10L));
     }
 
-    @SuppressWarnings("java:S2699")
     @Disabled("PathPrefix not supported")
     @Override
-    @Test
     void listWithPathPrefix() {
         // empty
     }
 
-    @SuppressWarnings("java:S2699")
     @Disabled("PathPrefix not supported")
     @Override
-    @Test
     void listThenGetWithPathPrefix() {
         // empty
     }


### PR DESCRIPTION
**Description**:

This PR fixes the cloud bucket `pathPrefix` bug when downloading block files.

**Related issue(s)**:

Fixes #10612

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
