### PR TITLE
Add `isModularizedCall` exception parameter in the mono flow

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -134,7 +134,7 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
                     && !payload.isEmpty()
                     && isNotCallingNativePrecompile) {
                 throw new MirrorEvmTransactionException(
-                        ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
+                        ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY, false);
             }
 
             return baseInitialFrame

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -31,8 +31,12 @@ public class MirrorEvmTransactionException extends EvmException {
         this(responseCode.name(), detail, hexData, null, null);
     }
 
-    public MirrorEvmTransactionException(final String message, final String detail, final String hexData) {
-        this(message, detail, hexData, null, null);
+    public MirrorEvmTransactionException(
+            final ResponseCodeEnum responseCode,
+            final String detail,
+            final String hexData,
+            final Boolean isCallModularized) {
+        this(responseCode.name(), detail, hexData, null, isCallModularized);
     }
 
     public MirrorEvmTransactionException(
@@ -44,7 +48,7 @@ public class MirrorEvmTransactionException extends EvmException {
             final String message,
             final String detail,
             final String hexData,
-            HederaEvmTransactionProcessingResult result,
+            final HederaEvmTransactionProcessingResult result,
             final Boolean isCallModularized) {
         super(message);
         this.detail = detail;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -495,7 +495,7 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
 
         if (result.getRight() == null) {
             throw new MirrorEvmTransactionException(
-                    INVALID_TOKEN_ID, "Invalid token id or unsupported operation.", StringUtils.EMPTY);
+                    INVALID_TOKEN_ID, "Invalid token id or unsupported operation.", StringUtils.EMPTY, false);
         }
 
         return result;


### PR DESCRIPTION
**Description**:
In the Grafana logs there are some exceptions from the mono code where the `isModularizedCall` is passed like `null` instead of `false`. This PR sets the correct value.

Fixes #10889 
