### PR TITLE
Deploy v0.127.0-rc2 to integration-docker

### DIFF
--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.127.0-rc1'
+      version: '0.127.0-rc2'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/preprod/integration-docker/helmrelease.yaml
+++ b/clusters/preprod/integration-docker/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '>0.0.0' # Update to the latest release
+      version: '0.127.0-rc2'
   dependsOn:
     - name: mirror
       namespace: common
@@ -66,8 +66,12 @@ spec:
             test:
               acceptance:
                 network: OTHER
+                web3:
+                  modularizedServices: true
       enabled: true
     web3:
       env:
+        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "1.0"
+        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
         HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
 

--- a/clusters/preprod/integration/helmrelease.yaml
+++ b/clusters/preprod/integration/helmrelease.yaml
@@ -78,6 +78,4 @@ spec:
       env:
         HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "1.0"
         HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
-      git:
-        branch: main
 


### PR DESCRIPTION
**Description**:

* Deploy v0.127.0-rc2 to integration-docker for non-zero realm fixes
* Enable modularized web3 in integration-docker since mono doesn't support non-zero realm
* Delete unused `git.branch` from when we used to run acceptance tests via git checkouts

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
