### PR TITLE
Add claim token airdrop tests

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -610,6 +610,26 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         return Pair.of(tokenToUpdateEntity, autoRenewAccount);
     }
 
+    protected void persistAirdropForFungibleToken(final Token token, final Entity sender, final Entity receiver) {
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+    }
+
+    protected void persistAirdropForNft(final Token token, final Entity sender, final Entity receiver) {
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+    }
+
     protected String getAddressFromEntity(final Entity entity) {
         return EvmTokenUtils.toAddress(entity.toEntityId()).toHexString();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -78,6 +78,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final int DEFAULT_DECIMALS = 12;
     protected static final long DEFAULT_TOKEN_SUPPLY = 1000L;
     protected static final long DEFAULT_AMOUNT_GRANTED = 10L;
+    protected static final BigInteger DEFAULT_TOKEN_AIRDROP_AMOUNT = BigInteger.TEN;
     protected static final BigInteger DEFAULT_FEE_AMOUNT = BigInteger.valueOf(100L);
     protected static final BigInteger DEFAULT_DENOMINATOR_VALUE = BigInteger.valueOf(100L);
     protected static final BigInteger DEFAULT_NUMERATOR_VALUE = BigInteger.valueOf(20L);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAirdropSystemContractTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceTest {
 
-    private static final BigInteger DEFAULT_TOKEN_AIRDROP_AMOUNT = BigInteger.TEN;
     private static final BigInteger ZERO_VALUE = BigInteger.ZERO;
 
     @BeforeEach

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.web3j.generated.ClaimAirdrop;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallServiceTest {
+
+    @Test
+    void claimAirdrop() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+        tokenAccountPersist(token.getTokenId(), sender.getId());
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall =
+                contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimNFTAirdrop() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var treasuryEntityId = accountEntityPersist().toEntityId();
+        final var token = nonFungibleTokenCustomizable(
+                e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
+        nftPersistCustomizable(n ->
+                n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
+        tokenAccountPersist(token.getTokenId(), sender.getId());
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall = contract.send_claimNFTAirdrop(
+                getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress, DEFAULT_SERIAL_NUMBER);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claim10Airdrops() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+
+        List<String> tokens = new ArrayList<>();
+        List<String> senders = new ArrayList<>();
+        List<String> receivers = new ArrayList<>();
+        List<BigInteger> serials = List.of(
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER);
+        for (int i = 0; i < 5; i++) {
+            final var receiver = persistClaimAirdropReceiver();
+
+            final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+            tokenAccountPersist(token.getTokenId(), sender.getId());
+            final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+            domainBuilder
+                    .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                    .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                            .tokenId(token.getTokenId())
+                            .receiverAccountId(receiver.getId())
+                            .senderAccountId(sender.getId()))
+                    .persist();
+
+            tokens.add(tokenAddress);
+            senders.add(getAddressFromEntity(sender));
+            receivers.add(getAddressFromEntity(receiver));
+        }
+
+        final var treasuryEntityId = accountEntityPersist().toEntityId();
+        for (int i = 0; i < 5; i++) {
+            final var receiver = persistClaimAirdropReceiver();
+
+            final var token = nonFungibleTokenCustomizable(
+                    e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
+            nftPersistCustomizable(n ->
+                    n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
+            tokenAccountPersist(token.getTokenId(), sender.getId());
+            final var nftAddress = toAddress(token.getTokenId()).toHexString();
+            domainBuilder
+                    .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                    .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
+                            .tokenId(token.getTokenId())
+                            .receiverAccountId(receiver.getId())
+                            .senderAccountId(sender.getId()))
+                    .persist();
+
+            tokens.add(nftAddress);
+            senders.add(getAddressFromEntity(sender));
+            receivers.add(getAddressFromEntity(receiver));
+        }
+
+        final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claim11AirdropsFails() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+
+        List<String> tokens = new ArrayList<>();
+        List<String> senders = new ArrayList<>();
+        List<String> receivers = new ArrayList<>();
+        List<BigInteger> serials = List.of(
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER,
+                DEFAULT_SERIAL_NUMBER);
+        for (int i = 0; i < 6; i++) {
+            final var receiver = persistClaimAirdropReceiver();
+
+            final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+            tokenAccountPersist(token.getTokenId(), sender.getId());
+            final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+            domainBuilder
+                    .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                    .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                            .tokenId(token.getTokenId())
+                            .receiverAccountId(receiver.getId())
+                            .senderAccountId(sender.getId()))
+                    .persist();
+
+            tokens.add(tokenAddress);
+            senders.add(getAddressFromEntity(sender));
+            receivers.add(getAddressFromEntity(receiver));
+        }
+
+        final var treasuryEntityId = accountEntityPersist().toEntityId();
+        for (int i = 0; i < 5; i++) {
+            final var receiver = persistClaimAirdropReceiver();
+
+            final var token = nonFungibleTokenCustomizable(
+                    e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
+            nftPersistCustomizable(n ->
+                    n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
+            tokenAccountPersist(token.getTokenId(), sender.getId());
+            final var nftAddress = toAddress(token.getTokenId()).toHexString();
+            domainBuilder
+                    .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                    .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
+                            .tokenId(token.getTokenId())
+                            .receiverAccountId(receiver.getId())
+                            .senderAccountId(sender.getId()))
+                    .persist();
+
+            tokens.add(nftAddress);
+            senders.add(getAddressFromEntity(sender));
+            receivers.add(getAddressFromEntity(receiver));
+        }
+
+        final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimAirdropFailsWithMissingAirdropRecord() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+        tokenAccountPersist(token.getTokenId(), sender.getId());
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall =
+                contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimAirdropFailsWithInvalidTokenId() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var token = accountEntityPersist();
+
+        final var functionCall = contract.send_claim(
+                getAddressFromEntity(sender), getAddressFromEntity(receiver), getAddressFromEntity(token));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimAirdropFailsWithInvalidSender() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(token.getTokenId()))
+                .persist();
+
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall = contract.send_claim(tokenAddress, getAddressFromEntity(receiver), tokenAddress);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimAirdropFailsWithInvalidReceiver() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+
+        final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
+        tokenAccountPersist(token.getTokenId(), sender.getId());
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(token.getTokenId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall = contract.send_claim(getAddressFromEntity(sender), tokenAddress, tokenAddress);
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimAirdropFailsWithInvalidNft() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
+                        .tokenId(receiver.getId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+
+        final var functionCall = contract.send_claim(
+                getAddressFromEntity(sender), getAddressFromEntity(receiver), getAddressFromEntity(receiver));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    @Test
+    void claimNFTAirdropFailsWithInvalidSerialNumber() {
+        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+        final var sender = accountEntityPersist();
+        final var receiver = persistClaimAirdropReceiver();
+
+        final var treasuryEntityId = accountEntityPersist().toEntityId();
+        final var token = nonFungibleTokenCustomizable(
+                e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
+        nftPersistCustomizable(n ->
+                n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
+        tokenAccountPersist(token.getTokenId(), sender.getId());
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
+                        .tokenId(token.getTokenId())
+                        .receiverAccountId(receiver.getId())
+                        .senderAccountId(sender.getId()))
+                .persist();
+
+        final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+
+        final var functionCall = contract.send_claimNFTAirdrop(
+                getAddressFromEntity(sender),
+                getAddressFromEntity(receiver),
+                tokenAddress,
+                BigInteger.valueOf(DEFAULT_SERIAL_NUMBER.longValue() + 1));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        } else {
+            assertThrows(PrecompileNotSupportedException.class, functionCall::send);
+        }
+    }
+
+    private Entity persistClaimAirdropReceiver() {
+        return accountEntityPersistCustomizable(
+                e -> e.maxAutomaticTokenAssociations(0).evmAddress(null).alias(null));
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
@@ -28,13 +28,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
         tokenAccountPersist(token.getTokenId(), sender.getId());
 
-        domainBuilder
-                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
-                .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
-                        .tokenId(token.getTokenId())
-                        .receiverAccountId(receiver.getId())
-                        .senderAccountId(sender.getId()))
-                .persist();
+        persistAirdropForFungibleToken(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
@@ -60,13 +54,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
         tokenAccountPersist(token.getTokenId(), sender.getId());
 
-        domainBuilder
-                .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
-                .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
-                        .tokenId(token.getTokenId())
-                        .receiverAccountId(receiver.getId())
-                        .senderAccountId(sender.getId()))
-                .persist();
+        persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
@@ -105,13 +93,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             tokenAccountPersist(token.getTokenId(), sender.getId());
             final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-            domainBuilder
-                    .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
-                    .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
-                            .tokenId(token.getTokenId())
-                            .receiverAccountId(receiver.getId())
-                            .senderAccountId(sender.getId()))
-                    .persist();
+            persistAirdropForFungibleToken(token, sender, receiver);
 
             tokens.add(tokenAddress);
             senders.add(getAddressFromEntity(sender));
@@ -128,13 +110,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                     n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
             tokenAccountPersist(token.getTokenId(), sender.getId());
             final var nftAddress = toAddress(token.getTokenId()).toHexString();
-            domainBuilder
-                    .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
-                    .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
-                            .tokenId(token.getTokenId())
-                            .receiverAccountId(receiver.getId())
-                            .senderAccountId(sender.getId()))
-                    .persist();
+            persistAirdropForNft(token, sender, receiver);
 
             tokens.add(nftAddress);
             senders.add(getAddressFromEntity(sender));
@@ -176,13 +152,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             tokenAccountPersist(token.getTokenId(), sender.getId());
             final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-            domainBuilder
-                    .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
-                    .customize(t -> t.amount(DEFAULT_TOKEN_AIRDROP_AMOUNT.longValue())
-                            .tokenId(token.getTokenId())
-                            .receiverAccountId(receiver.getId())
-                            .senderAccountId(sender.getId()))
-                    .persist();
+            persistAirdropForFungibleToken(token, sender, receiver);
 
             tokens.add(tokenAddress);
             senders.add(getAddressFromEntity(sender));
@@ -199,13 +169,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                     n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
             tokenAccountPersist(token.getTokenId(), sender.getId());
             final var nftAddress = toAddress(token.getTokenId()).toHexString();
-            domainBuilder
-                    .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
-                    .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
-                            .tokenId(token.getTokenId())
-                            .receiverAccountId(receiver.getId())
-                            .senderAccountId(sender.getId()))
-                    .persist();
+            persistAirdropForNft(token, sender, receiver);
 
             tokens.add(nftAddress);
             senders.add(getAddressFromEntity(sender));
@@ -349,13 +313,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 n.accountId(sender.toEntityId()).tokenId(token.getTokenId()).spender(sender.toEntityId()));
         tokenAccountPersist(token.getTokenId(), sender.getId());
 
-        domainBuilder
-                .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
-                .customize(t -> t.serialNumber(DEFAULT_SERIAL_NUMBER.longValue())
-                        .tokenId(token.getTokenId())
-                        .receiverAccountId(receiver.getId())
-                        .senderAccountId(sender.getId()))
-                .persist();
+        persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 

--- a/hedera-mirror-web3/src/test/solidity/ClaimAirdrop.sol
+++ b/hedera-mirror-web3/src/test/solidity/ClaimAirdrop.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+
+contract ClaimAirdrop is HederaTokenService {
+
+    function claim(address sender, address receiver, address token) public returns(int64 responseCode){
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
+
+        IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+        pendingAirdrop.sender = sender;
+        pendingAirdrop.receiver = receiver;
+        pendingAirdrop.token = token;
+
+        pendingAirdrops[0] = pendingAirdrop;
+
+        responseCode = claimAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+
+    function claimNFTAirdrop(address sender, address receiver, address token, int64 serial) public returns(int64 responseCode){
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
+
+        IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+        pendingAirdrop.sender = sender;
+        pendingAirdrop.receiver = receiver;
+        pendingAirdrop.token = token;
+        pendingAirdrop.serial = serial;
+
+        pendingAirdrops[0] = pendingAirdrop;
+
+        responseCode = claimAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+
+    function claimAirdrops(address[] memory senders, address[] memory receivers, address[] memory tokens, int64[] memory serials) public returns (int64 responseCode) {
+        uint length = senders.length;
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](length);
+        for (uint i = 0; i < length; i++) {
+            IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+            pendingAirdrop.sender = senders[i];
+            pendingAirdrop.receiver = receivers[i];
+            pendingAirdrop.token = tokens[i];
+            pendingAirdrop.serial = serials[i];
+
+            pendingAirdrops[i] = pendingAirdrop;
+        }
+
+        responseCode = claimAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+}


### PR DESCRIPTION
**Description**:

This PR adds token claim airdrop tests similar to the ones in `TokenClaimAirdropSystemContractTest` in hiero-consensus-node.


`ContractCallClaimAirdropSystemContractTest` - adds tests
`ClaimAirdrop.sol` - copied from consensus repo

**Related issue(s)**:

Fixes #10773 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
