### PR TITLE
Fix stack frames not initialized with modularized

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -102,7 +102,7 @@ public abstract class ContractCallService {
         }
 
         // initializes the stack frame with the current state or historical state (if the call is historical)
-        if (!mirrorNodeEvmProperties.isModularizedServices()) {
+        if (!mirrorNodeEvmProperties.isModularizedServices() || !params.isModularized()) {
             ctx.initializeStackFrames(store.getStackedStateFrames());
         }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceUnitTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceUnitTest.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmTxProcessor;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.evm.store.StackedStateFrames;
+import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.service.model.CallServiceParameters;
+import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
+import com.hedera.mirror.web3.throttle.ThrottleProperties;
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
+import io.github.bucket4j.Bucket;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContractCallServiceUnitTest {
+
+    @Mock
+    MirrorEvmTxProcessor mirrorEvmTxProcessor;
+
+    @Mock
+    private Store store;
+
+    @Mock
+    private MirrorNodeEvmProperties mirrorNodeEvmProperties;
+
+    @Mock
+    private CallServiceParameters params;
+
+    @Mock
+    private ContractCallContext ctx;
+
+    @Mock
+    private RecordFileService recordFileService;
+
+    @Mock
+    private StackedStateFrames stackedStateFrames;
+
+    @Mock
+    private Bucket gasLimitBucket;
+
+    @Mock
+    private TransactionExecutionService transactionExecutionService;
+
+    private ContractCallService contractCallService;
+
+    @BeforeEach
+    void setup() {
+        contractCallService = new ContractCallService(
+                mirrorEvmTxProcessor,
+                gasLimitBucket,
+                new ThrottleProperties(),
+                new SimpleMeterRegistry(),
+                recordFileService,
+                store,
+                mirrorNodeEvmProperties,
+                transactionExecutionService) {};
+    }
+
+    @Test
+    void callContractShouldInitializeStackFramesPropertyFalse() throws MirrorEvmTransactionException {
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(false);
+        when(params.getCallType()).thenReturn(CallType.ETH_CALL);
+        when(recordFileService.findByBlockType(any())).thenReturn(Optional.of(new RecordFile()));
+        final var successResult = HederaEvmTransactionProcessingResult.successful(null, 1000, 0, 0, null, Address.ZERO);
+        when(store.getStackedStateFrames()).thenReturn(stackedStateFrames);
+        when(mirrorEvmTxProcessor.execute(any(), anyLong())).thenReturn(successResult);
+
+        contractCallService.callContract(params, ctx);
+        verify(ctx).initializeStackFrames(stackedStateFrames);
+    }
+
+    @Test
+    void callContractShouldInitializeStackFramesPropertyTrueTrafficFalse() throws MirrorEvmTransactionException {
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        when(params.isModularized()).thenReturn(false);
+        when(params.getCallType()).thenReturn(CallType.ETH_CALL);
+        when(recordFileService.findByBlockType(any())).thenReturn(Optional.of(new RecordFile()));
+        final var successResult = HederaEvmTransactionProcessingResult.successful(null, 1000, 0, 0, null, Address.ZERO);
+        when(store.getStackedStateFrames()).thenReturn(stackedStateFrames);
+        when(mirrorEvmTxProcessor.execute(any(), anyLong())).thenReturn(successResult);
+
+        contractCallService.callContract(params, ctx);
+        verify(ctx).initializeStackFrames(stackedStateFrames);
+    }
+
+    @Test
+    void callContractShouldInitializeStackFramesPropertyTrueTrafficTrue() throws MirrorEvmTransactionException {
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        when(params.isModularized()).thenReturn(true);
+        when(params.getCallType()).thenReturn(CallType.ETH_CALL);
+        when(recordFileService.findByBlockType(any())).thenReturn(Optional.of(new RecordFile()));
+        final var successResult = HederaEvmTransactionProcessingResult.successful(null, 1000, 0, 0, null, Address.ZERO);
+        when(transactionExecutionService.execute(any(), anyLong(), any())).thenReturn(successResult);
+
+        contractCallService.callContract(params, ctx);
+        verify(ctx, never()).initializeStackFrames(any());
+    }
+}


### PR DESCRIPTION
When running with modularized logic but traffic still has to be split to go through mono we missed to check the params modularized flag to see if we need to initialize stack frames for running mono logic and calls start to fail.  

This pr adjusts the if statement where we initialize the stacked frames initialization based on the modularized flags.

**Related issue(s)**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
