### PR TITLE
Support non-zero realm in importer

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
@@ -2,11 +2,18 @@
 
 package com.hedera.mirror.common;
 
+import com.hedera.mirror.common.domain.SystemEntities;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationPropertiesScan(basePackages = "com.hedera.mirror")
 @EntityScan("com.hedera.mirror.common.domain")
-public class CommonConfiguration {}
+public class CommonConfiguration {
+    @Bean
+    SystemEntities systemEntities(CommonProperties commonProperties) {
+        return new SystemEntities(commonProperties);
+    }
+}

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
@@ -5,15 +5,17 @@ package com.hedera.mirror.common;
 import com.hedera.mirror.common.domain.SystemEntities;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationPropertiesScan(basePackages = "com.hedera.mirror")
+@EnableConfigurationProperties(CommonProperties.class)
 @EntityScan("com.hedera.mirror.common.domain")
 public class CommonConfiguration {
     @Bean
-    SystemEntities systemEntities() {
-        return new SystemEntities(CommonProperties.getInstance());
+    SystemEntities systemEntities(CommonProperties commonProperties) {
+        return new SystemEntities(commonProperties);
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/CommonConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 @EntityScan("com.hedera.mirror.common.domain")
 public class CommonConfiguration {
     @Bean
-    SystemEntities systemEntities(CommonProperties commonProperties) {
-        return new SystemEntities(commonProperties);
+    SystemEntities systemEntities() {
+        return new SystemEntities(CommonProperties.getInstance());
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/SystemEntities.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/SystemEntities.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.common.domain;
+
+import com.hedera.mirror.common.CommonProperties;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Accessors(fluent = true)
+@RequiredArgsConstructor
+public class SystemEntities {
+
+    private final CommonProperties commonProperties;
+
+    @Getter(lazy = true)
+    private final EntityId addressBookFile101 = toEntityId(101L);
+
+    @Getter(lazy = true)
+    private final EntityId addressBookFile102 = toEntityId(102L);
+
+    @Getter(lazy = true)
+    private final EntityId feeCollectorAccount = toEntityId(98L);
+
+    @Getter(lazy = true)
+    private final EntityId nodeRewardAccount = toEntityId(801L);
+
+    @Getter(lazy = true)
+    private final EntityId stakingRewardAccount = toEntityId(800L);
+
+    @Getter(lazy = true)
+    private final EntityId treasuryAccount = toEntityId(2L);
+
+    private EntityId toEntityId(long num) {
+        return EntityId.of(commonProperties.getShard(), commonProperties.getRealm(), num);
+    }
+}

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -171,6 +171,22 @@ public final class EntityId implements Serializable, Comparable<EntityId> {
         return (id >> (NUM_BITS + REALM_BITS)) & SHARD_MASK;
     }
 
+    public AccountID toAccountID() {
+        return AccountID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setAccountNum(getNum())
+                .build();
+    }
+
+    public ContractID toContractID() {
+        return ContractID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setContractNum(getNum())
+                .build();
+    }
+
     public Entity toEntity() {
         Entity entity = new Entity();
         entity.setId(id);
@@ -179,6 +195,38 @@ public final class EntityId implements Serializable, Comparable<EntityId> {
         entity.setShard(getShard());
         entity.setTimestampRange(DEFAULT_RANGE);
         return entity;
+    }
+
+    public FileID toFileID() {
+        return FileID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setFileNum(getNum())
+                .build();
+    }
+
+    public ScheduleID toScheduleID() {
+        return ScheduleID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setScheduleNum(getNum())
+                .build();
+    }
+
+    public TokenID toTokenID() {
+        return TokenID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setTokenNum(getNum())
+                .build();
+    }
+
+    public TopicID toTopicID() {
+        return TopicID.newBuilder()
+                .setShardNum(getShard())
+                .setRealmNum(getRealm())
+                .setTopicNum(getNum())
+                .build();
     }
 
     @Override

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonIntegrationTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonIntegrationTest.java
@@ -2,7 +2,9 @@
 
 package com.hedera.mirror.common.config;
 
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.SystemEntities;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.Resource;
 import java.util.Collection;
@@ -25,10 +27,16 @@ public abstract class CommonIntegrationTest {
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
     @Resource
+    protected CommonProperties commonProperties;
+
+    @Resource
     protected DomainBuilder domainBuilder;
 
     @Autowired(required = false)
     protected MeterRegistry meterRegistry;
+
+    @Resource
+    protected SystemEntities systemEntities;
 
     @Autowired(required = false)
     private Collection<CacheManager> cacheManagers;
@@ -40,6 +48,9 @@ public abstract class CommonIntegrationTest {
     }
 
     protected void reset() {
+        commonProperties.setRealm(0L);
+        commonProperties.setShard(0L);
+
         if (cacheManagers != null) {
             cacheManagers.forEach(this::resetCacheManager);
         }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
@@ -3,6 +3,7 @@
 package com.hedera.mirror.common.config;
 
 import com.google.common.collect.ImmutableMap;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -38,8 +39,11 @@ public class CommonTestConfiguration {
     private boolean v2;
 
     @Bean
-    DomainBuilder domainBuilder(EntityManager entityManager, TransactionOperations transactionOperations) {
-        return new DomainBuilder(entityManager, transactionOperations);
+    DomainBuilder domainBuilder(
+            CommonProperties commonProperties,
+            EntityManager entityManager,
+            TransactionOperations transactionOperations) {
+        return new DomainBuilder(commonProperties, entityManager, transactionOperations);
     }
 
     @Bean

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityIdTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityIdTest.java
@@ -10,6 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hedera.mirror.common.exception.InvalidEntityException;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -77,5 +83,65 @@ class EntityIdTest {
     void isUnset() {
         assertThat(EntityId.isUnset(UNSET)).isTrue();
         assertThat(EntityId.isUnset(EntityId.of(UNSET.getId()))).isFalse();
+    }
+
+    @Test
+    void toAccountId() {
+        assertThat(EntityId.of(1, 2, 3).toAccountID())
+                .isEqualTo(AccountID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setAccountNum(3)
+                        .build());
+    }
+
+    @Test
+    void toContractId() {
+        assertThat(EntityId.of(1, 2, 3).toContractID())
+                .isEqualTo(ContractID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setContractNum(3)
+                        .build());
+    }
+
+    @Test
+    void toFileId() {
+        assertThat(EntityId.of(1, 2, 3).toFileID())
+                .isEqualTo(FileID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setFileNum(3)
+                        .build());
+    }
+
+    @Test
+    void toScheduleId() {
+        assertThat(EntityId.of(1, 2, 3).toScheduleID())
+                .isEqualTo(ScheduleID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setScheduleNum(3)
+                        .build());
+    }
+
+    @Test
+    void toTokenId() {
+        assertThat(EntityId.of(1, 2, 3).toTokenID())
+                .isEqualTo(TokenID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setTokenNum(3)
+                        .build());
+    }
+
+    @Test
+    void toTopicId() {
+        assertThat(EntityId.of(1, 2, 3).toTopicID())
+                .isEqualTo(TopicID.newBuilder()
+                        .setShardNum(1)
+                        .setRealmNum(2)
+                        .setTopicNum(3)
+                        .build());
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
@@ -6,7 +6,6 @@ import static com.hedera.mirror.grpc.service.NetworkServiceImpl.INVALID_FILE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
@@ -36,7 +35,6 @@ class NetworkServiceTest extends GrpcIntegrationTest {
 
     private final AddressBookEntryRepository addressBookEntryRepository;
     private final AddressBookProperties addressBookProperties;
-    private final CommonProperties commonProperties;
     private final DomainBuilder domainBuilder;
     private final NetworkService networkService;
     private final NodeStakeRepository nodeStakeRepository;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
@@ -59,7 +59,7 @@ public class EntityIdServiceImpl implements EntityIdService {
                 byte[] alias = toBytes(accountId.getAlias());
                 yield alias.length == EVM_ADDRESS_LENGTH
                         ? cacheLookup(accountId.getAlias(), () -> findByEvmAddress(alias, shard, realm))
-                        : cacheLookup(accountId.getAlias(), () -> findByAlias(alias))
+                        : cacheLookup(accountId.getAlias(), () -> findByAlias(shard, realm, alias))
                                 .or(() -> findByAliasEvmAddress(alias, shard, realm));
             }
             default -> {
@@ -165,7 +165,9 @@ public class EntityIdServiceImpl implements EntityIdService {
         var id = Optional.ofNullable(DomainUtils.fromEvmAddress(evmAddress))
                 // Verify shard and realm match when assuming evmAddress is in the 'shard.realm.num' form
                 .filter(e -> e.getShard() == shardNum && e.getRealm() == realmNum)
-                .or(() -> entityRepository.findByEvmAddress(evmAddress).map(EntityId::of));
+                .or(() -> entityRepository
+                        .findByEvmAddress(shardNum, realmNum, evmAddress)
+                        .map(EntityId::of));
 
         if (id.isEmpty() && throwRecoverableError) {
             Utility.handleRecoverableError("Entity not found for EVM address {}", Hex.encodeHexString(evmAddress));
@@ -174,8 +176,8 @@ public class EntityIdServiceImpl implements EntityIdService {
         return id;
     }
 
-    private Optional<EntityId> findByAlias(byte[] alias) {
-        return entityRepository.findByAlias(alias).map(EntityId::of);
+    private Optional<EntityId> findByAlias(long shard, long realm, byte[] alias) {
+        return entityRepository.findByAlias(shard, realm, alias).map(EntityId::of);
     }
 
     // Try to fall back to the 20-byte evm address recovered from the ECDSA secp256k1 alias

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -12,11 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface EntityRepository extends CrudRepository<Entity, Long> {
 
-    @Query(value = "select id from entity where alias = ?1 and deleted <> true", nativeQuery = true)
-    Optional<Long> findByAlias(byte[] alias);
+    @Query(
+            value = "select id from entity where shard = ?1 and realm = ?2 and alias = ?3 and deleted <> true",
+            nativeQuery = true)
+    Optional<Long> findByAlias(long shard, long realm, byte[] alias);
 
-    @Query(value = "select id from entity where evm_address = ?1 and deleted <> true", nativeQuery = true)
-    Optional<Long> findByEvmAddress(byte[] evmAddress);
+    @Query(
+            value = "select id from entity where shard = ?1 and realm = ?2 and evm_address = ?3 and deleted <> true",
+            nativeQuery = true)
+    Optional<Long> findByEvmAddress(long shard, long realm, byte[] evmAddress);
 
     @Modifying
     @Query(value = "update entity set type = 'CONTRACT' where id in (:ids) and type <> 'CONTRACT'", nativeQuery = true)

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
@@ -3,15 +3,6 @@
 package com.hedera.mirror.importer.repository;
 
 import com.hedera.mirror.common.domain.schedule.Schedule;
-import jakarta.transaction.Transactional;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 
-public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
-    @Modifying
-    @Transactional
-    @Query("update Schedule set executedTimestamp = :timestamp where scheduleId = :schedule")
-    void updateExecutedTimestamp(@Param("schedule") Long scheduleId, @Param("timestamp") long executedTimestamp);
-}
+public interface ScheduleRepository extends CrudRepository<Schedule, Long> {}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.ByteString;
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
 import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
@@ -80,8 +79,6 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
     @Qualifier(CacheConfiguration.CACHE_ADDRESS_BOOK)
     private final CacheManager cacheManager;
 
-    private final CommonProperties commonProperties;
-
     private final FileDataRepository fileDataRepository;
     private final ImporterProperties importerProperties;
 
@@ -136,7 +133,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
     private FileData createFileData(
             byte[] contents, long consensusTimeStamp, boolean is102, TransactionType transactionType) {
-        EntityId entityId = is102 ? AddressBookServiceImpl.FILE_102 : AddressBookServiceImpl.FILE_101;
+        EntityId entityId = is102 ? systemEntities.addressBookFile102() : systemEntities.addressBookFile101();
         return new FileData(consensusTimeStamp, contents, entityId, transactionType.getProtoId());
     }
 
@@ -388,7 +385,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(initialTimestamp + 1))
                 .get()
                 .returns(addressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(UPDATED.getNodeAddressCount(), AddressBook::getNodeCount)
                 .returns(initialTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
@@ -401,7 +398,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(newTimestamp + 1))
                 .get()
                 .returns(newAddressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(newTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
                 .satisfies(a -> assertAddressBook(a, FINAL));
@@ -414,7 +411,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         // verify end consensus timestamp was set for previous address book
         assertThat(addressBookRepository.findById(initialTimestamp + 1))
                 .get()
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(initialTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(newTimestamp, AddressBook::getEndConsensusTimestamp);
     }
@@ -428,7 +425,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(initialTimestamp + 1))
                 .get()
                 .returns(addressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_101, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile101(), AddressBook::getFileId)
                 .returns(initialTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
                 .satisfies(a -> assertAddressBook(a, UPDATED));
@@ -440,7 +437,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(newTimestamp + 1))
                 .get()
                 .returns(newAddressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_101, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile101(), AddressBook::getFileId)
                 .returns(newTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
                 .satisfies(a -> assertAddressBook(a, FINAL));
@@ -453,7 +450,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         // verify end consensus timestamp was set for previous address book
         assertThat(addressBookRepository.findById(initialTimestamp + 1))
                 .get()
-                .returns(AddressBookServiceImpl.FILE_101, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile101(), AddressBook::getFileId)
                 .returns(initialTimestamp + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(newTimestamp, AddressBook::getEndConsensusTimestamp);
     }
@@ -492,7 +489,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(timestamp102 + 1))
                 .get()
                 .returns(addressBookBytes102, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(timestamp102 + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
                 .satisfies(a -> assertAddressBook(a, UPDATED));
@@ -504,7 +501,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertThat(addressBookRepository.findById(timestamp101 + 1))
                 .get()
                 .returns(addressBookBytes101, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_101, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile101(), AddressBook::getFileId)
                 .returns(timestamp101 + 1, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp)
                 .satisfies(a -> assertAddressBook(a, FINAL));
@@ -568,7 +565,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
         assertThat(addressBookService.getCurrent())
                 .returns(initialAddressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(1L, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp);
         assertEquals(1, addressBookRepository.count());
@@ -586,7 +583,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
         assertThat(addressBookService.getCurrent())
                 .returns(initialAddressBookBytes, AddressBook::getFileData)
-                .returns(AddressBookServiceImpl.FILE_102, AddressBook::getFileId)
+                .returns(systemEntities.addressBookFile102(), AddressBook::getFileId)
                 .returns(1L, AddressBook::getStartConsensusTimestamp)
                 .returns(null, AddressBook::getEndConsensusTimestamp);
         assertEquals(1, addressBookRepository.count());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/CryptoTransformerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/block/transformer/CryptoTransformerTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
-import com.hedera.mirror.importer.parser.domain.RecordItemBuilder;
 import com.hedera.mirror.importer.parser.domain.RecordItemBuilder.TransferType;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.util.List;
@@ -19,6 +18,14 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class CryptoTransformerTest extends AbstractTransformerTest {
+
+    private static Stream<Arguments> provideAliasAndExpectedEvmAddress() {
+        var randomAlias = recordItemBuilder.bytes(20);
+        return Stream.of(
+                arguments(ByteString.EMPTY, ByteString.EMPTY),
+                arguments(recordItemBuilder.key().toByteString(), ByteString.EMPTY),
+                arguments(randomAlias, randomAlias));
+    }
 
     @ParameterizedTest
     @MethodSource("provideAliasAndExpectedEvmAddress")
@@ -83,14 +90,5 @@ class CryptoTransformerTest extends AbstractTransformerTest {
             assertRecordItems(items, List.of(expectedRecordItem, expectedRecordItem2));
             assertThat(items).map(RecordItem::getParent).containsOnlyNulls();
         });
-    }
-
-    private static Stream<Arguments> provideAliasAndExpectedEvmAddress() {
-        RecordItemBuilder recordItemBuilder1 = new RecordItemBuilder();
-        var randomAlias = recordItemBuilder1.bytes(20);
-        return Stream.of(
-                arguments(ByteString.EMPTY, ByteString.EMPTY),
-                arguments(recordItemBuilder1.key().toByteString(), ByteString.EMPTY),
-                arguments(randomAlias, randomAlias));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
@@ -13,7 +13,6 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
 import com.hedera.mirror.importer.repository.FileDataRepository;
@@ -87,10 +86,10 @@ class MissingAddressBooksMigrationTest extends ImporterIntegrationTest {
     @Transactional
     void verifyAddressBookMigrationWithNewFileDataAfterCurrentAddressBook() {
         // store initial address books
-        addressBookRepository.save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.FILE_101), 1, 4));
-        addressBookRepository.save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.FILE_102), 2, 4));
-        addressBookRepository.save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.FILE_101), 11, 8));
-        addressBookRepository.save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.FILE_102), 12, 8));
+        addressBookRepository.save(addressBook(ab -> ab.fileId(systemEntities.addressBookFile101()), 1, 4));
+        addressBookRepository.save(addressBook(ab -> ab.fileId(systemEntities.addressBookFile102()), 2, 4));
+        addressBookRepository.save(addressBook(ab -> ab.fileId(systemEntities.addressBookFile101()), 11, 8));
+        addressBookRepository.save(addressBook(ab -> ab.fileId(systemEntities.addressBookFile102()), 12, 8));
         assertEquals(4, addressBookRepository.count());
 
         // un-parsed file_data
@@ -115,7 +114,7 @@ class MissingAddressBooksMigrationTest extends ImporterIntegrationTest {
         missingAddressBooksMigration.doMigrate();
         assertEquals(6, addressBookRepository.count());
         AddressBook newAddressBook = addressBookRepository
-                .findLatest(205, AddressBookServiceImpl.FILE_102.getId())
+                .findLatest(205, systemEntities.addressBookFile102().getId())
                 .get();
         assertThat(newAddressBook.getStartConsensusTimestamp()).isEqualTo(203L);
         assertAddressBook(newAddressBook, FINAL);
@@ -155,7 +154,7 @@ class MissingAddressBooksMigrationTest extends ImporterIntegrationTest {
                 .startConsensusTimestamp(startConsensusTimestamp)
                 .fileData("address book memo".getBytes())
                 .nodeCount(nodeCount)
-                .fileId(AddressBookServiceImpl.FILE_102)
+                .fileId(systemEntities.addressBookFile102())
                 .entries(addressBookEntryList);
 
         if (addressBookCustomizer != null) {
@@ -186,7 +185,7 @@ class MissingAddressBooksMigrationTest extends ImporterIntegrationTest {
 
     private FileData createAndStoreFileData(
             byte[] contents, long consensusTimeStamp, boolean is102, TransactionType transactionType) {
-        EntityId entityId = is102 ? AddressBookServiceImpl.FILE_102 : AddressBookServiceImpl.FILE_101;
+        EntityId entityId = is102 ? systemEntities.addressBookFile102() : systemEntities.addressBookFile101();
         FileData fileData = new FileData(consensusTimeStamp, contents, entityId, transactionType.getProtoId());
         return fileDataRepository.save(fileData);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/BlockItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/BlockItemBuilder.java
@@ -50,7 +50,6 @@ import com.hederahashgraph.api.proto.java.Account;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.AccountPendingAirdrop;
 import com.hederahashgraph.api.proto.java.ContractID;
-import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.NftID;
 import com.hederahashgraph.api.proto.java.PendingAirdropId;
 import com.hederahashgraph.api.proto.java.PendingAirdropValue;
@@ -72,6 +71,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 
@@ -79,9 +79,69 @@ import org.springframework.context.annotation.Scope;
  * Generates typical protobuf request and response objects with all fields populated.
  */
 @Named
+@RequiredArgsConstructor
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class BlockItemBuilder {
-    private final RecordItemBuilder recordItemBuilder = new RecordItemBuilder();
+
+    private final RecordItemBuilder recordItemBuilder;
+
+    private static StateChanges buildFileIdStateChanges(RecordItem recordItem) {
+        var fileId = recordItem.getTransactionRecord().getReceipt().getFileID();
+        var key = MapChangeKey.newBuilder().setFileIdKey(fileId).build();
+        var mapUpdate = MapUpdateChange.newBuilder().setKey(key).build();
+
+        var firstChange = StateChange.newBuilder()
+                .setMapUpdate(MapUpdateChange.newBuilder().build())
+                .setStateId(1)
+                .build();
+
+        var secondChange = StateChange.newBuilder()
+                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
+                .build();
+
+        var thirdChange = StateChange.newBuilder()
+                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
+                .setMapUpdate(MapUpdateChange.newBuilder().build())
+                .build();
+
+        var fourtChange = StateChange.newBuilder()
+                .setMapUpdate(mapUpdate)
+                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
+                .build();
+
+        var changes = List.of(firstChange, secondChange, thirdChange, fourtChange);
+
+        return StateChanges.newBuilder().addAllStateChanges(changes).build();
+    }
+
+    private static StateChanges buildNodeIdStateChanges(RecordItem recordItem) {
+        var nodeId = recordItem.getTransactionRecord().getReceipt().getNodeId();
+        var key = MapChangeKey.newBuilder()
+                .setEntityNumberKey(UInt64Value.of(nodeId))
+                .build();
+        var mapUpdate = MapUpdateChange.newBuilder().setKey(key).build();
+
+        var firstChange = StateChange.newBuilder()
+                .setMapUpdate(MapUpdateChange.newBuilder().build())
+                .setStateId(1)
+                .build();
+
+        var secondChange =
+                StateChange.newBuilder().setStateId(STATE_ID_NODES_VALUE).build();
+
+        var thirdChange = StateChange.newBuilder()
+                .setStateId(STATE_ID_NODES_VALUE)
+                .setMapUpdate(MapUpdateChange.newBuilder().build())
+                .build();
+
+        var fourthChange = StateChange.newBuilder()
+                .setMapUpdate(mapUpdate)
+                .setStateId(STATE_ID_NODES_VALUE)
+                .build();
+
+        var changes = List.of(firstChange, secondChange, thirdChange, fourthChange);
+        return StateChanges.newBuilder().addAllStateChanges(changes).build();
+    }
 
     public BlockItemBuilder.Builder contractCall(RecordItem recordItem) {
         var contractCallResult = recordItem.getTransactionRecord().getContractCallResult();
@@ -99,11 +159,7 @@ public class BlockItemBuilder {
         }
 
         var contractId = contractCallResult.getContractID();
-        var accountId = AccountID.newBuilder()
-                .setShardNum(contractId.getShardNum())
-                .setRealmNum(contractId.getRealmNum())
-                .setAccountNum(contractId.getContractNum())
-                .build();
+        var accountId = toAccountId(contractId);
         var stateChanges = StateChanges.newBuilder()
                 .addStateChanges(StateChange.newBuilder()
                         .setStateId(STATE_ID_ACCOUNTS_VALUE)
@@ -139,11 +195,7 @@ public class BlockItemBuilder {
 
         var contractCreateResult = transactionRecord.getContractCreateResult();
         var contractId = contractCreateResult.getContractID();
-        var accountId = AccountID.newBuilder()
-                .setShardNum(contractId.getShardNum())
-                .setRealmNum(contractId.getRealmNum())
-                .setAccountNum(contractId.getContractNum())
-                .build();
+        var accountId = toAccountId(contractId);
         var evmAddress = contractCreateResult.hasEvmAddress()
                 ? contractCreateResult.getEvmAddress().getValue()
                 : ByteString.EMPTY;
@@ -182,11 +234,7 @@ public class BlockItemBuilder {
                     recordItem.getTransactionBody().getContractUpdateInstance().getContractID();
         }
 
-        var accountId = AccountID.newBuilder()
-                .setShardNum(contractId.getShardNum())
-                .setRealmNum(contractId.getRealmNum())
-                .setAccountNum(contractId.getContractNum())
-                .build();
+        var accountId = toAccountId(contractId);
         var evmAddress = getEvmAddress(contractIdInBody);
         var stateChanges = StateChanges.newBuilder()
                 .addStateChanges(StateChange.newBuilder()
@@ -224,11 +272,7 @@ public class BlockItemBuilder {
                 contractId = transactionRecord.getContractCallResult().getContractID();
             }
 
-            var accountId = AccountID.newBuilder()
-                    .setShardNum(contractId.getShardNum())
-                    .setRealmNum(contractId.getRealmNum())
-                    .setAccountNum(contractId.getContractNum())
-                    .build();
+            var accountId = toAccountId(contractId);
             var stateChanges = StateChanges.newBuilder()
                     .addStateChanges(StateChange.newBuilder()
                             .setStateId(STATE_ID_ACCOUNTS_VALUE)
@@ -638,65 +682,6 @@ public class BlockItemBuilder {
                 .build();
     }
 
-    private static StateChanges buildFileIdStateChanges(RecordItem recordItem) {
-        var id = recordItem.getTransactionRecord().getReceipt().getFileID().getFileNum();
-        var fileId = FileID.newBuilder().setFileNum(id).build();
-        var key = MapChangeKey.newBuilder().setFileIdKey(fileId).build();
-        var mapUpdate = MapUpdateChange.newBuilder().setKey(key).build();
-
-        var firstChange = StateChange.newBuilder()
-                .setMapUpdate(MapUpdateChange.newBuilder().build())
-                .setStateId(1)
-                .build();
-
-        var secondChange = StateChange.newBuilder()
-                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
-                .build();
-
-        var thirdChange = StateChange.newBuilder()
-                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
-                .setMapUpdate(MapUpdateChange.newBuilder().build())
-                .build();
-
-        var fourtChange = StateChange.newBuilder()
-                .setMapUpdate(mapUpdate)
-                .setStateId(StateIdentifier.STATE_ID_FILES_VALUE)
-                .build();
-
-        var changes = List.of(firstChange, secondChange, thirdChange, fourtChange);
-
-        return StateChanges.newBuilder().addAllStateChanges(changes).build();
-    }
-
-    private static StateChanges buildNodeIdStateChanges(RecordItem recordItem) {
-        var nodeId = recordItem.getTransactionRecord().getReceipt().getNodeId();
-        var key = MapChangeKey.newBuilder()
-                .setEntityNumberKey(UInt64Value.of(nodeId))
-                .build();
-        var mapUpdate = MapUpdateChange.newBuilder().setKey(key).build();
-
-        var firstChange = StateChange.newBuilder()
-                .setMapUpdate(MapUpdateChange.newBuilder().build())
-                .setStateId(1)
-                .build();
-
-        var secondChange =
-                StateChange.newBuilder().setStateId(STATE_ID_NODES_VALUE).build();
-
-        var thirdChange = StateChange.newBuilder()
-                .setStateId(STATE_ID_NODES_VALUE)
-                .setMapUpdate(MapUpdateChange.newBuilder().build())
-                .build();
-
-        var fourthChange = StateChange.newBuilder()
-                .setMapUpdate(mapUpdate)
-                .setStateId(STATE_ID_NODES_VALUE)
-                .build();
-
-        var changes = List.of(firstChange, secondChange, thirdChange, fourthChange);
-        return StateChanges.newBuilder().addAllStateChanges(changes).build();
-    }
-
     private ByteString getEvmAddress(ContractID contractId) {
         if (contractId.hasEvmAddress()) {
             var entityId = DomainUtils.fromEvmAddress(DomainUtils.toBytes(contractId.getEvmAddress()));
@@ -711,6 +696,14 @@ public class BlockItemBuilder {
     private Timestamp timestamp(long consensusTimestamp) {
         var instant = Instant.ofEpochSecond(0, consensusTimestamp);
         return Utility.instantToTimestamp(instant);
+    }
+
+    private AccountID toAccountId(ContractID contractId) {
+        return AccountID.newBuilder()
+                .setShardNum(contractId.getShardNum())
+                .setRealmNum(contractId.getRealmNum())
+                .setAccountNum(contractId.getContractNum())
+                .build();
     }
 
     private TransactionResult transactionResult(RecordItem recordItem) {
@@ -739,11 +732,11 @@ public class BlockItemBuilder {
     }
 
     public class Builder {
-        private BlockItem previous;
         private final Transaction transaction;
         private final Map<TransactionCase, TransactionOutput> transactionOutputs;
         private final TransactionResult.Builder transactionResultBuilder;
         private final List<StateChanges> stateChanges;
+        private BlockItem previous;
 
         @SuppressWarnings("java:S1640")
         private Builder(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -379,13 +379,20 @@ public abstract class AbstractEntityRecordItemListenerTest extends ImporterInteg
         return AccountAmount.newBuilder().setAccountID(account).setAmount(amount);
     }
 
-    protected AccountAmount.Builder accountAmount(long accountNum, long amount) {
-        return accountAmount(AccountID.newBuilder().setAccountNum(accountNum).build(), amount);
+    protected AccountAmount.Builder accountAmount(long accountId, long amount) {
+        return accountAmount(EntityId.of(accountId), amount);
+    }
+
+    protected AccountAmount.Builder accountAmount(EntityId accountId, long amount) {
+        return accountAmount(accountId.toAccountID(), amount);
     }
 
     protected AccountAmount.Builder accountAliasAmount(ByteString alias, long amount) {
         return AccountAmount.newBuilder()
-                .setAccountID(AccountID.newBuilder().setAlias(alias))
+                .setAccountID(AccountID.newBuilder()
+                        .setShardNum(commonProperties.getShard())
+                        .setRealmNum(commonProperties.getRealm())
+                        .setAlias(alias))
                 .setAmount(amount);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.mirror.common.CommonProperties;
+import com.hedera.mirror.common.domain.SystemEntities;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.importer.db.TimePartitionService;
 import com.hedera.mirror.importer.downloader.balance.BalanceDownloaderProperties;
@@ -56,11 +57,11 @@ class HistoricalBalanceServiceTest {
             var service = new HistoricalBalanceService(
                     accountBalanceFileRepository,
                     accountBalanceRepository,
-                    new CommonProperties(),
                     new SimpleMeterRegistry(),
                     platformTransactionManager,
                     historicalBalanceProperties,
                     recordFileRepository,
+                    new SystemEntities(new CommonProperties()),
                     timePartitionService,
                     tokenBalanceRepository);
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
@@ -2,8 +2,6 @@
 
 package com.hedera.mirror.importer.repository;
 
-import static com.hedera.mirror.importer.addressbook.AddressBookServiceImpl.FILE_101;
-import static com.hedera.mirror.importer.addressbook.AddressBookServiceImpl.FILE_102;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
@@ -40,10 +38,14 @@ class AddressBookRepositoryTest extends ImporterIntegrationTest {
     void findLatest() {
         domainBuilder.addressBook().persist();
         var addressBook2 = domainBuilder.addressBook().persist();
-        var addressBook3 =
-                domainBuilder.addressBook().customize(a -> a.fileId(FILE_101)).persist();
+        var addressBook3 = domainBuilder
+                .addressBook()
+                .customize(a -> a.fileId(systemEntities.addressBookFile101()))
+                .persist();
 
-        assertThat(addressBookRepository.findLatest(addressBook3.getStartConsensusTimestamp(), FILE_102.getId()))
+        assertThat(addressBookRepository.findLatest(
+                        addressBook3.getStartConsensusTimestamp(),
+                        systemEntities.addressBookFile102().getId()))
                 .get()
                 .isEqualTo(addressBook2);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -93,20 +93,33 @@ class EntityRepositoryTest extends ImporterIntegrationTest {
         Entity entity = domainBuilder.entity().persist();
         byte[] alias = entity.getAlias();
 
-        assertThat(entityRepository.findByAlias(alias)).get().isEqualTo(entity.getId());
+        assertThat(entityRepository.findByAlias(entity.getShard(), entity.getRealm(), alias))
+                .get()
+                .isEqualTo(entity.getId());
+        assertThat(entityRepository.findByAlias(1000L, entity.getRealm(), alias))
+                .isEmpty();
+        assertThat(entityRepository.findByAlias(entity.getShard(), 1000L, alias))
+                .isEmpty();
     }
 
     @Test
     void findByEvmAddress() {
-        Entity entity = domainBuilder.entity().persist();
-        Entity entityDeleted =
+        var entity = domainBuilder.entity().persist();
+        var entityDeleted =
                 domainBuilder.entity().customize(b -> b.deleted(true)).persist();
-        assertThat(entityRepository.findByEvmAddress(entity.getEvmAddress()))
+
+        assertThat(entityRepository.findByEvmAddress(entity.getShard(), entity.getRealm(), entity.getEvmAddress()))
                 .get()
                 .isEqualTo(entity.getId());
-        assertThat(entityRepository.findByEvmAddress(entityDeleted.getEvmAddress()))
+        assertThat(entityRepository.findByEvmAddress(1000L, entity.getRealm(), entity.getEvmAddress()))
                 .isEmpty();
-        assertThat(entityRepository.findByEvmAddress(new byte[] {1, 2, 3})).isEmpty();
+        assertThat(entityRepository.findByEvmAddress(entity.getShard(), 1000L, entity.getEvmAddress()))
+                .isEmpty();
+        assertThat(entityRepository.findByEvmAddress(
+                        entity.getShard(), entity.getRealm(), entityDeleted.getEvmAddress()))
+                .isEmpty();
+        assertThat(entityRepository.findByEvmAddress(entity.getShard(), entity.getRealm(), new byte[] {1, 2, 3}))
+                .isEmpty();
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -3,10 +3,7 @@
 package com.hedera.mirror.importer.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.from;
 
-import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.schedule.Schedule;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -18,27 +15,7 @@ class ScheduleRepositoryTest extends ImporterIntegrationTest {
 
     @Test
     void save() {
-        Schedule schedule = scheduleRepository.save(schedule(1));
+        var schedule = domainBuilder.schedule().persist();
         assertThat(scheduleRepository.findById(schedule.getScheduleId())).get().isEqualTo(schedule);
-    }
-
-    @Test
-    void updateExecutedTimestamp() {
-        Schedule schedule = scheduleRepository.save(schedule(1));
-        long newExecutedTimestamp = 1000L;
-        scheduleRepository.updateExecutedTimestamp(schedule.getScheduleId(), newExecutedTimestamp);
-        assertThat(scheduleRepository.findById(schedule.getScheduleId()))
-                .get()
-                .returns(newExecutedTimestamp, from(Schedule::getExecutedTimestamp));
-    }
-
-    private Schedule schedule(long consensusTimestamp) {
-        Schedule schedule = new Schedule();
-        schedule.setConsensusTimestamp(consensusTimestamp);
-        schedule.setCreatorAccountId(EntityId.of("0.0.123"));
-        schedule.setPayerAccountId(EntityId.of("0.0.456"));
-        schedule.setScheduleId(EntityId.of("0.0.789"));
-        schedule.setTransactionBody("transaction body".getBytes());
-        return schedule;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
@@ -5,7 +5,6 @@ package com.hedera.mirror.importer.repository;
 import static com.hedera.mirror.common.util.CommonUtils.DEFAULT_TREASURY_ACCOUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance.Id;
@@ -34,13 +33,12 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
             """)
     void balanceSnapshot(long shard, long realm) {
         // given
-        var commonProperties = new CommonProperties();
         commonProperties.setShard(shard);
         commonProperties.setRealm(realm);
         var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
-        var tokenAccount1 = domainBuilder.tokenAccount(shard, realm).persist();
+        var tokenAccount1 = domainBuilder.tokenAccount().persist();
         var tokenAccount2 = domainBuilder
-                .tokenAccount(shard, realm)
+                .tokenAccount()
                 .customize(ta -> ta.associated(false).balance(0))
                 .persist();
 
@@ -100,7 +98,6 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
     void balanceSnapshotDeduplicate(long shard, long realm) {
         long lowerRangeTimestamp = 0L;
         long timestamp = 100;
-        var commonProperties = new CommonProperties();
         commonProperties.setShard(shard);
         commonProperties.setRealm(realm);
         var treasury = SystemEntity.TREASURY_ACCOUNT.getScopedEntityId(commonProperties);
@@ -109,11 +106,11 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         assertThat(tokenBalanceRepository.findAll()).isEmpty();
 
         var tokenAccount = domainBuilder
-                .tokenAccount(shard, realm)
+                .tokenAccount()
                 .customize(t -> t.balanceTimestamp(1L))
                 .persist();
         var tokenAccount2 = domainBuilder
-                .tokenAccount(shard, realm)
+                .tokenAccount()
                 .customize(t -> t.balanceTimestamp(1L))
                 .persist();
 
@@ -143,7 +140,7 @@ class TokenBalanceRepositoryTest extends ImporterIntegrationTest {
         tokenAccountRepository.save(tokenAccount2);
         expected.add(buildTokenBalance(tokenAccount2, timestamp3));
         var tokenAccount3 = domainBuilder
-                .tokenAccount(shard, realm)
+                .tokenAccount()
                 .customize(t -> t.balanceTimestamp(timestamp3))
                 .persist();
         expected.add(buildTokenBalance(tokenAccount3, timestamp3));

--- a/hedera-mirror-rest/__tests__/application.yml
+++ b/hedera-mirror-rest/__tests__/application.yml
@@ -7,3 +7,4 @@ hedera:
         enabled: false
       redis:
         enabled: false
+        maxRetriesPerRequest: 10

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
@@ -4,13 +4,11 @@ package com.hedera.mirror.web3.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -18,24 +16,16 @@ import org.junit.jupiter.params.provider.CsvSource;
 @RequiredArgsConstructor
 class AccountBalanceRepositoryTest extends Web3IntegrationTest {
 
-    private final AccountBalanceRepository accountBalanceRepository;
-
     static final long TRANSFER_AMOUNT = 10L;
     static final long TRANSFER_INCREMENT = 1L;
-
-    private CommonProperties commonProperties;
-
-    @BeforeEach
-    void setup() {
-        commonProperties = new CommonProperties();
-    }
+    private final AccountBalanceRepository accountBalanceRepository;
 
     @Test
     void findHistoricalByIdAndTimestampLessThanBlockTimestamp() {
         var accountBalance = domainBuilder.accountBalance().persist();
         assertThat(accountBalanceRepository.findByIdAndTimestampLessThan(
                         accountBalance.getId().getAccountId().getId(),
-                        accountBalance.getId().getConsensusTimestamp() + 1l))
+                        accountBalance.getId().getConsensusTimestamp() + 1L))
                 .get()
                 .isEqualTo(accountBalance);
     }
@@ -55,7 +45,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         var accountBalance = domainBuilder.accountBalance().persist();
         assertThat(accountBalanceRepository.findByIdAndTimestampLessThan(
                         accountBalance.getId().getAccountId().getId(),
-                        accountBalance.getId().getConsensusTimestamp() - 1l))
+                        accountBalance.getId().getConsensusTimestamp() - 1L))
                 .isEmpty();
     }
 
@@ -124,7 +114,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
                         accountBalance1.getId().getAccountId().getId(),
-                        consensusTimestamp + 10l,
+                        consensusTimestamp + 10L,
                         treasuryAccount.getId()))
                 .get()
                 .isEqualTo(historicalAccountBalance);
@@ -215,14 +205,14 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
 
     private void persistCryptoTransfersBefore(int count, long baseTimestamp, AccountBalance accountBalance1) {
         for (int i = 0; i < count; i++) {
-            long timestamp = baseTimestamp - TRANSFER_INCREMENT * (i + 1l);
+            long timestamp = baseTimestamp - TRANSFER_INCREMENT * (i + 1L);
             persistCryptoTransfer(timestamp, accountBalance1);
         }
     }
 
     private void persistCryptoTransfers(int count, long baseTimestamp, AccountBalance accountBalance1) {
         for (int i = 0; i < count; i++) {
-            long timestamp = baseTimestamp + TRANSFER_INCREMENT * (i + 1l);
+            long timestamp = baseTimestamp + TRANSFER_INCREMENT * (i + 1L);
             persistCryptoTransfer(timestamp, accountBalance1);
         }
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenBalanceRepositoryTest.java
@@ -4,7 +4,6 @@ package com.hedera.mirror.web3.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalance.Id;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
@@ -13,7 +12,6 @@ import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -25,13 +23,6 @@ class TokenBalanceRepositoryTest extends Web3IntegrationTest {
     private static final long TRANSFER_INCREMENT = 1L;
 
     private final TokenBalanceRepository tokenBalanceRepository;
-
-    private CommonProperties commonProperties;
-
-    @BeforeEach
-    void setup() {
-        commonProperties = new CommonProperties();
-    }
 
     @Test
     void findHistoricalByIdAndTimestampLessThanBlockTimestamp() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenBalanceRepositoryTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalance.Id;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.web3.Web3IntegrationTest;
@@ -77,7 +76,7 @@ class TokenBalanceRepositoryTest extends Web3IntegrationTest {
                 .customize(tb -> tb.id(new TokenBalance.Id(
                         accountBalance.getId().getConsensusTimestamp(),
                         accountBalance.getId().getAccountId(),
-                        EntityId.of(shard, realm, domainBuilder.id()))))
+                        domainBuilder.entityId())))
                 .persist();
         long consensusTimestamp = tokenBalance1.getId().getConsensusTimestamp();
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenRepositoryTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.SystemEntity;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
@@ -138,7 +137,7 @@ class TokenRepositoryTest extends Web3IntegrationTest {
             """)
     void findFungibleTotalSupplyByTokenIdAndTimestamp(long shard, long realm) {
         // given
-        var tokenId = EntityId.of(shard, realm, domainBuilder.id());
+        var tokenId = domainBuilder.entityId();
         long blockTimestamp = domainBuilder.timestamp();
         long snapshotTimestamp = blockTimestamp - Duration.ofMinutes(12).toNanos();
         commonProperties.setShard(shard);
@@ -150,48 +149,40 @@ class TokenRepositoryTest extends Web3IntegrationTest {
                 .persist();
         var tokenBalance1 = domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(
-                        new TokenBalance.Id(snapshotTimestamp, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
+                .customize(tb -> tb.id(new TokenBalance.Id(snapshotTimestamp, domainBuilder.entityId(), tokenId)))
                 .persist();
         var tokenBalance2 = domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(
-                        snapshotTimestamp - 1, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
+                .customize(tb -> tb.id(new TokenBalance.Id(snapshotTimestamp - 1, domainBuilder.entityId(), tokenId)))
                 .persist();
         // a token balance after the block timestamp
         domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(
-                        blockTimestamp + 1, EntityId.of(shard, realm, domainBuilder.id()), tokenId)))
+                .customize(tb -> tb.id(new TokenBalance.Id(blockTimestamp + 1, domainBuilder.entityId(), tokenId)))
                 .persist();
         domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(
-                                snapshotTimestamp + 1, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
+                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 1, tokenId, domainBuilder.entityId()))
                         .amount(1L))
                 .persist();
         domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(
-                                snapshotTimestamp + 1, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
+                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 1, tokenId, domainBuilder.entityId()))
                         .amount(-1L))
                 .persist();
         var tokenMintTransfer1 = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(
-                        snapshotTimestamp + 2, tokenId, EntityId.of(shard, realm, domainBuilder.id()))))
+                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 2, tokenId, domainBuilder.entityId())))
                 .persist();
         var tokenBurnTransfer = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(new TokenTransfer.Id(
-                                snapshotTimestamp + 3, tokenId, EntityId.of(shard, realm, domainBuilder.id())))
+                .customize(tt -> tt.id(new TokenTransfer.Id(snapshotTimestamp + 3, tokenId, domainBuilder.entityId()))
                         .amount(-2L))
                 .persist();
         // A mint transfer at the block timestamp
         var tokenMintTransfer2 = domainBuilder
                 .tokenTransfer()
-                .customize(tt -> tt.id(
-                        new TokenTransfer.Id(blockTimestamp, tokenId, EntityId.of(shard, realm, domainBuilder.id()))))
+                .customize(tt -> tt.id(new TokenTransfer.Id(blockTimestamp, tokenId, domainBuilder.entityId())))
                 .persist();
 
         // when, then

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/EntityIdSingletonIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/EntityIdSingletonIntegrationTest.java
@@ -4,7 +4,6 @@ package com.hedera.mirror.web3.state.singleton;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test;
 class EntityIdSingletonIntegrationTest extends Web3IntegrationTest {
 
     private final EntityIdSingleton entityIdSingleton;
-    private final CommonProperties commonProperties;
 
     @Test
     void shouldReturnNextIdWithIncrementAndRealmAndShard() {
@@ -50,11 +48,8 @@ class EntityIdSingletonIntegrationTest extends Web3IntegrationTest {
         final var entityNumber3 = entityIdSingleton.get();
 
         assertThat(entityNumberBeforeConfig.number()).isNotEqualTo(entityWithShardAndRealm.getNum() + 1);
-
         assertThat(entityNumberAfterConfig.number()).isEqualTo(entityWithShardAndRealm.getNum() + 1);
-
         assertThat(entityNumber2.number()).isEqualTo(entity2.getNum() + 1);
-
         assertThat(entityNumber3.number()).isEqualTo(entity3.getNum() + 1);
     }
 }


### PR DESCRIPTION
**Description**:

* Change address book service to use configured realm and shard
* Change `DomainBuilder`, `RecordItemBuilder`, `BlockItemBuilder`, `BlockFileBuilder`, and `RecordFileBuilder` to use configured realm and shard
* Change alias and EVM address lookup to pass shard and realm
* Partially replace `SystemEntity` enum with `SystemEntities` bean
* Set redis `maxRetriesPerRequest` to 10 in REST API tests to decrease flakiness

**Related issue(s)**:

Fixes #10617

**Notes for reviewer**:

I will do a follow up to fully replace `SystemEntity` with `SystemEntities`. It'd be too large of a change to do in this PR.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
