### PR TITLE
Don't print whole account data when payer account is invalid

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
@@ -523,6 +523,11 @@ public record Account(
         return numberPendingAirdrops == thatObj.numberPendingAirdrops;
     }
 
+    @Override
+    public String toString() {
+        return alias.toString();
+    }
+
     /**
      * Convenience method to check if the accountId has a value
      *

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -73,7 +73,7 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     private ResponseEntity<?> mirrorEvmTransactionError(final MirrorEvmTransactionException e, WebRequest request) {
-        log.error(
+        log.warn(
                 "Mirror EVM transaction error: {}, detail: {}, data: {}, isModularized: {}",
                 e.getMessage(),
                 e.getDetail(),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -73,8 +73,8 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     private ResponseEntity<?> mirrorEvmTransactionError(final MirrorEvmTransactionException e, WebRequest request) {
-        log.warn(
-                "Mirror EVM transaction error: {}, detail: {}, data: {}, isCallModularized: {}",
+        log.error(
+                "Mirror EVM transaction error: {}, detail: {}, data: {}, isModularized: {}",
                 e.getMessage(),
                 e.getDetail(),
                 e.getData(),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -123,7 +123,8 @@ public abstract class ContractCallService {
                 result = mirrorEvmTxProcessor.execute(params, estimatedGas);
             }
         } catch (IllegalStateException | IllegalArgumentException e) {
-            throw new MirrorEvmTransactionException(e.getMessage(), EMPTY, EMPTY);
+            log.error("Error processing contract call: ", e);
+            throw new MirrorEvmTransactionException(e.getMessage(), EMPTY, EMPTY, params.isModularized());
         } catch (MirrorEvmTransactionException e) {
             // This result is needed in case of exception to be still able to call restoreGasToBucket method
             result = e.getResult();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -123,7 +123,6 @@ public abstract class ContractCallService {
                 result = mirrorEvmTxProcessor.execute(params, estimatedGas);
             }
         } catch (IllegalStateException | IllegalArgumentException e) {
-            log.error("Error processing contract call: ", e);
             throw new MirrorEvmTransactionException(e.getMessage(), EMPTY, EMPTY, params.isModularized());
         } catch (MirrorEvmTransactionException e) {
             // This result is needed in case of exception to be still able to call restoreGasToBucket method


### PR DESCRIPTION
**Description**:
When payer account is not valid during the check in the DispatchValidator, the whole account data is printed as part of the exception message, which results in similar output:
![invalidpayer](https://github.com/user-attachments/assets/e392337c-5009-4b41-b300-0f66ead2cc19)

The outcome of this PR will be to print only the Account alias 
<img width="1077" alt="Screenshot 2025-03-21 at 9 13 19" src="https://github.com/user-attachments/assets/5dab1221-0918-46a3-a59d-3a3531e6efa2" />


**Related issue(s)**:

Fixes #10620

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
