### PR TITLE
Enforce JSON parsing limits in rest-java and web3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
         api("org.mapstruct:mapstruct-processor:$mapStructVersion")
         api("org.msgpack:jackson-dataformat-msgpack:0.9.9")
         api("org.springdoc:springdoc-openapi-webflux-ui:1.8.0")
-        api("org.springframework.cloud:spring-cloud-dependencies:2024.0.1")
+        api("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
         api("org.testcontainers:junit-jupiter:1.20.6")
         api("org.mockito:mockito-inline:5.2.0")
         api("software.amazon.awssdk:bom:2.30.31")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ extra.apply {
     set("nodeJsVersion", "18.20.7")
     set("protobufVersion", "3.25.5")
     set("reactorGrpcVersion", "1.2.4")
+    set("spring-security.version", "6.4.4") // Temporary until next Spring Boot
     set("vertxVersion", "4.5.13")
     set("tuweniVersion", "2.3.1")
 }
@@ -85,7 +86,7 @@ dependencies {
         api("org.mapstruct:mapstruct-processor:$mapStructVersion")
         api("org.msgpack:jackson-dataformat-msgpack:0.9.9")
         api("org.springdoc:springdoc-openapi-webflux-ui:1.8.0")
-        api("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+        api("org.springframework.cloud:spring-cloud-dependencies:2024.0.1")
         api("org.testcontainers:junit-jupiter:1.20.6")
         api("org.mockito:mockito-inline:5.2.0")
         api("software.amazon.awssdk:bom:2.30.31")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ extra.apply {
     set("nodeJsVersion", "18.20.7")
     set("protobufVersion", "3.25.5")
     set("reactorGrpcVersion", "1.2.4")
-    set("spring-security.version", "6.4.4") // Temporary until next Spring Boot
     set("vertxVersion", "4.5.13")
     set("tuweniVersion", "2.3.1")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.12.0")
     implementation("org.owasp:dependency-check-gradle:12.1.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:6.0.1.5171")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.4.3")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.4.4")
     implementation("org.testcontainers:postgresql:1.20.6")
     implementation("org.web3j:web3j-gradle-plugin:4.13.0")
 }

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/config/JacksonConfiguration.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/config/JacksonConfiguration.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.restjava.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class JacksonConfiguration {
+
+    // Configure JSON parsing limits to reject malicious input
+    @Bean
+    Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> {
+            var streamReadConstraints = StreamReadConstraints.builder()
+                    .maxDocumentLength(1000)
+                    .maxNameLength(100)
+                    .maxNestingDepth(10)
+                    .maxNumberLength(19)
+                    .maxStringLength(1000)
+                    .maxTokenCount(100)
+                    .build();
+            var streamWriteConstraints =
+                    StreamWriteConstraints.builder().maxNestingDepth(100).build();
+            var factory = new MappingJsonFactory();
+            factory.setStreamReadConstraints(streamReadConstraints);
+            factory.setStreamWriteConstraints(streamWriteConstraints);
+            builder.factory(factory);
+        };
+    }
+}

--- a/hedera-mirror-rest-java/src/main/resources/application.yml
+++ b/hedera-mirror-rest-java/src/main/resources/application.yml
@@ -62,6 +62,7 @@ server:
   tomcat:
     connection-timeout: 3s
     max-http-form-post-size: 1KB
+    max-swallow-size: 1KB
 spring:
   application:
     name: hedera-mirror-rest-java

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/RestSpecTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/RestSpecTest.java
@@ -87,11 +87,10 @@ class RestSpecTest extends RestJavaIntegrationTest {
             @Value("classpath:cleanup.sql") Resource cleanupSqlResource,
             DataSource dataSource,
             @Qualifier(REST_API) GenericContainer<?> jsRestApi,
-            ObjectMapper objectMapper,
             SpecDomainBuilder specDomainBuilder) {
         this.databaseCleaner = new ResourceDatabasePopulator(cleanupSqlResource);
         this.dataSource = dataSource;
-        this.objectMapper = objectMapper;
+        this.objectMapper = new ObjectMapper();
         this.specDomainBuilder = specDomainBuilder;
 
         var baseJsRestApiUrl =

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/RestSpecNormalized.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/RestSpecNormalized.java
@@ -12,9 +12,9 @@ import org.springframework.util.CollectionUtils;
  *
  * @param description
  * @param extendedDescription
- * @param matrix ignored for now
- * @param setup features and other config are not yet supported, just database entity definitions
- * @param tests at least one normalized test
+ * @param matrix              ignored for now
+ * @param setup               features and other config are not yet supported, just database entity definitions
+ * @param tests               at least one normalized test
  */
 public record RestSpecNormalized(
         String description,
@@ -33,6 +33,7 @@ public record RestSpecNormalized(
         List<SpecTestNormalized> normalizedTests;
         if (CollectionUtils.isEmpty(restSpec.tests())) {
             var specTest = new SpecTest(
+                    restSpec.description(),
                     restSpec.responseHeaders(),
                     restSpec.responseJson(),
                     restSpec.responseStatus(),

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/SpecSetup.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/SpecSetup.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public record SpecSetup(
         Map<String, Object> config,
         List<Map<String, Object>> accounts,
+        List<Map<String, Object>> balances,
         List<Map<String, Object>> contracts,
         List<Map<String, Object>> cryptoAllowances,
         @JsonProperty("cryptotransfers") List<Map<String, Object>> cryptoTransfers,

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/SpecTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/model/SpecTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import org.springframework.util.StringUtils;
 
 public record SpecTest(
+        String description,
         Map<String, String> responseHeaders,
         @JsonDeserialize(using = JsonAsStringDeserializer.class) String responseJson,
         int responseStatus,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1544,10 +1544,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -69,6 +69,7 @@
   },
   "baseUrlPath": "/api/v1",
   "overrides": {
+    "@babel/runtime": "7.26.10",
     "cross-spawn": "^7.0.6",
     "micromatch": "^4.0.8",
     "swagger-stats": {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/JacksonConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/JacksonConfiguration.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class JacksonConfiguration {
+
+    // Configure JSON parsing limits to reject malicious input
+    @Bean
+    Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer(MirrorNodeEvmProperties properties) {
+        final int maxSize = (int) properties.getMaxDataSize().toBytes() * 2 + 1024;
+        return builder -> {
+            var streamReadConstraints = StreamReadConstraints.builder()
+                    .maxDocumentLength(maxSize)
+                    .maxNameLength(100)
+                    .maxNestingDepth(10)
+                    .maxNumberLength(19)
+                    .maxStringLength(maxSize)
+                    .maxTokenCount(100)
+                    .build();
+            var streamWriteConstraints =
+                    StreamWriteConstraints.builder().maxNestingDepth(100).build();
+            var factory = new MappingJsonFactory();
+            factory.setStreamReadConstraints(streamReadConstraints);
+            factory.setStreamWriteConstraints(streamWriteConstraints);
+            builder.factory(factory);
+        };
+    }
+}

--- a/hedera-mirror-web3/src/main/resources/application.yml
+++ b/hedera-mirror-web3/src/main/resources/application.yml
@@ -54,6 +54,7 @@ server:
   tomcat:
     connection-timeout: 3s
     max-http-form-post-size: 1MB
+    max-swallow-size: 1MB
 spring:
   application:
     name: hedera-mirror-web3


### PR DESCRIPTION
**Description**:

* Bump `@babel/runtime` from `7.26.0` to `7.26.10`
* Bump Spring Security from `6.4.3` to `6.4.4`
* Enforce JSON request parsing limits of rest-java and web3 for enhanced security

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
