### PR TITLE
Add evm version 51 support for hedera account service

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -107,7 +107,8 @@ public class EvmConfiguration {
     public static final SemanticVersion EVM_VERSION_0_38 = new SemanticVersion(0, 38, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_46 = new SemanticVersion(0, 46, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_50 = new SemanticVersion(0, 50, 0, "", "");
-    public static final SemanticVersion EVM_VERSION = EVM_VERSION_0_50;
+    public static final SemanticVersion EVM_VERSION_0_51 = new SemanticVersion(0, 51, 0, "", "");
+    public static final SemanticVersion EVM_VERSION = EVM_VERSION_0_51;
     private final CacheProperties cacheProperties;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
     private final GasCalculatorHederaV22 gasCalculator;
@@ -251,6 +252,7 @@ public class EvmConfiguration {
         processorsMap.put(EVM_VERSION_0_38, () -> contractCreationProcessor38);
         processorsMap.put(EVM_VERSION_0_46, () -> contractCreationProcessor46);
         processorsMap.put(EVM_VERSION_0_50, () -> contractCreationProcessor50);
+        processorsMap.put(EVM_VERSION_0_51, () -> contractCreationProcessor50);
         return processorsMap;
     }
 
@@ -267,6 +269,7 @@ public class EvmConfiguration {
         processorsMap.put(EVM_VERSION_0_38, () -> mirrorEvmMessageCallProcessor38);
         processorsMap.put(EVM_VERSION_0_46, () -> mirrorEvmMessageCallProcessor46);
         processorsMap.put(EVM_VERSION_0_50, () -> mirrorEvmMessageCallProcessor50);
+        processorsMap.put(EVM_VERSION_0_51, () -> mirrorEvmMessageCallProcessor50);
         return processorsMap;
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -8,6 +8,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_51;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static com.swirlds.state.lifecycle.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
@@ -381,6 +382,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
             evmVersionsMap.put(49117794L, EVM_VERSION_0_38);
             evmVersionsMap.put(60258042L, EVM_VERSION_0_46);
             evmVersionsMap.put(65435845L, EVM_VERSION_0_50);
+            evmVersionsMap.put(66602102L, EVM_VERSION_0_51);
 
             return Collections.unmodifiableNavigableMap(evmVersionsMap);
         }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -7,6 +7,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_34;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -164,6 +165,8 @@ class MirrorEvmTxProcessorTest {
                 () -> new MessageCallProcessor(v38, new PrecompileContractRegistry()),
                 EVM_VERSION_0_46,
                 () -> new MessageCallProcessor(v38, new PrecompileContractRegistry()),
+                EVM_VERSION_0_50,
+                () -> new MessageCallProcessor(v50, new PrecompileContractRegistry()),
                 EVM_VERSION,
                 () -> new MessageCallProcessor(v50, new PrecompileContractRegistry()));
         Map<SemanticVersion, Provider<ContractCreationProcessor>> processorsMap = Map.of(
@@ -171,6 +174,7 @@ class MirrorEvmTxProcessorTest {
                 EVM_VERSION_0_34, () -> new ContractCreationProcessor(gasCalculator, v34, true, List.of(), 1),
                 EVM_VERSION_0_38, () -> new ContractCreationProcessor(gasCalculator, v38, true, List.of(), 1),
                 EVM_VERSION_0_46, () -> new ContractCreationProcessor(gasCalculator, v38, true, List.of(), 1),
+                EVM_VERSION_0_50, () -> new ContractCreationProcessor(gasCalculator, v50, true, List.of(), 1),
                 EVM_VERSION, () -> new ContractCreationProcessor(gasCalculator, v50, true, List.of(), 1));
 
         mirrorEvmTxProcessor = new MirrorEvmTxProcessorImpl(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
@@ -8,6 +8,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_51;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
@@ -60,6 +61,7 @@ class MirrorNodeEvmPropertiesTest {
         evmVersions.put(100L, EVM_VERSION_0_38);
         evmVersions.put(150L, EVM_VERSION_0_46);
         evmVersions.put(200L, EVM_VERSION_0_50);
+        evmVersions.put(250L, EVM_VERSION_0_51);
         return Collections.unmodifiableNavigableMap(evmVersions);
     }
 
@@ -70,6 +72,7 @@ class MirrorNodeEvmPropertiesTest {
         evmVersions.put(49117794L, EVM_VERSION_0_38);
         evmVersions.put(60258042L, EVM_VERSION_0_46);
         evmVersions.put(65435845L, EVM_VERSION_0_50);
+        evmVersions.put(66602102L, EVM_VERSION_0_51);
         return Collections.unmodifiableNavigableMap(evmVersions);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallHASSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallHASSystemContractTest.java
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.web3j.generated.HRC632Contract;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+
+class ContractCallHASSystemContractTest extends AbstractContractCallServiceTest {
+
+    private static final long DEFAULT_ALLOWANCE_AMOUNT = 100L;
+
+    @Test
+    void testHASAllowanceCall() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC632Contract::deploy);
+        final var ownerEntityId = accountEntityPersist().toEntityId();
+        final var spenderEntityId = accountEntityPersist().toEntityId();
+        domainBuilder
+                .cryptoAllowance()
+                .customize(a -> a.owner(ownerEntityId.getId())
+                        .spender(spenderEntityId.getId())
+                        .amount(DEFAULT_ALLOWANCE_AMOUNT))
+                .persist();
+        final var ownerAddress = toAddress(ownerEntityId).toHexString();
+        final var spenderAddress = toAddress(spenderEntityId).toHexString();
+
+        // When
+        final var functionCall = contract.call_hbarAllowanceCall(ownerAddress, spenderAddress);
+
+        // Then
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var result = functionCall.send();
+            assertThat(result.component2()).isEqualTo(BigInteger.valueOf(DEFAULT_ALLOWANCE_AMOUNT));
+        } else {
+            assertThatThrownBy(functionCall::send)
+                    .isInstanceOf(MirrorEvmTransactionException.class)
+                    .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+        }
+    }
+
+    @Test
+    void testHASAllowanceCallMissingOwner() {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC632Contract::deploy);
+        final var ownerEntityId = domainBuilder.entity().get().toEntityId();
+        final var spenderEntityId = accountEntityPersist().toEntityId();
+        domainBuilder
+                .cryptoAllowance()
+                .customize(a -> a.owner(ownerEntityId.getId())
+                        .spender(spenderEntityId.getId())
+                        .amount(DEFAULT_ALLOWANCE_AMOUNT))
+                .persist();
+        final var ownerAddress = toAddress(ownerEntityId).toHexString();
+        final var spenderAddress = toAddress(spenderEntityId).toHexString();
+
+        // When
+        final var functionCall = contract.call_hbarAllowanceCall(ownerAddress, spenderAddress);
+
+        // Then
+        assertThatThrownBy(functionCall::send)
+                .isInstanceOf(MirrorEvmTransactionException.class)
+                .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class ContractCallSystemPrecompileHistoricalTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
-    @CsvSource({"200", "150", "100", "50", "49"})
+    @CsvSource({"250", "200", "150", "100", "50", "49"})
     void exchangeRatePrecompileTinycentsToTinybars(long blockNumber) throws Exception {
         // Given
         final var recordFile =
@@ -33,7 +33,7 @@ public class ContractCallSystemPrecompileHistoricalTest extends AbstractContract
     }
 
     @ParameterizedTest
-    @CsvSource({"200", "150", "100", "50", "49"})
+    @CsvSource({"250", "200", "150", "100", "50", "49"})
     void exchangeRatePrecompileTinybarsToTinycents(long blockNumber) throws Exception {
         // Given
         final var recordFile =
@@ -50,7 +50,7 @@ public class ContractCallSystemPrecompileHistoricalTest extends AbstractContract
     }
 
     @ParameterizedTest
-    @CsvSource({"200", "150", "100", "50", "49"})
+    @CsvSource({"250", "200", "150", "100", "50", "49"})
     void pseudoRandomGeneratorPrecompileFunctionsTestEthCallHistorical(long blockNumber) throws Exception {
         // Given
         final var recordFile =

--- a/hedera-mirror-web3/src/test/solidity/HRC632Contract.sol
+++ b/hedera-mirror-web3/src/test/solidity/HRC632Contract.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaAccountService.sol";
+import "./IHederaAccountService.sol";
+import "./HederaResponseCodes.sol";
+
+contract HRC632Contract is HederaAccountService {
+
+    function hbarAllowanceCall(address owner, address spender) external returns (int64 responseCode, int256 amount)
+    {
+        (responseCode, amount) = HederaAccountService.hbarAllowance(owner, spender);
+        require(responseCode == HederaResponseCodes.SUCCESS, "Hbar allowance failed");
+    }
+
+    function hbarApproveCall(address owner, address spender, int256 amount) external returns (int64 responseCode)
+    {
+        responseCode = HederaAccountService.hbarApprove(owner, spender, amount);
+        require(responseCode == HederaResponseCodes.SUCCESS, "Hbar approve failed");
+    }
+
+    function hbarApproveDelegateCall(address owner, address spender, int256 amount) external {
+        (bool success, ) =
+                            precompileAddress.delegatecall(
+                abi.encodeWithSignature("hbarApproveCall(address,address,int256)", owner, spender, amount));
+        if (!success) {
+            revert ("hbarApprove() Failed As Expected");
+        }
+    }
+
+    function getEvmAddressAliasCall(address accountNumAlias) external
+    returns (int64 responseCode, address evmAddressAlias) {
+        (responseCode, evmAddressAlias) = HederaAccountService.getEvmAddressAlias(accountNumAlias);
+        require(responseCode == HederaResponseCodes.SUCCESS, "getEvmAddressAlias failed");
+    }
+
+    function getHederaAccountNumAliasCall(address evmAddressAlias) external
+    returns (int64 responseCode, address accountNumAlias) {
+        (responseCode, accountNumAlias) = HederaAccountService.getHederaAccountNumAlias(evmAddressAlias);
+        require(responseCode == HederaResponseCodes.SUCCESS, "getHederaAccountNumAlias failed");
+    }
+
+    function isValidAliasCall(address addr) external returns (bool response) {
+        (response) = HederaAccountService.isValidAlias(addr);
+    }
+
+    function isAuthorizedRawCall(address account, bytes memory messageHash, bytes memory signature) external
+    returns (bool result) {
+        result = HederaAccountService.isAuthorizedRaw(account, messageHash, signature);
+    }
+
+    function isAuthorizedCall(address account, bytes memory message, bytes memory signature) external
+    returns (bool result) {
+        int64 responseCode;
+        (responseCode, result) = HederaAccountService.isAuthorized(account, message, signature);
+        require(responseCode == HederaResponseCodes.SUCCESS, "getHederaAccountNumAlias failed");
+    }
+}

--- a/hedera-mirror-web3/src/test/solidity/HederaAccountService.sol
+++ b/hedera-mirror-web3/src/test/solidity/HederaAccountService.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaResponseCodes.sol";
+import "./IHederaAccountService.sol";
+
+abstract contract HederaAccountService {
+    address constant precompileAddress = address(0x16a);
+
+    // TODO: in case of the precompile call returning `!success` should we return some code OTHER
+    // than `UNKNOWN`, e.g., perhaps `CONTRACT_EXECUTION_EXCEPTION`?  (Perhaps it _never_ happens,
+    // so doesn't matter?)
+
+    /// Returns the amount of hbar that the spender has been authorized to spend on behalf of the owner.
+    /// @param owner The account that has authorized the spender.
+    /// @param spender The account that has been authorized by the owner.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return amount The amount of hbar that the spender has been authorized to spend on behalf of the owner.
+    function hbarAllowance(address owner, address spender) internal returns (int64 responseCode, int256 amount)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.hbarAllowance.selector,
+                owner, spender));
+        (responseCode, amount) = success ? abi.decode(result, (int32, int256)) : (HederaResponseCodes.UNKNOWN, (int256)(0));
+    }
+
+
+    /// Allows spender to withdraw hbars from the owner account multiple times, up to the value amount. If this function is called
+    /// again it overwrites the current allowance with the new amount.
+    /// @param owner The owner of the hbars.
+    /// @param spender the account address authorized to spend.
+    /// @param amount the amount of tokens authorized to spend.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function hbarApprove(address owner, address spender, int256 amount) internal returns (int64 responseCode)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.hbarApprove.selector,
+                owner, spender, amount));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    /// Returns the EVM address alias for the given Hedera account.
+    /// @param accountNumAlias The Hedera account to get the EVM address alias for.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return evmAddressAlias The EVM address alias for the given Hedera account.
+    function getEvmAddressAlias(address accountNumAlias) internal returns (int64 responseCode, address evmAddressAlias) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.getEvmAddressAlias.selector, accountNumAlias));
+        return success ? abi.decode(result, (int64, address)) : (int64(HederaResponseCodes.UNKNOWN), address(0));
+    }
+
+    /// Returns the Hedera Account ID (as account num alias) for the given EVM address alias
+    /// @param evmAddressAlias The EVM address alias to get the Hedera account for.
+    /// @return responseCode The response code for the status of the request.  SUCCESS is 22.
+    /// @return accountNumAlias The Hedera account's num for the given EVM address alias.
+    function getHederaAccountNumAlias(address evmAddressAlias) internal
+    returns (int64 responseCode, address accountNumAlias) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.getHederaAccountNumAlias.selector, evmAddressAlias));
+        return success ? abi.decode(result, (int64, address)) : (int64(HederaResponseCodes.UNKNOWN), address(0));
+    }
+
+    /// Returns true iff a Hedera account num alias or EVM address alias.
+    /// @param addr Some 20-byte address.
+    /// @return response true iff addr is a Hedera account num alias or an EVM address alias (and false otherwise).
+    function isValidAlias(address addr) internal returns (bool response) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.isValidAlias.selector, addr));
+        return success ? abi.decode(result, (bool)) : false;
+    }
+
+    /// Determines if the signature is valid for the given message hash and account.
+    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// @param account The account to check the signature against.
+    /// @param messageHash The hash of the message to check the signature against.
+    /// @param signature The signature to check.
+    /// @return response True if the signature is valid, false otherwise.
+    function isAuthorizedRaw(address account, bytes memory messageHash, bytes memory signature) internal
+    returns (bool response) {
+        (, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.isAuthorizedRaw.selector,
+                account, messageHash, signature));
+        // _not_ checking `success` allows this call to revert on error
+        response = abi.decode(result, (bool));
+    }
+
+    /// Determines if the signature is valid for the given message and account.
+    /// It is assumed that the signature is composed of a possibly complex cryptographic key.
+    /// @param account The account to check the signature against.
+    /// @param message The message to check the signature against.
+    /// @param signature The signature to check encoded as bytes.
+    /// @return responseCode The response code for the status of the request.  SUCCESS is 22.
+    /// @return response True if the signature is valid, false otherwise.
+    function isAuthorized(address account, bytes memory message, bytes memory signature) internal
+    returns (int64 responseCode, bool response) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.isAuthorized.selector,
+                account, message, signature));
+        return success ? abi.decode(result, (int64, bool)) : (int64(HederaResponseCodes.UNKNOWN), false);
+    }
+}

--- a/hedera-mirror-web3/src/test/solidity/IHederaAccountService.sol
+++ b/hedera-mirror-web3/src/test/solidity/IHederaAccountService.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+interface IHederaAccountService {
+
+    /// Returns the amount of hbar that the spender has been authorized to spend on behalf of the owner.
+    /// @param owner The account that has authorized the spender.
+    /// @param spender The account that has been authorized by the owner.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return amount The amount of hbar that the spender has been authorized to spend on behalf of the owner.
+    function hbarAllowance(address owner, address spender)
+    external
+    returns (int64 responseCode, int256 amount);
+
+    /// Allows spender to withdraw hbars from the owner account multiple times, up to the value amount. If this
+    /// function is called again it overwrites the current allowance with the new amount.
+    /// @param owner The owner of the hbars.
+    /// @param spender the account address authorized to spend.
+    /// @param amount the amount of tokens authorized to spend.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function hbarApprove(
+        address owner,
+        address spender,
+        int256 amount
+    ) external returns (int64 responseCode);
+
+    /// Returns the EVM address alias for the given Hedera account.
+    /// @param accountNumAlias The Hedera account to get the EVM address alias for.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return evmAddressAlias The EVM address alias for the given Hedera account.
+    function getEvmAddressAlias(address accountNumAlias) external
+    returns (int64 responseCode, address evmAddressAlias);
+
+    /// Returns the Hedera Account ID (as account num alias) for the given EVM address alias
+    /// @param evmAddressAlias The EVM address alias to get the Hedera account for.
+    /// @return responseCode The response code for the status of the request.  SUCCESS is 22.
+    /// @return accountNumAlias The Hedera account's num for the given EVM address alias.
+    function getHederaAccountNumAlias(address evmAddressAlias) external
+    returns (int64 responseCode, address accountNumAlias);
+
+    /// Returns true iff a Hedera account num alias or EVM address alias.
+    /// @param addr Some 20-byte address.
+    /// @return response true iff addr is a Hedera account num alias or an EVM address alias (and false otherwise).
+    function isValidAlias(address addr) external returns (bool response);
+
+    /// Determines if the signature is valid for the given message hash and account.
+    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// @param account The account to check the signature against.
+    /// @param messageHash The hash of the message to check the signature against.
+    /// @param signature The signature to check.
+    /// @return response True if the signature is valid, false otherwise.
+    function isAuthorizedRaw(
+        address account,
+        bytes memory messageHash,
+        bytes memory signature) external returns (bool response);
+
+    /// Determines if the signature is valid for the given message  and account.
+    /// It is assumed that the signature is composed of a possibly complex cryptographic key.
+    /// @param account The account to check the signature against.
+    /// @param message The message to check the signature against.
+    /// @param signature The signature to check encoded as bytes.
+    /// @return responseCode The response code for the status of the request.  SUCCESS is 22.
+    /// @return response True if the signature is valid, false otherwise.
+    function isAuthorized(
+        address account,
+        bytes memory message,
+        bytes memory signature) external returns (int64 responseCode, bool response);
+}


### PR DESCRIPTION
**Description**:

This PR add support for evm version 51 for modularized.
Adds support for HederaAccountService.

`EvmConfiguration` - add default evm version to 0.51 from 0.50
`MirrorNodeEvmProperties` - update evm versions map for mainnet.
`ContractCallHASSystemContractTest` - basic tests to verify HAS calls

Fixes #10115

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
