### PR TITLE
Add cancel airdrop tests

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallCancelAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallCancelAirdropSystemContractTest.java
@@ -11,29 +11,27 @@ import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
-import com.hedera.mirror.web3.web3j.generated.ClaimAirdrop;
+import com.hedera.mirror.web3.web3j.generated.CancelAirdrop;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallServiceTest {
+class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallServiceTest {
 
     @Test
-    void claimAirdrop() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelAirdrop() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
         tokenAccountPersist(token.getTokenId(), sender.getId());
 
         persistAirdropForFungibleToken(token, sender, receiver);
-
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
         final var functionCall =
-                contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+                contract.send_cancelAirdrop(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -42,10 +40,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimNFTAirdrop() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelNFTAirdrop() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         final var treasuryEntityId = accountEntityPersist().toEntityId();
         final var token = nonFungibleTokenCustomizable(
@@ -58,7 +56,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-        final var functionCall = contract.send_claimNFTAirdrop(
+        final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress, DEFAULT_SERIAL_NUMBER);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
@@ -68,8 +66,8 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claim10Airdrops() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancel10Airdrops() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
         List<String> tokens = new ArrayList<>();
@@ -87,7 +85,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 DEFAULT_SERIAL_NUMBER,
                 DEFAULT_SERIAL_NUMBER);
         for (int i = 0; i < 5; i++) {
-            final var receiver = persistClaimAirdropReceiver();
+            final var receiver = persistCancelAirdropReceiver();
 
             final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
             tokenAccountPersist(token.getTokenId(), sender.getId());
@@ -102,7 +100,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var treasuryEntityId = accountEntityPersist().toEntityId();
         for (int i = 0; i < 5; i++) {
-            final var receiver = persistClaimAirdropReceiver();
+            final var receiver = persistCancelAirdropReceiver();
 
             final var token = nonFungibleTokenCustomizable(
                     e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
@@ -117,7 +115,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             receivers.add(getAddressFromEntity(receiver));
         }
 
-        final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        final var functionCall = contract.send_cancelAirdrops(senders, receivers, tokens, serials);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -126,8 +124,8 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claim11AirdropsFails() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancel11AirdropsFails() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
         List<String> tokens = new ArrayList<>();
@@ -146,7 +144,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 DEFAULT_SERIAL_NUMBER,
                 DEFAULT_SERIAL_NUMBER);
         for (int i = 0; i < 6; i++) {
-            final var receiver = persistClaimAirdropReceiver();
+            final var receiver = persistCancelAirdropReceiver();
 
             final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
             tokenAccountPersist(token.getTokenId(), sender.getId());
@@ -161,7 +159,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var treasuryEntityId = accountEntityPersist().toEntityId();
         for (int i = 0; i < 5; i++) {
-            final var receiver = persistClaimAirdropReceiver();
+            final var receiver = persistCancelAirdropReceiver();
 
             final var token = nonFungibleTokenCustomizable(
                     e -> e.treasuryAccountId(treasuryEntityId).kycKey(null));
@@ -176,7 +174,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             receivers.add(getAddressFromEntity(receiver));
         }
 
-        final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        final var functionCall = contract.send_cancelAirdrops(senders, receivers, tokens, serials);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -186,17 +184,17 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimAirdropFailsWithMissingAirdropRecord() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelAirdropFailsWithMissingAirdropRecord() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
         tokenAccountPersist(token.getTokenId(), sender.getId());
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
         final var functionCall =
-                contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+                contract.send_cancelAirdrop(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -206,14 +204,14 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimAirdropFailsWithInvalidTokenId() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelAirdropFailsWithInvalidTokenId() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         final var token = accountEntityPersist();
 
-        final var functionCall = contract.send_claim(
+        final var functionCall = contract.send_cancelAirdrop(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), getAddressFromEntity(token));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
@@ -224,9 +222,9 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimAirdropFailsWithInvalidSender() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
-        final var receiver = persistClaimAirdropReceiver();
+    void cancelAirdropFailsWithInvalidSender() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
+        final var receiver = persistCancelAirdropReceiver();
 
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
 
@@ -240,7 +238,8 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-        final var functionCall = contract.send_claim(tokenAddress, getAddressFromEntity(receiver), tokenAddress);
+        final var functionCall =
+                contract.send_cancelAirdrop(tokenAddress, getAddressFromEntity(receiver), tokenAddress);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -250,8 +249,8 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimAirdropFailsWithInvalidReceiver() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelAirdropFailsWithInvalidReceiver() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
@@ -267,7 +266,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-        final var functionCall = contract.send_claim(getAddressFromEntity(sender), tokenAddress, tokenAddress);
+        final var functionCall = contract.send_cancelAirdrop(getAddressFromEntity(sender), tokenAddress, tokenAddress);
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -277,10 +276,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimAirdropFailsWithInvalidNft() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelAirdropFailsWithInvalidNft() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         domainBuilder
                 .tokenAirdrop(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
@@ -290,7 +289,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                         .senderAccountId(sender.getId()))
                 .persist();
 
-        final var functionCall = contract.send_claimNFTAirdrop(
+        final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 getAddressFromEntity(receiver),
@@ -304,10 +303,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
     }
 
     @Test
-    void claimNFTAirdropFailsWithInvalidSerialNumber() {
-        final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
+    void cancelNFTAirdropFailsWithInvalidSerialNumber() {
+        final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
-        final var receiver = persistClaimAirdropReceiver();
+        final var receiver = persistCancelAirdropReceiver();
 
         final var treasuryEntityId = accountEntityPersist().toEntityId();
         final var token = nonFungibleTokenCustomizable(
@@ -320,7 +319,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
 
-        final var functionCall = contract.send_claimNFTAirdrop(
+        final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 tokenAddress,
@@ -333,7 +332,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         }
     }
 
-    private Entity persistClaimAirdropReceiver() {
+    private Entity persistCancelAirdropReceiver() {
         return accountEntityPersistCustomizable(
                 e -> e.maxAutomaticTokenAssociations(0).evmAddress(null).alias(null));
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallCancelAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallCancelAirdropSystemContractTest.java
@@ -21,6 +21,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdrop() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
@@ -30,8 +31,10 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
         persistAirdropForFungibleToken(token, sender, receiver);
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
+        // When
         final var functionCall =
                 contract.send_cancelAirdrop(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -41,6 +44,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelNFTAirdrop() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
@@ -55,9 +59,10 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
         persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress, DEFAULT_SERIAL_NUMBER);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -67,6 +72,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancel10Airdrops() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -114,8 +120,9 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
             senders.add(getAddressFromEntity(sender));
             receivers.add(getAddressFromEntity(receiver));
         }
-
+        // When
         final var functionCall = contract.send_cancelAirdrops(senders, receivers, tokens, serials);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -125,6 +132,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancel11AirdropsFails() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -173,8 +181,9 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
             senders.add(getAddressFromEntity(sender));
             receivers.add(getAddressFromEntity(receiver));
         }
-
+        // When
         final var functionCall = contract.send_cancelAirdrops(senders, receivers, tokens, serials);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -185,6 +194,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdropFailsWithMissingAirdropRecord() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
@@ -192,9 +202,10 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
         tokenAccountPersist(token.getTokenId(), sender.getId());
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall =
                 contract.send_cancelAirdrop(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -205,14 +216,16 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdropFailsWithInvalidTokenId() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
 
         final var token = accountEntityPersist();
-
+        // When
         final var functionCall = contract.send_cancelAirdrop(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), getAddressFromEntity(token));
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -223,6 +236,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdropFailsWithInvalidSender() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var receiver = persistCancelAirdropReceiver();
 
@@ -237,9 +251,10 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
                 .persist();
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall =
                 contract.send_cancelAirdrop(tokenAddress, getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -250,6 +265,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdropFailsWithInvalidReceiver() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -265,8 +281,9 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
                 .persist();
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_cancelAirdrop(getAddressFromEntity(sender), tokenAddress, tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -277,6 +294,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelAirdropFailsWithInvalidNft() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
@@ -288,12 +306,13 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
                         .receiverAccountId(receiver.getId())
                         .senderAccountId(sender.getId()))
                 .persist();
-
+        // When
         final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 getAddressFromEntity(receiver),
                 DEFAULT_SERIAL_NUMBER);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -304,6 +323,7 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
 
     @Test
     void cancelNFTAirdropFailsWithInvalidSerialNumber() {
+        // Given
         final var contract = testWeb3jService.deploy(CancelAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistCancelAirdropReceiver();
@@ -318,12 +338,13 @@ class ContractCallCancelAirdropSystemContractTest extends AbstractContractCallSe
         persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_cancelNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 tokenAddress,
                 BigInteger.valueOf(DEFAULT_SERIAL_NUMBER.longValue() + 1));
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallClaimAirdropSystemContractTest.java
@@ -21,6 +21,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdrop() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
@@ -31,9 +32,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         persistAirdropForFungibleToken(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall =
                 contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -43,6 +45,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimNFTAirdrop() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
@@ -57,9 +60,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_claimNFTAirdrop(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress, DEFAULT_SERIAL_NUMBER);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -69,6 +73,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claim10Airdrops() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -116,8 +121,9 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             senders.add(getAddressFromEntity(sender));
             receivers.add(getAddressFromEntity(receiver));
         }
-
+        // When
         final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
@@ -127,6 +133,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claim11AirdropsFails() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -175,8 +182,9 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
             senders.add(getAddressFromEntity(sender));
             receivers.add(getAddressFromEntity(receiver));
         }
-
+        // When
         final var functionCall = contract.send_claimAirdrops(senders, receivers, tokens, serials);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -187,6 +195,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdropFailsWithMissingAirdropRecord() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
@@ -194,9 +203,10 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         final var token = fungibleTokenCustomizable(e -> e.kycKey(null));
         tokenAccountPersist(token.getTokenId(), sender.getId());
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall =
                 contract.send_claim(getAddressFromEntity(sender), getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -207,14 +217,16 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdropFailsWithInvalidTokenId() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
 
         final var token = accountEntityPersist();
-
+        // When
         final var functionCall = contract.send_claim(
                 getAddressFromEntity(sender), getAddressFromEntity(receiver), getAddressFromEntity(token));
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -225,6 +237,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdropFailsWithInvalidSender() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var receiver = persistClaimAirdropReceiver();
 
@@ -239,8 +252,9 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 .persist();
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_claim(tokenAddress, getAddressFromEntity(receiver), tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -251,6 +265,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdropFailsWithInvalidReceiver() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
 
@@ -266,8 +281,9 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                 .persist();
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_claim(getAddressFromEntity(sender), tokenAddress, tokenAddress);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -278,6 +294,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimAirdropFailsWithInvalidNft() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
@@ -289,12 +306,13 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
                         .receiverAccountId(receiver.getId())
                         .senderAccountId(sender.getId()))
                 .persist();
-
+        // When
         final var functionCall = contract.send_claimNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 getAddressFromEntity(receiver),
                 DEFAULT_SERIAL_NUMBER);
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -305,6 +323,7 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
 
     @Test
     void claimNFTAirdropFailsWithInvalidSerialNumber() {
+        // Given
         final var contract = testWeb3jService.deploy(ClaimAirdrop::deploy);
         final var sender = accountEntityPersist();
         final var receiver = persistClaimAirdropReceiver();
@@ -319,12 +338,13 @@ class ContractCallClaimAirdropSystemContractTest extends AbstractContractCallSer
         persistAirdropForNft(token, sender, receiver);
 
         final var tokenAddress = toAddress(token.getTokenId()).toHexString();
-
+        // When
         final var functionCall = contract.send_claimNFTAirdrop(
                 getAddressFromEntity(sender),
                 getAddressFromEntity(receiver),
                 tokenAddress,
                 BigInteger.valueOf(DEFAULT_SERIAL_NUMBER.longValue() + 1));
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());

--- a/hedera-mirror-web3/src/test/solidity/CancelAirdrop.sol
+++ b/hedera-mirror-web3/src/test/solidity/CancelAirdrop.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+
+contract CancelAirdrop is HederaTokenService {
+
+    function cancelAirdrop(address sender, address receiver, address token) public returns(int64 responseCode){
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
+
+        IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+        pendingAirdrop.sender = sender;
+        pendingAirdrop.receiver = receiver;
+        pendingAirdrop.token = token;
+
+        pendingAirdrops[0] = pendingAirdrop;
+
+        responseCode = cancelAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+
+    function cancelNFTAirdrop(address sender, address receiver, address token, int64 serial) public returns(int64 responseCode){
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](1);
+
+        IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+        pendingAirdrop.sender = sender;
+        pendingAirdrop.receiver = receiver;
+        pendingAirdrop.token = token;
+        pendingAirdrop.serial = serial;
+
+        pendingAirdrops[0] = pendingAirdrop;
+
+        responseCode = cancelAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+
+    function cancelAirdrops(address[] memory senders, address[] memory receivers, address[] memory tokens, int64[] memory serials) public returns (int64 responseCode) {
+        uint length = senders.length;
+        IHederaTokenService.PendingAirdrop[] memory pendingAirdrops = new IHederaTokenService.PendingAirdrop[](length);
+        for (uint i = 0; i < length; i++) {
+            IHederaTokenService.PendingAirdrop memory pendingAirdrop;
+            pendingAirdrop.sender = senders[i];
+            pendingAirdrop.receiver = receivers[i];
+            pendingAirdrop.token = tokens[i];
+            pendingAirdrop.serial = serials[i];
+
+            pendingAirdrops[i] = pendingAirdrop;
+        }
+
+        responseCode = cancelAirdrops(pendingAirdrops);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+        return responseCode;
+    }
+}


### PR DESCRIPTION
**Description**:
Added `ContractCallCancelAirdropSystemContractTest` similar to `TokenCancelAirdropSystemContractTest` in hiero-consensus-node

`ContractCallCancelAirdropSystemContractTest` - adds tests
`CancelAirdrop.sol` - copied from consensus node
`ContractCallClaimAirdropSystemContractTest` - fix small setup mistake in one of the tests

Fixes #10772

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
