### PR TITLE
Fix the wrongful modularized flag flip

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -703,10 +703,6 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         mirrorNodeEvmProperties.setProperties(propertiesMap);
     }
 
-    protected void deactivateModularizedFlag() {
-        mirrorNodeEvmProperties.setModularizedServices(false);
-    }
-
     public enum KeyType {
         ADMIN_KEY(1),
         KYC_KEY(2),

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -703,6 +703,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
     @Test
     void updateCustomFeesForTokenWithFixedFee() throws Exception {
+        final var backupModularizedValue = mirrorNodeEvmProperties.isModularizedServices();
         final var backupProperties = mirrorNodeEvmProperties.getProperties();
 
         try {
@@ -764,7 +765,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                     .isEqualTo(newFee.amount);
             verifyEthCallAndEstimateGas(updateCustomFeeFunctionCall, modificationPrecompileTestContract, ZERO_VALUE);
         } finally {
-            deactivateModularizedFlag();
+            mirrorNodeEvmProperties.setModularizedServices(backupModularizedValue);
             mirrorNodeEvmProperties.setProperties(backupProperties);
         }
     }


### PR DESCRIPTION
**Description**:
One of the integration tests (`updateCustomFeesForTokenWithFixedFee`) at the end of execution always used to set the `modularizedServices` flag to `false`. Now the flag is set to its previous value as it should be.

Fixes #10669 