### PR TITLE
Add new topic with custom fee variable in topicIds k6 test

### DIFF
--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -56,37 +56,37 @@ The following parameters can be used to configure all tests regardless of API:
 
 The following parameters can be used to configure a REST test:
 
-| Name                                | Default | Description                        |
-|-------------------------------------| ------- |------------------------------------|
-| DEFAULT_ACCOUNT_ID                  |         |                                    |
-| DEFAULT_ACCOUNT_ID_NFTS             |         |                                    |
-| DEFAULT_ACCOUNT_ID_TOKEN            |         |                                    |
-| DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE  |         |                                    |
-| DEFAULT_ACCOUNT_BALANCE             |         |                                    |
-| DEFAULT_BALANCE_TIMESTAMP           | now()   |                                    |
-| DEFAULT_BLOCK_NUMBER                |         |                                    |
-| DEFAULT_BLOCK_HASH                  |         |                                    |
-| DEFAULT_CONTRACT_ID                 |         |                                    |
-| DEFAULT_CONTRACT_TIMESTAMP          |         |                                    |
-| DEFAULT_CONTRACT_RESULT_HASH        |         |                                    |
-| DEFAULT_NFT_ID                      |         |                                    |
-| DEFAULT_NFT_SERIAL                  |         |                                    |
-| DEFAULT_PUBLIC_KEY                  |         |                                    |
-| DEFAULT_SCHEDULE_ACCOUNT_ID         |         |                                    |
-| DEFAULT_SCHEDULE_ID                 |         |                                    |
-| DEFAULT_START_ACCOUNT               | 0       |                                    |
-| DEFAULT_TOKEN_BALANCE_TIMESTAMP     | now()   |                                    |
-| DEFAULT_TOKEN_ID                    |         |                                    |
-| DEFAULT_TOKEN_NAME                  |         |                                    |
-| DEFAULT_TOKEN_TIMESTAMP             | now()   |                                    |
-| DEFAULT_TOPIC_ID                    |         |                                    |
-| DEFAULT_TOPIC_SEQUENCE              |         |                                    |
-| DEFAULT_TOPIC_TIMESTAMP             |         |                                    |
-| DEFAULT_TOPIC_WITH_FEE_ID           |         | Topic with custom fee id           |
-| DEFAULT_TRANSACTION_HASH            |         |                                    |
-| DEFAULT_TRANSACTION_ID              |         |                                    |
-| REST_TEST_EXCLUDE                   | ^$      | The rest test scenarios to exclude |
-| REST_TEST_INCLUDE                   | .\*     | The rest test scenarios to include |
+| Name                               | Default | Description                        |
+| ---------------------------------- | ------- | ---------------------------------- |
+| DEFAULT_ACCOUNT_ID                 |         |                                    |
+| DEFAULT_ACCOUNT_ID_NFTS            |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN           |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE |         |                                    |
+| DEFAULT_ACCOUNT_BALANCE            |         |                                    |
+| DEFAULT_BALANCE_TIMESTAMP          | now()   |                                    |
+| DEFAULT_BLOCK_NUMBER               |         |                                    |
+| DEFAULT_BLOCK_HASH                 |         |                                    |
+| DEFAULT_CONTRACT_ID                |         |                                    |
+| DEFAULT_CONTRACT_TIMESTAMP         |         |                                    |
+| DEFAULT_CONTRACT_RESULT_HASH       |         |                                    |
+| DEFAULT_NFT_ID                     |         |                                    |
+| DEFAULT_NFT_SERIAL                 |         |                                    |
+| DEFAULT_PUBLIC_KEY                 |         |                                    |
+| DEFAULT_SCHEDULE_ACCOUNT_ID        |         |                                    |
+| DEFAULT_SCHEDULE_ID                |         |                                    |
+| DEFAULT_START_ACCOUNT              | 0       |                                    |
+| DEFAULT_TOKEN_BALANCE_TIMESTAMP    | now()   |                                    |
+| DEFAULT_TOKEN_ID                   |         |                                    |
+| DEFAULT_TOKEN_NAME                 |         |                                    |
+| DEFAULT_TOKEN_TIMESTAMP            | now()   |                                    |
+| DEFAULT_TOPIC_ID                   |         |                                    |
+| DEFAULT_TOPIC_SEQUENCE             |         |                                    |
+| DEFAULT_TOPIC_TIMESTAMP            |         |                                    |
+| DEFAULT_TOPIC_WITH_FEE_ID          |         | Topic with custom fee id           |
+| DEFAULT_TRANSACTION_HASH           |         |                                    |
+| DEFAULT_TRANSACTION_ID             |         |                                    |
+| REST_TEST_EXCLUDE                  | ^$      | The rest test scenarios to exclude |
+| REST_TEST_INCLUDE                  | .\*     | The rest test scenarios to include |
 
 ### REST Java API
 

--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -56,36 +56,37 @@ The following parameters can be used to configure all tests regardless of API:
 
 The following parameters can be used to configure a REST test:
 
-| Name                               | Default | Description                        |
-| ---------------------------------- | ------- | ---------------------------------- |
-| DEFAULT_ACCOUNT_ID                 |         |                                    |
-| DEFAULT_ACCOUNT_ID_NFTS            |         |                                    |
-| DEFAULT_ACCOUNT_ID_TOKEN           |         |                                    |
-| DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE |         |                                    |
-| DEFAULT_ACCOUNT_BALANCE            |         |                                    |
-| DEFAULT_BALANCE_TIMESTAMP          | now()   |                                    |
-| DEFAULT_BLOCK_NUMBER               |         |                                    |
-| DEFAULT_BLOCK_HASH                 |         |                                    |
-| DEFAULT_CONTRACT_ID                |         |                                    |
-| DEFAULT_CONTRACT_TIMESTAMP         |         |                                    |
-| DEFAULT_CONTRACT_RESULT_HASH       |         |                                    |
-| DEFAULT_NFT_ID                     |         |                                    |
-| DEFAULT_NFT_SERIAL                 |         |                                    |
-| DEFAULT_PUBLIC_KEY                 |         |                                    |
-| DEFAULT_SCHEDULE_ACCOUNT_ID        |         |                                    |
-| DEFAULT_SCHEDULE_ID                |         |                                    |
-| DEFAULT_START_ACCOUNT              | 0       |                                    |
-| DEFAULT_TOKEN_BALANCE_TIMESTAMP    | now()   |                                    |
-| DEFAULT_TOKEN_ID                   |         |                                    |
-| DEFAULT_TOKEN_NAME                 |         |                                    |
-| DEFAULT_TOKEN_TIMESTAMP            | now()   |                                    |
-| DEFAULT_TOPIC_ID                   |         |                                    |
-| DEFAULT_TOPIC_SEQUENCE             |         |                                    |
-| DEFAULT_TOPIC_TIMESTAMP            |         |                                    |
-| DEFAULT_TRANSACTION_HASH           |         |                                    |
-| DEFAULT_TRANSACTION_ID             |         |                                    |
-| REST_TEST_EXCLUDE                  | ^$      | The rest test scenarios to exclude |
-| REST_TEST_INCLUDE                  | .\*     | The rest test scenarios to include |
+| Name                                | Default | Description                        |
+|-------------------------------------| ------- |------------------------------------|
+| DEFAULT_ACCOUNT_ID                  |         |                                    |
+| DEFAULT_ACCOUNT_ID_NFTS             |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN            |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE  |         |                                    |
+| DEFAULT_ACCOUNT_BALANCE             |         |                                    |
+| DEFAULT_BALANCE_TIMESTAMP           | now()   |                                    |
+| DEFAULT_BLOCK_NUMBER                |         |                                    |
+| DEFAULT_BLOCK_HASH                  |         |                                    |
+| DEFAULT_CONTRACT_ID                 |         |                                    |
+| DEFAULT_CONTRACT_TIMESTAMP          |         |                                    |
+| DEFAULT_CONTRACT_RESULT_HASH        |         |                                    |
+| DEFAULT_NFT_ID                      |         |                                    |
+| DEFAULT_NFT_SERIAL                  |         |                                    |
+| DEFAULT_PUBLIC_KEY                  |         |                                    |
+| DEFAULT_SCHEDULE_ACCOUNT_ID         |         |                                    |
+| DEFAULT_SCHEDULE_ID                 |         |                                    |
+| DEFAULT_START_ACCOUNT               | 0       |                                    |
+| DEFAULT_TOKEN_BALANCE_TIMESTAMP     | now()   |                                    |
+| DEFAULT_TOKEN_ID                    |         |                                    |
+| DEFAULT_TOKEN_NAME                  |         |                                    |
+| DEFAULT_TOKEN_TIMESTAMP             | now()   |                                    |
+| DEFAULT_TOPIC_ID                    |         |                                    |
+| DEFAULT_TOPIC_SEQUENCE              |         |                                    |
+| DEFAULT_TOPIC_TIMESTAMP             |         |                                    |
+| DEFAULT_TOPIC_WITH_FEE_ID           |         | Topic with custom fee id           |
+| DEFAULT_TRANSACTION_HASH            |         |                                    |
+| DEFAULT_TRANSACTION_ID              |         |                                    |
+| REST_TEST_EXCLUDE                   | ^$      | The rest test scenarios to exclude |
+| REST_TEST_INCLUDE                   | .\*     | The rest test scenarios to include |
 
 ### REST Java API
 

--- a/hedera-mirror-test/k6/src/rest-java/libex/parameters.js
+++ b/hedera-mirror-test/k6/src/rest-java/libex/parameters.js
@@ -8,6 +8,7 @@ const setupTestParameters = (requiredParameters) => {
     DEFAULT_ACCOUNT_ID_AIRDROP_SENDER: __ENV['DEFAULT_ACCOUNT_ID_AIRDROP_SENDER'],
     DEFAULT_ACCOUNT_ID_AIRDROP_RECEIVER: __ENV['DEFAULT_ACCOUNT_ID_AIRDROP_RECEIVER'],
     DEFAULT_TOPIC_ID: __ENV['DEFAULT_TOPIC_ID'],
+    DEFAULT_TOPIC_WITH_FEE_ID: __ENV['DEFAULT_TOPIC_WITH_FEE_ID'],
     DEFAULT_LIMIT: __ENV['DEFAULT_LIMIT'],
   };
   console.info(`Test parameters - ${JSON.stringify(testParameters, null, '\t')}`);

--- a/hedera-mirror-test/k6/src/rest-java/test/topicsId.js
+++ b/hedera-mirror-test/k6/src/rest-java/test/topicsId.js
@@ -6,7 +6,7 @@ import {isSuccess, RestJavaTestScenarioBuilder} from '../libex/common.js';
 
 const urlTag = '/topics/{id}';
 
-const getUrl = (testParameters) => `/topics/${testParameters['DEFAULT_TOPIC_ID']}`;
+const getUrl = (testParameters) => `/topics/${testParameters['DEFAULT_TOPIC_WITH_FEE_ID']}`;
 
 const {options, run, setup} = new RestJavaTestScenarioBuilder()
   .name('topicsId') // use unique scenario name among all tests
@@ -15,7 +15,7 @@ const {options, run, setup} = new RestJavaTestScenarioBuilder()
     const url = `${testParameters['BASE_URL_PREFIX']}${getUrl(testParameters)}`;
     return http.get(url);
   })
-  .requiredParameters('DEFAULT_TOPIC_ID')
+  .requiredParameters('DEFAULT_TOPIC_WITH_FEE_ID')
   .check('Topics ID OK', isSuccess)
   .build();
 


### PR DESCRIPTION
This PR adds a new variable `DEFAULT_TOPIC_WITH_FEE_ID` so we don't override the existing one that is used for another k6 tests like topicsIdMessages and so on

Related to #9569 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
