### PR TITLE
Add test cases for complex nft mint scenarios

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -76,7 +76,6 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
     void mintMultipleNftTokensGetTotalSupply() throws Exception {
         // Given
         final var treasury = accountEntityPersist();
-        final var treasuryAddress = toAddress(treasury.getId());
 
         final var tokenEntity = persistTokenWithAutoRenewAndTreasuryAccounts(
                         TokenTypeEnum.NON_FUNGIBLE_UNIQUE, treasury)
@@ -106,7 +105,6 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
     void mintNftAndBurnNft() {
         // Given
         final var treasury = accountEntityPersist();
-        final var treasuryAddress = toAddress(treasury.getId());
 
         final var tokenEntity = persistTokenWithAutoRenewAndTreasuryAccounts(
                         TokenTypeEnum.NON_FUNGIBLE_UNIQUE, treasury)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -4,6 +4,7 @@ package com.hedera.mirror.web3.service;
 
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdFromEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,6 +66,58 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
                 BigInteger.valueOf(amount),
                 metadata == null ? List.of() : List.of(metadata.getBytes()),
                 treasuryAddress.toHexString());
+
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
+    }
+
+    @Test
+    void mintMultipleNftTokensGetTotalSupply() throws Exception {
+        // Given
+        final var treasury = accountEntityPersist();
+        final var treasuryAddress = toAddress(treasury.getId());
+
+        final var tokenEntity = persistTokenWithAutoRenewAndTreasuryAccounts(
+                        TokenTypeEnum.NON_FUNGIBLE_UNIQUE, treasury)
+                .getLeft();
+        final var tokenAddress = toAddress(tokenEntity.getId());
+
+        final var contract = testWeb3jService.deploy(DynamicEthCalls::deploy);
+
+        // When
+        final var functionCall = contract.call_mintMultipleNftTokensGetTotalSupplyExternal(
+                tokenAddress.toHexString(), List.of(domainBuilder.bytes(12)), List.of(domainBuilder.bytes(12)));
+
+        final var functionCallWithSend = contract.send_mintMultipleNftTokensGetTotalSupplyExternal(
+                tokenAddress.toHexString(), List.of(domainBuilder.bytes(12)), List.of(domainBuilder.bytes(12)));
+
+        // Then
+        final var result = functionCall.send();
+
+        assertThat(result.component1().getLast()).isEqualTo(BigInteger.ONE); // first serial number
+        assertThat(result.component2().getLast()).isEqualTo(BigInteger.TWO); // second serial number
+
+        verifyEthCallAndEstimateGas(functionCallWithSend, contract);
+        verifyOpcodeTracerCall(functionCallWithSend.encodeFunctionCall(), contract);
+    }
+
+    @Test
+    void mintNftAndBurnNft() {
+        // Given
+        final var treasury = accountEntityPersist();
+        final var treasuryAddress = toAddress(treasury.getId());
+
+        final var tokenEntity = persistTokenWithAutoRenewAndTreasuryAccounts(
+                        TokenTypeEnum.NON_FUNGIBLE_UNIQUE, treasury)
+                .getLeft();
+        final var tokenAddress = toAddress(tokenEntity.getId());
+
+        final var contract = testWeb3jService.deploy(DynamicEthCalls::deploy);
+
+        // When
+        final var functionCall =
+                contract.send_mintNftAndBurnNft(tokenAddress.toHexString(), List.of(domainBuilder.bytes(12)));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -94,8 +94,11 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
         // Then
         final var result = functionCall.send();
 
-        assertThat(result.component1().getLast()).isEqualTo(BigInteger.ONE); // first serial number
-        assertThat(result.component2().getLast()).isEqualTo(BigInteger.TWO); // second serial number
+        BigInteger firstSerialNumber = result.component1().getLast();
+        assertThat(firstSerialNumber).isEqualTo(BigInteger.ONE);
+
+        BigInteger secondSerialNumber = result.component2().getLast();
+        assertThat(secondSerialNumber).isEqualTo(BigInteger.TWO);
 
         verifyEthCallAndEstimateGas(functionCallWithSend, contract);
         verifyOpcodeTracerCall(functionCallWithSend.encodeFunctionCall(), contract);


### PR DESCRIPTION
**Description**:
Up to this point it seems that there weren't integration tests that cover the following scenarios:
- mint multiple NFTs in one transaction and verify that the serial numbers are generated correctly.
- mint and then burn the minted NFT in the same transaction

This PR adds tests for these cases in order to verify that the state works correctly in the `modularizedServices` flow.

Fixes #10626 