### PR TITLE
Direct gas estimation requests only through mono code

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -100,7 +100,8 @@ class ContractController {
         final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
         final var block = request.getBlock();
 
-        boolean isModularized = evmProperties.directTrafficThroughTransactionExecutionService();
+        boolean isModularized =
+                evmProperties.directTrafficThroughTransactionExecutionService() && !request.isEstimate();
 
         boolean isModularizedRequest = Boolean.parseBoolean(isModularizedHeader);
         // Temporary workaround to ensure modularized services are fully available when enabled.


### PR DESCRIPTION
**Description**:
Temporary direct gas estimation requests only through mono code until the traffic starts going entirely through modularized flow.

Fixes #

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
