### PR TITLE
Support non-zero realms in gRPC API

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/SystemEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/SystemEntity.java
@@ -9,9 +9,11 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum SystemEntity {
-    FEE_COLLECTOR(98),
-    STAKING_REWARD_ACCOUNT(800),
-    NODE_REWARD_ACCOUNT(801);
+    ADDRESS_BOOK_101(101L),
+    ADDRESS_BOOK_102(102L),
+    FEE_COLLECTOR(98L),
+    STAKING_REWARD_ACCOUNT(800L),
+    NODE_REWARD_ACCOUNT(801L);
 
     private final long num;
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
@@ -2,6 +2,7 @@
 
 package com.hedera.mirror.grpc.domain;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -31,6 +32,11 @@ import reactor.core.publisher.Mono;
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class ReactiveDomainBuilder {
 
+    public static final EntityId TOPIC_ID = EntityId.of(
+            CommonProperties.getInstance().getShard(),
+            CommonProperties.getInstance().getRealm(),
+            100L);
+
     private final long now = DomainUtils.now();
     private final EntityRepository entityRepository;
     private final TopicMessageRepository topicMessageRepository;
@@ -50,7 +56,11 @@ public class ReactiveDomainBuilder {
     public Mono<Entity> entity(Consumer<Entity.EntityBuilder<?, ?>> customizer) {
         Entity entity = domainBuilder
                 .entity()
-                .customize(e -> e.id(100L).type(EntityType.TOPIC))
+                .customize(e -> e.id(TOPIC_ID.getId())
+                        .num(TOPIC_ID.getNum())
+                        .realm(TOPIC_ID.getRealm())
+                        .shard(TOPIC_ID.getShard())
+                        .type(EntityType.TOPIC))
                 .customize(customizer)
                 .get();
         return insert(entity).thenReturn(entity);
@@ -72,7 +82,7 @@ public class ReactiveDomainBuilder {
                 .topicMessage()
                 .customize(e -> e.consensusTimestamp(now + sequenceNumber)
                         .sequenceNumber(++sequenceNumber)
-                        .topicId(EntityId.of(100L)))
+                        .topicId(TOPIC_ID))
                 .customize(customizer)
                 .get();
         return insert(topicMessage)

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
@@ -2,6 +2,8 @@
 
 package com.hedera.mirror.grpc.retriever;
 
+import static com.hedera.mirror.grpc.domain.ReactiveDomainBuilder.TOPIC_ID;
+
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
 import com.hedera.mirror.common.util.DomainUtils;
@@ -22,7 +24,6 @@ import reactor.test.StepVerifier;
 @RequiredArgsConstructor
 class PollingTopicMessageRetrieverTest extends GrpcIntegrationTest {
 
-    private static final EntityId TOPIC_ID = EntityId.of(100L);
     private static final Duration WAIT = Duration.ofSeconds(10L);
 
     private final ReactiveDomainBuilder domainBuilder;


### PR DESCRIPTION
**Description**:

* Add address book entries to `SystemEntity`
* Fix validation of `fileId` parameter in `NetworkService.getNodes()`
* Some test cleanup to use modern standards and use a common topic ID

**Related issue(s)**:

Fixes #10629

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
