### PR TITLE
Bump com.hedera.hashgraph:app from 0.61.1 to 0.61.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.9")
         api("com.graphql-java:graphql-java-extended-scalars:22.0")
         api("com.graphql-java:graphql-java-extended-validation:22.0")
-        api("com.hedera.hashgraph:app:0.61.1")
+        api("com.hedera.hashgraph:app:0.61.2")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.61.1")
         api("com.hedera.hashgraph:sdk:2.50.0")


### PR DESCRIPTION
**Description**:

Bump com.hedera.hashgraph:app from 0.61.1 to 0.61.2

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
