### PR TITLE
Add metrics and logging for transaction traffic split

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -73,7 +73,12 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     private ResponseEntity<?> mirrorEvmTransactionError(final MirrorEvmTransactionException e, WebRequest request) {
-        log.warn("Mirror EVM transaction error: {}, detail: {}, data: {}", e.getMessage(), e.getDetail(), e.getData());
+        log.warn(
+                "Mirror EVM transaction error: {}, detail: {}, data: {}, isCallModularized: {}",
+                e.getMessage(),
+                e.getDetail(),
+                e.getData(),
+                e.getIsCallModularized());
         request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, e, SCOPE_REQUEST);
         return new ResponseEntity<>(new GenericErrorResponse(e.getMessage(), e.getDetail(), e.getData()), BAD_REQUEST);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -347,7 +347,8 @@ public class MirrorNodeEvmProperties implements EvmProperties {
      * @return true if the random value between 0 and 1 is less than modularizedTrafficPercent
      */
     public boolean directTrafficThroughTransactionExecutionService() {
-        return RandomUtils.secure().randomDouble(0.0d, 1.0d) < getModularizedTrafficPercent();
+        return isModularizedServices()
+                && RandomUtils.secure().randomDouble(0.0d, 1.0d) < getModularizedTrafficPercent();
     }
 
     @Getter

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -23,15 +23,21 @@ public class MirrorEvmTransactionException extends EvmException {
 
     private final String detail;
     private final String data;
+    private Boolean isCallModularized;
     private final transient HederaEvmTransactionProcessingResult result;
 
     public MirrorEvmTransactionException(
             final ResponseCodeEnum responseCode, final String detail, final String hexData) {
-        this(responseCode.name(), detail, hexData, null);
+        this(responseCode.name(), detail, hexData, null, null);
     }
 
     public MirrorEvmTransactionException(final String message, final String detail, final String hexData) {
-        this(message, detail, hexData, null);
+        this(message, detail, hexData, null, null);
+    }
+
+    public MirrorEvmTransactionException(
+            final String message, final String detail, final String hexData, Boolean isCallModularized) {
+        this(message, detail, hexData, null, isCallModularized);
     }
 
     public MirrorEvmTransactionException(
@@ -42,6 +48,19 @@ public class MirrorEvmTransactionException extends EvmException {
         super(message);
         this.detail = detail;
         this.data = hexData;
+        this.result = result;
+    }
+
+    public MirrorEvmTransactionException(
+            final String message,
+            final String detail,
+            final String hexData,
+            HederaEvmTransactionProcessingResult result,
+            final Boolean isCallModularized) {
+        super(message);
+        this.detail = detail;
+        this.data = hexData;
+        this.isCallModularized = isCallModularized;
         this.result = result;
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractDebugService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractDebugService.java
@@ -61,15 +61,16 @@ public class ContractDebugService extends ContractCallService {
             ctx.setContractActions(contractActionRepository.findFailedSystemActionsByConsensusTimestamp(
                     params.getConsensusTimestamp()));
             final var ethCallTxnResult = callContract(params, ctx);
-            validateResult(ethCallTxnResult, params.getCallType());
+            validateResult(ethCallTxnResult, params.getCallType(), params.isModularized());
             return new OpcodesProcessingResult(ethCallTxnResult, ctx.getOpcodes());
         });
     }
 
     @Override
-    protected void validateResult(final HederaEvmTransactionProcessingResult txnResult, final CallType type) {
+    protected void validateResult(
+            final HederaEvmTransactionProcessingResult txnResult, final CallType type, boolean modularized) {
         try {
-            super.validateResult(txnResult, type);
+            super.validateResult(txnResult, type, modularized);
         } catch (MirrorEvmTransactionException e) {
             log.warn(
                     "Transaction failed with status: {}, detail: {}, revertReason: {}",

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
@@ -54,8 +54,7 @@ public class ContractExecutionService extends ContractCallService {
             var stringResult = "";
 
             try {
-                updateGasLimitMetric(params.getCallType(), params.getGas());
-                updateModularizedCounter(params.isModularized());
+                updateGasLimitMetric(params.getCallType(), params.getGas(), params.isModularized());
 
                 Bytes result;
                 if (params.isEstimate()) {
@@ -87,7 +86,7 @@ public class ContractExecutionService extends ContractCallService {
      */
     private Bytes estimateGas(final ContractExecutionParameters params, final ContractCallContext context) {
         final var processingResult = callContract(params, context);
-        validateResult(processingResult, CallType.ETH_ESTIMATE_GAS);
+        validateResult(processingResult, CallType.ETH_ESTIMATE_GAS, params.isModularized());
 
         final var gasUsedByInitialCall = processingResult.getGasUsed();
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
@@ -55,6 +55,7 @@ public class ContractExecutionService extends ContractCallService {
 
             try {
                 updateGasLimitMetric(params.getCallType(), params.getGas());
+                updateModularizedCounter(params.isModularized());
 
                 Bytes result;
                 if (params.isEstimate()) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
@@ -126,7 +126,7 @@ public class TransactionExecutionService {
         if (result == null) {
             // No result - the call did not reach the EVM and probably failed at pre-checks. No metric to update in this
             // case.
-            throw new MirrorEvmTransactionException(status.protoName(), StringUtils.EMPTY, StringUtils.EMPTY);
+            throw new MirrorEvmTransactionException(status.protoName(), StringUtils.EMPTY, StringUtils.EMPTY, true);
         } else {
             var errorMessage = getErrorMessage(result).orElse(Bytes.EMPTY);
             var detail = maybeDecodeSolidityErrorStringToReadableMessage(errorMessage);
@@ -137,7 +137,8 @@ public class TransactionExecutionService {
                         detail,
                         errorMessage.toHexString(),
                         HederaEvmTransactionProcessingResult.failed(
-                                result.gasUsed(), 0L, 0L, Optional.of(errorMessage), Optional.empty()));
+                                result.gasUsed(), 0L, 0L, Optional.of(errorMessage), Optional.empty()),
+                        true);
             } else {
                 // If we are in an opcode trace scenario, we need to return a failed result in order to get the
                 // opcode list from the ContractCallContext. If we throw an exception instead of returning a result,

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
@@ -35,6 +35,7 @@ public interface CallServiceParameters {
         ETH_CALL,
         ETH_DEBUG_TRACE_TRANSACTION,
         ETH_ESTIMATE_GAS,
-        ERROR
+        ERROR,
+        IS_MODULARIZED,
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
@@ -35,7 +35,6 @@ public interface CallServiceParameters {
         ETH_CALL,
         ETH_DEBUG_TRACE_TRANSACTION,
         ETH_ESTIMATE_GAS,
-        ERROR,
-        IS_MODULARIZED,
+        ERROR
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
@@ -70,6 +70,7 @@ abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContr
     @BeforeEach
     void setUpArgumentCaptors() {
         if (!mirrorNodeEvmProperties.isModularizedServices()) {
+            mirrorNodeEvmProperties.setModularizedTrafficPercent(0.0);
             doAnswer(invocation -> {
                         final var transactionProcessingResult =
                                 (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
@@ -80,6 +81,7 @@ abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContr
                     .when(processor)
                     .execute(paramsCaptor.capture(), gasCaptor.capture());
         } else {
+            mirrorNodeEvmProperties.setModularizedTrafficPercent(1.0);
             doAnswer(invocation -> {
                         final var transactionProcessingResult =
                                 (HederaEvmTransactionProcessingResult) invocation.callRealMethod();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -121,6 +121,8 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         modularizedTrafficPercent = mirrorNodeEvmProperties.getModularizedTrafficPercent();
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             mirrorNodeEvmProperties.setModularizedTrafficPercent(1.0);
+        } else {
+            mirrorNodeEvmProperties.setModularizedTrafficPercent(0.0);
         }
 
         genesisRecordFile =

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -1157,10 +1157,22 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         void testDirectTrafficThroughTransactionExecutionService() {
             MirrorNodeEvmProperties spyEvmProperties = spy(mirrorNodeEvmProperties);
 
+            when(spyEvmProperties.isModularizedServices()).thenReturn(true);
             when(spyEvmProperties.getModularizedTrafficPercent()).thenReturn(1.0);
             assertThat(spyEvmProperties.directTrafficThroughTransactionExecutionService())
                     .isTrue();
 
+            when(spyEvmProperties.isModularizedServices()).thenReturn(true);
+            when(spyEvmProperties.getModularizedTrafficPercent()).thenReturn(0.0);
+            assertThat(spyEvmProperties.directTrafficThroughTransactionExecutionService())
+                    .isFalse();
+
+            when(spyEvmProperties.isModularizedServices()).thenReturn(false);
+            when(spyEvmProperties.getModularizedTrafficPercent()).thenReturn(1.0);
+            assertThat(spyEvmProperties.directTrafficThroughTransactionExecutionService())
+                    .isFalse();
+
+            when(spyEvmProperties.isModularizedServices()).thenReturn(false);
             when(spyEvmProperties.getModularizedTrafficPercent()).thenReturn(0.0);
             assertThat(spyEvmProperties.directTrafficThroughTransactionExecutionService())
                     .isFalse();


### PR DESCRIPTION
**Description**:
After implementing the gradual rollout for the modularized transaction execution (https://github.com/hiero-ledger/hiero-mirror-node/issues/10366) we have to create metrics which will allow us to track which service the transactions go through by inspecting the logs and grafana dashboards.

Solution
Use micrometer lib to log data to grafana.
Update MirrorEvmTransactionException to return data if the transaction is modularized.

**Related issue(s)**:

Fixes #10621 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
