### PR TITLE
Adapt web3 k6 estimate tests to work with environment variables

### DIFF
--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -118,7 +118,7 @@ The following parameters can be used to configure a rosetta test:
 The following parameters can be used to configure a web3 test:
 
 | Name                                                          | Default | Description                                                                                                                                     |
-|---------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | ACCOUNT_ADDRESS                                               |         | 64 character hex encoded account address without `0x` prefix                                                                                    |
 | AMOUNT                                                        |         | 64 character hex encoded amount without `0x` prefix                                                                                             |
 | ASSOCIATED_ACCOUNT                                            |         | 64 character hex encoded account evm address without `0x` prefix - associated to TOKEN_ADDRESS and NON_FUNGIBLE_TOKEN_ADDRESS                   |
@@ -126,7 +126,7 @@ The following parameters can be used to configure a web3 test:
 | DEFAULT_CONTRACT_ADDRESS                                      |         | 40 character hex encoded contract address without `0x` prefix for `Parent.sol`                                                                  |
 | ERC_CONTRACT_ADDRESS                                          |         | 40 character hex encoded contract address without `0x` prefix for `ErcTestContract.sol`                                                         |
 | ESTIMATE_PRECOMPILE_CONTRACT                                  |         | 40 character hex encoded contract address without `0x` prefix for `EstimatePrecompileContract.sol`                                              |
-| FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS                        |         | 64 character hex encoded fungible token address without `0x` prefix - with a freeze key set                                                     |                                                                   |
+| FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS                        |         | 64 character hex encoded fungible token address without `0x` prefix - with a freeze key set                                                     |
 | FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS     |         | 64 character hex encoded account evm address without `0x` prefix - an account associated to FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS              |
 | HTS_CONTRACT_ADDRESS                                          |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol`                                                  |
 | KEY_TYPE                                                      |         | 64 character hex encoded key type without `0x` prefix                                                                                           |

--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -117,27 +117,33 @@ The following parameters can be used to configure a rosetta test:
 
 The following parameters can be used to configure a web3 test:
 
-| Name                         | Default | Description                                                                                        |
-| ---------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| ACCOUNT_ADDRESS              |         | 64 character hex encoded account address without `0x` prefix                                       |
-| AMOUNT                       |         | 64 character hex encoded amount without `0x` prefix                                                |
-| DEFAULT_ACCOUNT_ADDRESS      |         | 40 character hex encoded account address without `0x` prefix                                       |
-| DEFAULT_CONTRACT_ADDRESS     |         | 40 character hex encoded contract address without `0x` prefix for `Parent.sol`                     |
-| ERC_CONTRACT_ADDRESS         |         | 40 character hex encoded contract address without `0x` prefix for `ErcTestContract.sol`            |
-| ESTIMATE_PRECOMPILE_CONTRACT |         | 40 character hex encoded contract address without `0x` prefix for `EstimatePrecompileContract.sol` |
-| HTS_CONTRACT_ADDRESS         |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol`     |
-| KEY_TYPE                     |         | 64 character hex encoded key type without `0x` prefix                                              |
-| NON_FUNGIBLE_TOKEN_ADDRESS   |         | 64 character hex encoded non-fungible token address without `0x` prefix                            |
-| PRECOMPILE_CONTRACT          |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol`     |
-| RECEIVER_ADDRESS             |         | 64 character hex encoded account address without `0x` prefix - associated account                  |
-| RUN_ESTIMATE_TESTS           | true    | If set to true, estimate gas tests will be run.                                                    |
-| RUN_MODIFICATION_TESTS       | true    | If set to true, modification tests will be run.                                                    |
-| RUN_WITH_VARIABLES           | true    | if set to false, tests will be run with data from modificationFunctions.json                       |
-| SERIAL_NUMBER                |         | 64 character hex encoded nft serial number without `0x` prefix                                     |
-| SPENDER_ADDRESS              |         | 64 character hex encoded account address without `0x` prefix                                       |
-| TOKEN_ADDRESS                |         | 64 character hex encoded token address without `0x` prefix                                         |
-| WEB3_TEST_EXCLUDE            | ^$      | The web3 test scenarios to exclude                                                                 |
-| WEB3_TEST_INCLUDE            | .\*     | The web3 test scenarios to include                                                                 |
+| Name                                                          | Default | Description                                                                                                                                     |
+|---------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACCOUNT_ADDRESS                                               |         | 64 character hex encoded account address without `0x` prefix                                                                                    |
+| AMOUNT                                                        |         | 64 character hex encoded amount without `0x` prefix                                                                                             |
+| ASSOCIATED_ACCOUNT                                            |         | 64 character hex encoded account evm address without `0x` prefix - associated to TOKEN_ADDRESS and NON_FUNGIBLE_TOKEN_ADDRESS                   |
+| DEFAULT_ACCOUNT_ADDRESS                                       |         | 40 character hex encoded account address without `0x` prefix                                                                                    |
+| DEFAULT_CONTRACT_ADDRESS                                      |         | 40 character hex encoded contract address without `0x` prefix for `Parent.sol`                                                                  |
+| ERC_CONTRACT_ADDRESS                                          |         | 40 character hex encoded contract address without `0x` prefix for `ErcTestContract.sol`                                                         |
+| ESTIMATE_PRECOMPILE_CONTRACT                                  |         | 40 character hex encoded contract address without `0x` prefix for `EstimatePrecompileContract.sol`                                              |
+| FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS                        |         | 64 character hex encoded fungible token address without `0x` prefix - with a freeze key set                                                     |                                                                   |
+| FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS     |         | 64 character hex encoded account evm address without `0x` prefix - an account associated to FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS              |
+| HTS_CONTRACT_ADDRESS                                          |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol`                                                  |
+| KEY_TYPE                                                      |         | 64 character hex encoded key type without `0x` prefix                                                                                           |
+| NON_FUNGIBLE_TOKEN_ADDRESS                                    |         | 64 character hex encoded non-fungible token address without `0x` prefix                                                                         |
+| NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS                    |         | 64 character hex encoded non-fungible token address without `0x` prefix - with a freeze key set                                                 |
+| NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS |         | 64 character hex encoded account evm address without `0x` prefix - an account associated to NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS          |
+| PAYER_ACCOUNT                                                 |         | 40 character hex encoded account address without `0x` prefix - with a lot of balance that can be used for costy operations such as token create |
+| PRECOMPILE_CONTRACT                                           |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol`                                                  |
+| RECEIVER_ADDRESS                                              |         | 64 character hex encoded account evm address without `0x` prefix - associated account                                                           |
+| RUN_ESTIMATE_TESTS                                            | true    | If set to true, estimate gas tests will be run.                                                                                                 |
+| RUN_MODIFICATION_TESTS                                        | true    | If set to true, modification tests will be run.                                                                                                 |
+| RUN_WITH_VARIABLES                                            | true    | if set to false, tests will be run with data from modificationFunctions.json                                                                    |
+| SERIAL_NUMBER                                                 |         | 64 character hex encoded nft serial number without `0x` prefix                                                                                  |
+| SPENDER_ADDRESS                                               |         | 64 character hex encoded account address without `0x` prefix                                                                                    |
+| TOKEN_ADDRESS                                                 |         | 64 character hex encoded token address without `0x` prefix                                                                                      |
+| WEB3_TEST_EXCLUDE                                             | ^$      | The web3 test scenarios to exclude                                                                                                              |
+| WEB3_TEST_INCLUDE                                             | .\*     | The web3 test scenarios to include                                                                                                              |
 
 For k6 to be run we need to deploy the relevant contracts in `hedera-mirror-test/src/test/resources/solidity` first. For
 that, we can use Hedera SDK. Example for ERC_CONTRACT deployment

--- a/hedera-mirror-test/k6/src/web3/test/common.js
+++ b/hedera-mirror-test/k6/src/web3/test/common.js
@@ -57,6 +57,8 @@ function ContractCallTestScenarioBuilder() {
         const payload = {
           to: that._to,
           estimate: that._estimate || false, // Set default to false
+          value: that._value,
+          from: that._from,
         };
 
         if (that._selector && that._args) {
@@ -160,6 +162,11 @@ function ContractCallTestScenarioBuilder() {
 
   this.shouldRevert = function (shouldRevert) {
     this._shouldRevert = shouldRevert;
+    return this;
+  };
+
+  this.estimate = function (estimate) {
+    this._estimate = estimate;
     return this;
   };
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallApproved.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallApproved.js
@@ -4,13 +4,13 @@ import {ContractCallTestScenarioBuilder} from './common.js';
 
 const contract = __ENV.ERC_CONTRACT_ADDRESS;
 const selector = '0x098f2366';
-const token = __ENV.TOKEN_ADDRESS;
-const account = __ENV.ACCOUNT_ADDRESS;
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
+const serialNumber = __ENV.SERIAL_NUMBER;
 
 const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallApproved') // use unique scenario name among all tests
   .selector(selector)
-  .args([token, account])
+  .args([token, serialNumber])
   .to(contract)
   .build();
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallApprovedForAll.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallApprovedForAll.js
@@ -4,7 +4,7 @@ import {ContractCallTestScenarioBuilder} from './common.js';
 
 const contract = __ENV.ERC_CONTRACT_ADDRESS;
 const selector = '0xf49f40db';
-const token = __ENV.TOKEN_ADDRESS;
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
 const account = __ENV.ACCOUNT_ADDRESS;
 const spender = __ENV.SPENDER_ADDRESS;
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApprove.js
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateApprove');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const selector = '0xceda64c4'; //approveExternal
+const token = __ENV.TOKEN_ADDRESS;
+const spender = __ENV.SPENDER_ADDRESS;
+const amount = __ENV.AMOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateApprove';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, spender, amount])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApprove.js
@@ -21,7 +21,6 @@ const {options, run} =
         .args([token, spender, amount])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApproveNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApproveNft.js
@@ -21,7 +21,6 @@ const {options, run} =
         .args([token, spender, serialNumber])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApproveNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateApproveNft.js
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateApproveNft');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const selector = '0x84d232f5'; //approveNFTExternal
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
+const spender = __ENV.SPENDER_ADDRESS;
+const serialNumber = __ENV.SERIAL_NUMBER;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateApproveNft';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, spender, serialNumber])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateAssociateTokens');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.SPENDER_ADDRESS;
+const token = __ENV.TOKEN_ADDRESS;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0xd91cfc95'; //associateTokenExternal
+const testName = 'estimateAssociateToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([account, token])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([account, token])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateFungibleToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateFungibleToken.js
@@ -21,7 +21,6 @@ const {options, run} =
         .to(contract)
         .from(from)
         .estimate(true)
-        .gas(15000000)
         .value(3000000000)
         .build();
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateFungibleToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateFungibleToken.js
@@ -1,5 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateCreateFungibleToken');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const treasury = __ENV.ACCOUNT_ADDRESS;
+const from = __ENV.PAYER_ACCOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x4b5c6687'; //createFungibleTokenPublic
+const testName = 'estimateCreateFungibleToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([treasury])
+        .to(contract)
+        .from(from)
+        .estimate(true)
+        .gas(15000000)
+        .value(3000000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateNft.js
@@ -21,7 +21,6 @@ const {options, run} =
         .to(contract)
         .from(from)
         .estimate(true)
-        .gas(15000000)
         .value(3000000000)
         .build();
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateCreateNft.js
@@ -1,5 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateCreateNFT');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const treasury = __ENV.ACCOUNT_ADDRESS;
+const from = __ENV.PAYER_ACCOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0xd85f74c1'; //createNonFungibleTokenPublic
+const testName = 'estimateCreateNFT';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([treasury])
+        .to(contract)
+        .from(from)
+        .estimate(true)
+        .gas(15000000)
+        .value(3000000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
@@ -4,11 +4,11 @@ import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
-const account = __ENV.ASSOCIATED_ACCOUNT;
-const token = __ENV.TOKEN_ADDRESS;
-const selector = '0x9c219247'; //dissociateTokenExternal
+const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS; // TODO: find out how to pass an array
+const selector = '0x2390c1fa'; //dissociateTokensExternal
 const runMode = __ENV.RUN_WITH_VARIABLES;
-const testName = 'estimateDissociateToken';
+const testName = 'estimateDissociateTokens';
 
 //If RUN_WITH_VARIABLES=true will run tests with __ENV variables
 const {options, run} =

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateDissociateTokens');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.ASSOCIATED_ACCOUNT;
+const token = __ENV.TOKEN_ADDRESS;
+const selector = '0x9c219247'; //dissociateTokenExternal
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateDissociateToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([account, token])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([account, token])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateDissociateTokens.js
@@ -5,7 +5,7 @@ import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemp
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
 const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
-const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS; // TODO: find out how to pass an array
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
 const selector = '0x2390c1fa'; //dissociateTokensExternal
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'estimateDissociateTokens';

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateERCApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateERCApprove.js
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateERCApprove');
+
+const contract = __ENV.ERC_CONTRACT_ADDRESS;
+const selector = '0xe1f21c67'; //approve
+const token = __ENV.TOKEN_ADDRESS;
+const spender = __ENV.SPENDER_ADDRESS;
+const amount = __ENV.AMOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateERCApprove';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, spender, amount])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateERCApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateERCApprove.js
@@ -21,7 +21,6 @@ const {options, run} =
         .args([token, spender, amount])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeNft.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateFreezeNft');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x9333700b'; //freezeTokenExternal
+const testName = 'estimateFreezeNft';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, account])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeNft.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([token, account])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeToken.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([token, account])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFreezeToken.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateFreezeToken');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0xe95a71e5'; //unfreezeTokenExternal
+const testName = 'estimateFreezeToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, account])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFungibleTokenCustomFees.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFungibleTokenCustomFees.js
@@ -1,5 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateCreateFungibleTokenWithCustomFees');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const treasury = __ENV.ACCOUNT_ADDRESS;
+const token = __ENV.TOKEN_ADDRESS;
+const from = __ENV.PAYER_ACCOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x8ba74da0'; //createFungibleTokenWithCustomFeesPublic
+const testName = 'estimateCreateFungibleTokenWithCustomFees';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([treasury, token])
+        .to(contract)
+        .from(from)
+        .estimate(true)
+        .gas(15000000)
+        .value(5000000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFungibleTokenCustomFees.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateFungibleTokenCustomFees.js
@@ -22,7 +22,6 @@ const {options, run} =
         .to(contract)
         .from(from)
         .estimate(true)
-        .gas(15000000)
         .value(5000000000)
         .build();
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateMintNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateMintNft.js
@@ -26,7 +26,6 @@ const {options, run} =
         .args([token, amount, metadata])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateMintNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateMintNft.js
@@ -1,5 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateMintNft');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
+const amount = '0000000000000000000000000000000000000000000000000000000000000000';
+const metadata =
+  '0000000000000000000000000000000000000000000000000000000000000060' +
+  '0000000000000000000000000000000000000000000000000000000000000001' +
+  '0000000000000000000000000000000000000000000000000000000000000020' +
+  '000000000000000000000000000000000000000000000000000000000000000c' +
+  'eee8fa2d815e9d9c0d2505ab0000000000000000000000000000000000000000';
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x0c0295d4'; //mintTokenExternal
+const testName = 'estimateMintNft';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, amount, metadata])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateNftCustomFees.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateNftCustomFees.js
@@ -22,7 +22,6 @@ const {options, run} =
         .to(contract)
         .from(from)
         .estimate(true)
-        .gas(15000000)
         .value(5000000000)
         .build();
 

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateNftCustomFees.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateNftCustomFees.js
@@ -1,5 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateCreateNFTWithCustomFees');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const treasury = __ENV.ACCOUNT_ADDRESS;
+const token = __ENV.TOKEN_ADDRESS;
+const from = __ENV.PAYER_ACCOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x0488c939'; //createNonFungibleTokenWithCustomFeesPublic
+const testName = 'estimateCreateNFTWithCustomFees';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([treasury, token])
+        .to(contract)
+        .from(from)
+        .estimate(true)
+        .gas(15000000)
+        .value(5000000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateSetApprovalForAll.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateSetApprovalForAll.js
@@ -21,7 +21,6 @@ const {options, run} =
         .args([token, account, trueValue])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateSetApprovalForAll.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateSetApprovalForAll.js
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateSetApprovalForAll');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const selector = '0xe31b839c'; //setApprovalForAllExternal
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
+const account = __ENV.ACCOUNT_ADDRESS;
+const trueValue = __ENV.AMOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateSetApprovalForAll';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, account, trueValue])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
@@ -4,8 +4,8 @@ import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
-const account = __ENV.ASSOCIATED_ACCOUNT;
-const token = __ENV.TOKEN_ADDRESS;
+const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
 const selector = '0x9c219247'; //dissociateTokenExternal
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'estimateTokenDissociate';

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([account, token])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTokenDissociate.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateTokenDissociate');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.ASSOCIATED_ACCOUNT;
+const token = __ENV.TOKEN_ADDRESS;
+const selector = '0x9c219247'; //dissociateTokenExternal
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const testName = 'estimateTokenDissociate';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([account, token])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTransferNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTransferNft.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateTransferNft');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const sender = __ENV.ACCOUNT_ADDRESS;
+const receiver = __ENV.ASSOCIATED_ACCOUNT;
+const token = __ENV.NON_FUNGIBLE_TOKEN_ADDRESS;
+const amount = __ENV.AMOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0xbafa6a91'; //transferNFTExternal
+const testName = 'estimateTransferNft';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, sender, receiver, amount])
+        .to(contract)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTransferToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateTransferToken.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateTransferToken');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const sender = __ENV.ACCOUNT_ADDRESS;
+const receiver = __ENV.ASSOCIATED_ACCOUNT;
+const token = __ENV.TOKEN_ADDRESS;
+const amount = __ENV.AMOUNT;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x4fd6ce0a'; //transferTokenExternal
+const testName = 'estimateTransferToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, sender, receiver, amount])
+        .to(contract)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeNft.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([token, account])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeNft.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeNft.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateUnfreezeNft');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.NON_FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0xe95a71e5'; //unfreezeTokenExternal
+const testName = 'estimateUnfreezeNft';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, account])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeToken.js
@@ -20,7 +20,6 @@ const {options, run} =
         .args([token, account])
         .to(contract)
         .estimate(true)
-        .gas(15000000)
         .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateUnfreezeToken.js
@@ -1,5 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import {ContractCallTestScenarioBuilder} from './common.js';
 import {ContractCallEstimateTestTemplate} from './commonContractCallEstimateTemplate.js';
-const {options, run} = new ContractCallEstimateTestTemplate('estimateUnfreezeToken');
+
+const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
+const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
+const runMode = __ENV.RUN_WITH_VARIABLES;
+const selector = '0x9333700b'; //freezeTokenExternal
+const testName = 'estimateUnfreezeToken';
+
+//If RUN_WITH_VARIABLES=true will run tests with __ENV variables
+const {options, run} =
+  runMode === 'false'
+    ? new ContractCallEstimateTestTemplate(testName, false)
+    : new ContractCallTestScenarioBuilder()
+        .name(testName) // use unique scenario name among all tests
+        .selector(selector)
+        .args([token, account])
+        .to(contract)
+        .estimate(true)
+        .gas(15000000)
+        .build();
+
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallReceive.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallReceive.js
@@ -3,12 +3,13 @@
 import {ContractCallTestScenarioBuilder} from './common.js';
 
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
-const account = __ENV.DEFAULT_ACCOUNT_ADDRESS;
+const account = __ENV.PAYER_ACCOUNT;
 
 const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallReceive') // use unique scenario name among all tests
   .from(account)
   .to(contract)
+  .value(10)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileApprove.js
@@ -6,7 +6,7 @@ import {PrecompileModificationTestTemplate} from '../commonPrecompileModificatio
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
 const selector = '0xceda64c4'; //approveExternal
 const token = __ENV.TOKEN_ADDRESS;
-const spender = __ENV.RECEIVER_ADDRESS;
+const spender = __ENV.ACCOUNT_ADDRESS;
 const amount = __ENV.AMOUNT;
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'contractCallPrecompileApprove';

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileCryptoTransferToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileCryptoTransferToken.js
@@ -6,7 +6,7 @@ import {PrecompileModificationTestTemplate} from '../commonPrecompileModificatio
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
 const selector = '0xa6218810'; //cryptoTransferExternal
 const sender = __ENV.ACCOUNT_ADDRESS;
-const receiver = __ENV.RECEIVER_ADDRESS;
+const receiver = __ENV.ASSOCIATED_ACCOUNT;
 const token = __ENV.TOKEN_ADDRESS;
 const runMode = __ENV.RUN_WITH_VARIABLES;
 //ABI encoded parameters used for crypto transfer token

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileDissociate.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileDissociate.js
@@ -4,8 +4,8 @@ import {ContractCallTestScenarioBuilder} from '../common.js';
 import {PrecompileModificationTestTemplate} from '../commonPrecompileModificationFunctionsTemplate.js';
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
-const account = __ENV.ASSOCIATED_ACCOUNT;
-const token = __ENV.TOKEN_ADDRESS;
+const account = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
 const selector = '0x9c219247'; //dissociateTokenExternal
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'contractCallPrecompileDissociate';

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileDissociate.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileDissociate.js
@@ -4,7 +4,7 @@ import {ContractCallTestScenarioBuilder} from '../common.js';
 import {PrecompileModificationTestTemplate} from '../commonPrecompileModificationFunctionsTemplate.js';
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
-const account = __ENV.RECEIVER_ADDRESS;
+const account = __ENV.ASSOCIATED_ACCOUNT;
 const token = __ENV.TOKEN_ADDRESS;
 const selector = '0x9c219247'; //dissociateTokenExternal
 const runMode = __ENV.RUN_WITH_VARIABLES;

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileTransferFungibleToken.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallPrecompileTransferFungibleToken.js
@@ -5,7 +5,7 @@ import {PrecompileModificationTestTemplate} from '../commonPrecompileModificatio
 
 const contract = __ENV.ESTIMATE_PRECOMPILE_CONTRACT;
 const sender = __ENV.ACCOUNT_ADDRESS;
-const receiver = __ENV.RECEIVER_ADDRESS;
+const receiver = __ENV.ASSOCIATED_ACCOUNT;
 const token = __ENV.TOKEN_ADDRESS;
 const amount = __ENV.AMOUNT;
 const runMode = __ENV.RUN_WITH_VARIABLES;

--- a/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallRedirectApprove.js
+++ b/hedera-mirror-test/k6/src/web3/test/modificationTests/contractCallRedirectApprove.js
@@ -6,7 +6,7 @@ import {PrecompileModificationTestTemplate} from '../commonPrecompileModificatio
 const contract = __ENV.PRECOMPILE_CONTRACT;
 const selector = '0x911ce425'; //approveRedirect
 const token = __ENV.TOKEN_ADDRESS;
-const spender = __ENV.RECEIVER_ADDRESS;
+const spender = __ENV.ACCOUNT_ADDRESS;
 const amount = __ENV.AMOUNT;
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'contractCallRedirectApprove';


### PR DESCRIPTION
**Description**:
This PR adapts the web3 k6 estimate tests to work with environment variables. This is needed for convenience when we need to make the performance testing. The test environment variables are updated and ready to be used against the mainnet snapshot DB. _At this point they will not work directly against mainnet (valid for the estimate and the modification tests)._

2 more tests need to be fixed but this will be done in a future PR: `contractCallRedirectApprove` and `estimateDissociateTokens`

**Related issue(s)**:  #10623