### PR TITLE
Fix typo in contractCallEstimateAssociateTokens

### DIFF
--- a/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallEstimateAssociateTokens.js
@@ -8,7 +8,7 @@ const account = __ENV.SPENDER_ADDRESS;
 const token = __ENV.TOKEN_ADDRESS;
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const selector = '0xd91cfc95'; //associateTokenExternal
-const testName = 'estimateAssociateToken';
+const testName = 'estimateAssociateTokens';
 
 //If RUN_WITH_VARIABLES=true will run tests with __ENV variables
 const {options, run} =


### PR DESCRIPTION
**Description**:

**Related issue(s)**:

Fixes #10793

**Notes for reviewer**:
Even though estimate is not enabled, since the module is loaded regardlessly, it still causes the whole test suite to fail.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
