### PR TITLE
Bump Node.js from 18.20.8 to 22.14.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ extra.apply {
     set("grpcVersion", "1.71.0")
     set("jooq.version", "3.20.2") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
-    set("nodeJsVersion", "18.20.8")
+    set("nodeJsVersion", "22.14.0")
     set("protobufVersion", "4.30.2")
     set("reactorGrpcVersion", "1.2.4")
     set("vertxVersion", "4.5.13")

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.8-bookworm-slim
+FROM node:lts-bookworm-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -25,4 +25,4 @@ RUN apt-get update && \
 USER node
 
 # Run
-ENTRYPOINT ["node", "--experimental-specifier-resolution=node", "server.js"]
+ENTRYPOINT ["node", "--import=extensionless/register", "server.js"]

--- a/hedera-mirror-rest/check-state-proof/package.json
+++ b/hedera-mirror-rest/check-state-proof/package.json
@@ -3,7 +3,7 @@
   "version": "0.128.0-SNAPSHOT",
   "description": "An example implementation of a state proof flow for a transaction utilizing the mirror node.",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "type": "module",
   "main": "index.js",

--- a/hedera-mirror-rest/monitoring/package.json
+++ b/hedera-mirror-rest/monitoring/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=20 < 21"
+    "node": ">= 22"
   },
   "scripts": {
     "dev": "nodemon --import=extensionless/register server.js",

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -20,6 +20,7 @@
         "express-http-context",
         "express-openapi-validator",
         "extend",
+        "extensionless",
         "ioredis",
         "ip-anonymize",
         "js-yaml",
@@ -54,6 +55,7 @@
         "express-http-context": "^1.2.5",
         "express-openapi-validator": "^5.4.7",
         "extend": "^3.0.2",
+        "extensionless": "^1.9.9",
         "ioredis": "^5.6.0",
         "ip-anonymize": "^0.1.0",
         "js-yaml": "^4.1.0",
@@ -75,7 +77,7 @@
         "word-wrap": "npm:@aashutoshrathi/word-wrap@^1.2.6"
       },
       "devDependencies": {
-        "@testcontainers/postgresql": "^10.23.0",
+        "@testcontainers/postgresql": "^10.24.0",
         "@testcontainers/redis": "^10.23.0",
         "app-root-path": "^3.1.0",
         "jest": "^29.7.0",
@@ -89,7 +91,7 @@
         "supertest": "^7.1.0"
       },
       "engines": {
-        "node": ">= 18 < 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3340,13 +3342,13 @@
       }
     },
     "node_modules/@testcontainers/postgresql": {
-      "version": "10.23.0",
-      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-10.23.0.tgz",
-      "integrity": "sha512-PKuv7cSWxOxW4aOEuw1XyYb7tS8rcPEmg2ez97WTLLnVZj4JaoPJqFDSEJ2OSj8s3+6HqLC6hXDCMFmYhP63/A==",
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-10.24.0.tgz",
+      "integrity": "sha512-vRgwRxblOMhzNrUOmiXjvjOn8efqI3eyDT4KLh5kgmpGjE+Wz5LtCrhTmT4hMv5KPeZmftx+1OhQQrfyBqSvtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "testcontainers": "^10.23.0"
+        "testcontainers": "^10.24.0"
       }
     },
     "node_modules/@testcontainers/redis": {
@@ -6084,6 +6086,13 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "inBundle": true
+    },
+    "node_modules/extensionless": {
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/extensionless/-/extensionless-1.9.9.tgz",
+      "integrity": "sha512-fz0cWfLA4pgc2nwmg6lc2UH+g+NlFuD63VWqp8n1wGAZSSbPNoARkA54BxXRjYCYW9LvhBnA3NyJaGS2KudkWw==",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -10435,9 +10444,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.23.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.23.0.tgz",
-      "integrity": "sha512-sZeij9mAyR9ixlaAmxU/DNb5LQ2duGCBDVjLaI975QGsX3sWatsBMDr4rqnP3IBemLynp+azZBMEfw75YsXMMg==",
+      "version": "10.24.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.24.0.tgz",
+      "integrity": "sha512-akkNb3LO2IhxnJzl5kj6dDt2c5q0bWHSTUSLSsqqLuZkaJTYCyWCE76uSzJLGpCkASV7Bw4XOOKvn4Tu0GHeFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10453,7 +10462,7 @@
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^2.3.0",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.6",
+        "tar-fs": "^3.0.7",
         "tmp": "^0.2.3",
         "undici": "^5.28.5"
       }

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -6,13 +6,13 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">= 18 < 20"
+    "node": ">= 22"
   },
   "scripts": {
-    "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --experimental-specifier-resolution=node server.js",
-    "start": "node --experimental-specifier-resolution=node server.js",
-    "pretest": "node --experimental-specifier-resolution=node __tests__/integration/generator.js",
-    "test": "node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --import=extensionless/register server.js",
+    "start": "node --import=extensionless/register server.js",
+    "pretest": "node --import=extensionless/register __tests__/integration/generator.js",
+    "test": "node --import=extensionless/register --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "author": "Hedera Mirror Node Team",
   "license": "Apache-2.0",
@@ -29,6 +29,7 @@
     "express-http-context": "^1.2.5",
     "express-openapi-validator": "^5.4.7",
     "extend": "^3.0.2",
+    "extensionless": "^1.9.9",
     "ioredis": "^5.6.0",
     "ip-anonymize": "^0.1.0",
     "js-yaml": "^4.1.0",
@@ -50,7 +51,7 @@
     "word-wrap": "npm:@aashutoshrathi/word-wrap@^1.2.6"
   },
   "devDependencies": {
-    "@testcontainers/postgresql": "^10.23.0",
+    "@testcontainers/postgresql": "^10.24.0",
     "app-root-path": "^3.1.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",


### PR DESCRIPTION
**Description**:

* Bump Node.js from 18.20.8 to 22.14.0
* Change Node.js loader to extensionless

**Related issue(s)**:

Fixes #10667

**Notes for reviewer**:

Test results show mostly equivalent results except a few endpoints like contract results and transactions list that show some degradation. Since 18 is end of life we can live with that as we research further the cause.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
