### PR TITLE
Fix flaky eth call acceptance test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -64,6 +64,9 @@ import java.util.List;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.web.client.HttpClientErrorException;
 
 @CustomLog
 @RequiredArgsConstructor
@@ -492,6 +495,10 @@ public class CallFeature extends AbstractFeature {
                 .isEqualTo(intValue(results.get(3)));
     }
 
+    @Retryable(
+            retryFor = {HttpClientErrorException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     @Then("I burn NFT and get the total supply and balance")
     public void ethCallBurnNftTokenGetTotalSupplyAndBalanceOfTreasury() {
         var data = encodeData(


### PR DESCRIPTION
**Description**:
This PR adds a retry mechanism for `I burn NFT and get the total supply and balance`.

The test is flaky and is executed right after the token mint operation and then we wait:
```
Given I mint a NFT
Then the mirror node should return status 200 for the HAPI transaction
I burn NFT and get the total supply and balance
```

Seems like even though we wait for successful hapi transaction the next token burn simulations fails because it does not yet find the nft in db and fails.(This happens in very very rare cases, have seen similar problems with other flaky tests in the past). Simulated that with an integration test if we removed the nft persist method. Will cause the same error as in the acceptance test.


Fixes #10618 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
