### PR TITLE
Add `EntityCountsSingleton`

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/EntityCountsSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/EntityCountsSingleton.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.ids.schemas.V0590EntityIdSchema.ENTITY_COUNTS_KEY;
+
+import com.hedera.hapi.node.state.entity.EntityCounts;
+import jakarta.inject.Named;
+
+@Named
+public class EntityCountsSingleton implements SingletonState<EntityCounts> {
+
+    @Override
+    public String getKey() {
+        return ENTITY_COUNTS_KEY;
+    }
+
+    @Override
+    public EntityCounts get() {
+        return EntityCounts.DEFAULT;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/EntityCountsSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/EntityCountsSingletonTest.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.ids.schemas.V0590EntityIdSchema.ENTITY_COUNTS_KEY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.hedera.hapi.node.state.entity.EntityCounts;
+import org.junit.jupiter.api.Test;
+
+class EntityCountsSingletonTest {
+
+    private final EntityCountsSingleton entityCountsSingleton = new EntityCountsSingleton();
+
+    @Test
+    void testExpectedValueIsReturned() {
+        assertThat(entityCountsSingleton.get()).isEqualTo(EntityCounts.DEFAULT);
+    }
+
+    @Test
+    void testGetKeyReturnsExpectedKey() {
+        assertThat(entityCountsSingleton.getKey()).isEqualTo(ENTITY_COUNTS_KEY);
+    }
+}


### PR DESCRIPTION
**Description**:
During the `modularizedServices` flow testing we found the need to implement an `EntityCountsSingleton` that is needed for the hedera-app dependency. This PR adds a very basic implementation which should be enough for our purposes. The value of the singleton is updated during the transaction but it is actually needed in the persist logic in hedera-app, which in web3 we don't do anyway, so we don't need to query the DB and populate real data.

Fixes #10628 
