### PR TITLE
Rework bootstrap to handle V2 DB exports

### DIFF
--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -40,41 +40,41 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
 3. Ensure the following tools are installed on your machine:
 
-   - `psql`
-   - `gunzip`
-   - `realpath`
-   - `flock`
-   - `curl`
-   - `b3sum`
    - `awk`
-   - `python3`
-   - `find`
-   - `cat`
-   - `sed`
-   - `tr`
-   - `sort`
-   - `wc`
-   - `ps`
-   - `date`
+   - `b3sum`
    - `basename`
-   - `mkdir`
-   - `rm`
-   - `touch`
-   - `grep`
    - `bc`
+   - `cat`
+   - `chmod`
    - `column`
-   - `mktemp`
+   - `curl`
+   - `date`
+   - `dd`
+   - `find`
+   - `flock`
+   - `grep`
+   - `gunzip`
+   - `head`
+   - `mkdir`
    - `mkfifo`
+   - `mktemp`
+   - `mv`
    - `nproc`
-   - `sleep`
    - `pgrep`
    - `pkill`
+   - `ps`
+   - `psql`
+   - `python3`
+   - `realpath`
+   - `rm`
+   - `sed`
+   - `sleep`
+   - `sort`
    - `stat`
-   - `dd`
    - `tail`
-   - `head`
-   - `mv`
-   - `chmod`
+   - `touch`
+   - `tr`
+   - `wc`
 
    ### 1. Optional High-Performance Decompressors
 
@@ -91,9 +91,8 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
    **Important:** These thread counts apply _per parallel import job_ launched by the main script, not globally for the entire script. For example, if `MAX_JOBS` allows 4 concurrent import jobs and `B3SUM_THREADS` is set to 2, up to 8 threads could be used for hashing simultaneously across those jobs.
 
-   - `export B3SUM_THREADS=N` (Default: 2) - Number of threads for `b3sum` hash calculation.
-   - `export RAPIDGZIP_THREADS=N` (Default: 2) - Number of threads used _only if_ `rapidgzip` is installed and selected by the script for decompression.
-   - `export IGZIP_THREADS=N` (Default: 2) - Number of threads used _only if_ `igzip` is installed and selected by the script for decompression.
+   - `export B3SUM_THREADS=N`        (Default: 2) - Number of threads for `b3sum` hash calculation.
+   - `export DECOMPRESSOR_THREADS=N` (Default: 2) - Number of threads used *only if* `rapidgzip` or `igzip` is installed and selected by the script for decompression.
 
    **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine _running the script_. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
 
@@ -176,14 +175,12 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
   export PROGRESS_INTERVAL=10
 
   # Parallelism for compression and checksum calculation
-  export IGZIP_THREADS=2      # Number of threads for igzip
-  export RAPIDGZIP_THREADS=2  # Number of threads for rapidgzip
-  export B3SUM_THREADS=2      # Number of threads for b3sum
+  export DECOMPRESSOR_THREADS=2 # Number of threads for selected decompressor (rapidgzip or igzip)
+  export B3SUM_THREADS=2        # Number of threads for b3sum
   ```
 
   - `PROGRESS_INTERVAL`: How often (in seconds) the progress monitor updates `bootstrap_progress.log` (Default: 10).
-  - `IGZIP_THREADS`: Number of threads used _only if_ `igzip` is installed and selected for decompression (Default: 2).
-  - `RAPIDGZIP_THREADS`: Number of threads used _only if_ `rapidgzip` is installed and selected for decompression (Default: 2).
+  - `DECOMPRESSOR_THREADS`: Number of threads used *only if* `rapidgzip` or `igzip` is installed and selected for decompression (Default: 2).
   - `B3SUM_THREADS`: Number of threads for `b3sum` hash calculation (Default: 2).
   - **Note:** The thread counts apply _per parallel import job_. Be mindful of the CPU resources on the machine _running the script_ to avoid overcontention.
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -255,6 +255,9 @@ gcloud storage rsync -r -x ".*_atma\.csv\.gz$" "gs://mirrornode-db-export/$VERSI
 
 ##### Download Full DB Data Files
 
+> [!WARNING]
+> Bootstrap of a full database export is currently **not supported** by the `bootstrap.sh` script in this version. Support for full database bootstrap will be added in the near future. The instructions below are for informational purposes only. For full-db support, you may use the previous version by checking out the following branch: `git checkout release/0.127`. The previous version is compatible only with the data files of the `0.113.2` export in the GCS bucket.
+
 Create a directory and download all files and subdirectories for the selected version:
 
 ```bash
@@ -316,6 +319,9 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
 
    For a full database import:
 
+   > [!WARNING]
+   > The `--full` option for a full database import is currently **not supported** in this version of the `bootstrap.sh` script. Using this flag will result in errors and a failed database bootstrap.
+
    ```bash
    setsid ./bootstrap.sh 8 --full /path/to/db_export 2>> bootstrap.log
    ```
@@ -358,20 +364,20 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
   ```bash
   tail -f bootstrap.log
   ```
-  
+
   - The script logs all activity to `bootstrap.log`.
   - Note that the script processes files in parallel and asynchronously. Activities are logged as they occur, so log entries may appear in an arbitrary order.
 
 - **Check the Progress Log File:**
 
   - To continuously view the latest progress with automatic screen refreshing, use the following `watch` command:
-  
+
   ```bash
   watch --color -n .1 "cat bootstrap_progress.log | tail -n $(($(tput lines) - 2))"
   ```
-  
+
   - This command uses `watch` to re-run the `cat | tail` command every 0.1 seconds. `$(($(tput lines) - 2))` calculates the number of lines in your current terminal and subtracts 2, and `tail -n` uses this value to display the most recent log lines that fit your screen height.
-  
+
   - This file provides a real-time, formatted view of active import jobs. It typically updates every `$PROGRESS_INTERVAL` seconds (default: 10 seconds, configurable in `bootstrap.env`).
   - Columns include:
     - `Filename`: The data file being imported.
@@ -427,10 +433,13 @@ If you need to stop the script before it completes:
 
 - **Re-run the Bootstrap Script:**
 
+  > [!WARNING]
+  > The `--full` option for resuming a full database import is currently **not supported** in this version.
+
   ```bash
   # Minimal DB
   setsid ./bootstrap.sh 8 /path/to/db_export 2>> bootstrap.log
-  
+
   # Full DB
   setsid ./bootstrap.sh 8 --full /path/to/db_export 2>> bootstrap.log
   ```

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -91,8 +91,8 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
    **Important:** These thread counts apply _per parallel import job_ launched by the main script, not globally for the entire script. For example, if `MAX_JOBS` allows 4 concurrent import jobs and `B3SUM_THREADS` is set to 2, up to 8 threads could be used for hashing simultaneously across those jobs.
 
-   - `export B3SUM_THREADS=N`        (Default: 2) - Number of threads for `b3sum` hash calculation.
-   - `export DECOMPRESSOR_THREADS=N` (Default: 2) - Number of threads used *only if* `rapidgzip` or `igzip` is installed and selected by the script for decompression.
+   - `export B3SUM_THREADS=N` (Default: 2) - Number of threads for `b3sum` hash calculation.
+   - `export DECOMPRESSOR_THREADS=N` (Default: 2) - Number of threads used _only if_ `rapidgzip` or `igzip` is installed and selected by the script for decompression.
 
    **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine _running the script_. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
 
@@ -180,7 +180,7 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
   ```
 
   - `PROGRESS_INTERVAL`: How often (in seconds) the progress monitor updates `bootstrap_progress.log` (Default: 10).
-  - `DECOMPRESSOR_THREADS`: Number of threads used *only if* `rapidgzip` or `igzip` is installed and selected for decompression (Default: 2).
+  - `DECOMPRESSOR_THREADS`: Number of threads used _only if_ `rapidgzip` or `igzip` is installed and selected for decompression (Default: 2).
   - `B3SUM_THREADS`: Number of threads for `b3sum` hash calculation (Default: 2).
   - **Note:** The thread counts apply _per parallel import job_. Be mindful of the CPU resources on the machine _running the script_ to avoid overcontention.
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -43,8 +43,7 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
    - `psql`
    - `python3`
 
-   > [!NOTE]
-   > The `bootstrap.sh` script performs a check for all required command-line tools upon startup and will halt if any are missing. The complete list of checked tools can be found in the `REQUIRED_TOOLS` array variable within the `bootstrap.sh` script itself. Most tools listed there are standard core utilities and are typically included in common Linux distributions.
+    **Note:** The `bootstrap.sh` script performs a check for all required command-line tools upon startup and will halt if any are missing. The complete list of checked tools can be found in the `REQUIRED_TOOLS` array variable within the `bootstrap.sh` script itself. Most tools listed there are standard core utilities and are typically included in common Linux distributions.
 
    ### 1. Optional High-Performance Decompressors
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -89,13 +89,13 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
    Thread counts for certain parallel operations can be configured via environment variables before running the script. If not set, defaults will be used.
 
-   **Important:** These thread counts apply *per parallel import job* launched by the main script, not globally for the entire script. For example, if `MAX_JOBS` allows 4 concurrent import jobs and `B3SUM_THREADS` is set to 2, up to 8 threads could be used for hashing simultaneously across those jobs.
+   **Important:** These thread counts apply _per parallel import job_ launched by the main script, not globally for the entire script. For example, if `MAX_JOBS` allows 4 concurrent import jobs and `B3SUM_THREADS` is set to 2, up to 8 threads could be used for hashing simultaneously across those jobs.
 
    - `export B3SUM_THREADS=N` (Default: 2) - Number of threads for `b3sum` hash calculation.
-   - `export RAPIDGZIP_THREADS=N` (Default: 2) - Number of threads used *only if* `rapidgzip` is installed and selected by the script for decompression.
-   - `export IGZIP_THREADS=N` (Default: 2) - Number of threads used *only if* `igzip` is installed and selected by the script for decompression.
+   - `export RAPIDGZIP_THREADS=N` (Default: 2) - Number of threads used _only if_ `rapidgzip` is installed and selected by the script for decompression.
+   - `export IGZIP_THREADS=N` (Default: 2) - Number of threads used _only if_ `igzip` is installed and selected by the script for decompression.
 
-   **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine *running the script*. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
+   **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine _running the script_. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
 
 4. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), then authenticate:
 
@@ -182,10 +182,10 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
   ```
 
   - `PROGRESS_INTERVAL`: How often (in seconds) the progress monitor updates `bootstrap_progress.log` (Default: 10).
-  - `IGZIP_THREADS`: Number of threads used *only if* `igzip` is installed and selected for decompression (Default: 2).
-  - `RAPIDGZIP_THREADS`: Number of threads used *only if* `rapidgzip` is installed and selected for decompression (Default: 2).
+  - `IGZIP_THREADS`: Number of threads used _only if_ `igzip` is installed and selected for decompression (Default: 2).
+  - `RAPIDGZIP_THREADS`: Number of threads used _only if_ `rapidgzip` is installed and selected for decompression (Default: 2).
   - `B3SUM_THREADS`: Number of threads for `b3sum` hash calculation (Default: 2).
-  - **Note:** The thread counts apply *per parallel import job*. Be mindful of the CPU resources on the machine *running the script* to avoid overcontention.
+  - **Note:** The thread counts apply _per parallel import job_. Be mindful of the CPU resources on the machine _running the script_ to avoid overcontention.
 
 - **Save and Secure the `bootstrap.env` File:**
 
@@ -325,6 +325,7 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
    ```bash
    setsid ./bootstrap.sh 8 --full /path/to/db_export 2>> bootstrap.log
    ```
+
    - The script handles logging internally to `bootstrap.log`, and the execution command will also append stderr to the log file
    - `8` refers to the number of CPU cores to use for parallel processing. Adjust this number based on your system's resources.
    - `/path/to/db_export` is the directory where you downloaded the database export data.
@@ -491,7 +492,7 @@ token_balance_p2024_01.csv.gz IMPORTED HASH_VERIFIED
 ## Troubleshooting
 
 - **Connection Errors:**
-  - Confirm that `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` in `bootstrap.env` are correctly set for the *initial connection* (usually as `postgres` user to the `postgres` database). The script switches credentials internally after initialization.
+  - Confirm that `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` in `bootstrap.env` are correctly set for the _initial connection_ (usually as `postgres` user to the `postgres` database). The script switches credentials internally after initialization.
   - Ensure that the database server allows connections from your client machine (check `pg_hba.conf` and firewall rules).
   - Verify that the database port (`PGPORT`) is correct and accessible.
 - **Import Failures:**

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -8,6 +8,7 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
 - [Prerequisites](#prerequisites)
   - [1. Optional High-Performance Decompressors](#1-optional-high-performance-decompressors)
+  - [2. Environment Variables for Thread Counts](#2-environment-variables-for-thread-counts)
 - [Database Initialization and Data Import](#database-initialization-and-data-import)
   - [1. Download the Required Scripts and Configuration File](#1-download-the-required-scripts-and-configuration-file)
   - [2. Edit the `bootstrap.env` Configuration File](#2-edit-the-bootstrapenv-configuration-file)
@@ -45,6 +46,35 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
    - `flock`
    - `curl`
    - `b3sum`
+   - `awk`
+   - `python3`
+   - `find`
+   - `cat`
+   - `sed`
+   - `tr`
+   - `sort`
+   - `wc`
+   - `ps`
+   - `date`
+   - `basename`
+   - `mkdir`
+   - `rm`
+   - `touch`
+   - `grep`
+   - `bc`
+   - `column`
+   - `mktemp`
+   - `mkfifo`
+   - `nproc`
+   - `sleep`
+   - `pgrep`
+   - `pkill`
+   - `stat`
+   - `dd`
+   - `tail`
+   - `head`
+   - `mv`
+   - `chmod`
 
    ### 1. Optional High-Performance Decompressors
 
@@ -54,6 +84,18 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
    - [igzip](https://github.com/intel/isa-l) - Intel's optimized gzip implementation from ISA-L (second fastest option)
 
    These tools can significantly improve decompression performance during the import process. If neither is available, the script will fall back to using standard `gunzip`.
+
+   ### 2. Environment Variables for Thread Counts
+
+   Thread counts for certain parallel operations can be configured via environment variables before running the script. If not set, defaults will be used.
+
+   **Important:** These thread counts apply *per parallel import job* launched by the main script, not globally for the entire script. For example, if `MAX_JOBS` allows 4 concurrent import jobs and `B3SUM_THREADS` is set to 2, up to 8 threads could be used for hashing simultaneously across those jobs.
+
+   - `export B3SUM_THREADS=N` (Default: 2) - Number of threads for `b3sum` hash calculation.
+   - `export RAPIDGZIP_THREADS=N` (Default: 2) - Number of threads used *only if* `rapidgzip` is installed and selected by the script for decompression.
+   - `export IGZIP_THREADS=N` (Default: 2) - Number of threads used *only if* `igzip` is installed and selected by the script for decompression.
+
+   **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine *running the script*. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
 
 4. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), then authenticate:
 
@@ -127,6 +169,24 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
 
   - Replace each `SET_PASSWORD` with a strong, unique password for each respective database user.
 
+- **(Optional) Configure Parallelism and Progress Monitoring:**
+
+  ```bash
+  # Progress tracking refresh interval in seconds
+  export PROGRESS_INTERVAL=10
+
+  # Parallelism for compression and checksum calculation
+  export IGZIP_THREADS=2      # Number of threads for igzip
+  export RAPIDGZIP_THREADS=2  # Number of threads for rapidgzip
+  export B3SUM_THREADS=2      # Number of threads for b3sum
+  ```
+
+  - `PROGRESS_INTERVAL`: How often (in seconds) the progress monitor updates `bootstrap_progress.log` (Default: 10).
+  - `IGZIP_THREADS`: Number of threads used *only if* `igzip` is installed and selected for decompression (Default: 2).
+  - `RAPIDGZIP_THREADS`: Number of threads used *only if* `rapidgzip` is installed and selected for decompression (Default: 2).
+  - `B3SUM_THREADS`: Number of threads for `b3sum` hash calculation (Default: 2).
+  - **Note:** The thread counts apply *per parallel import job*. Be mindful of the CPU resources on the machine *running the script* to avoid overcontention.
+
 - **Save and Secure the `bootstrap.env` File:**
 
   - After editing, save the file.
@@ -186,10 +246,11 @@ Choose one of the following download options based on your needs:
 Create a directory and download only the minimal database files:
 
 ```bash
-mkdir -p /path/to/db_export
+VERSION="<VERSION_NUMBER>"
+DOWNLOAD_DIR="</path/to/db_export>"
+mkdir -p "$DOWNLOAD_DIR"
 export CLOUDSDK_STORAGE_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS=1 && \
-VERSION_NUMBER=<VERSION_NUMBER> && \
-gcloud storage rsync -r -x '.*_part_\d+_\d+_\d+_atma\.csv\.gz$' "gs://mirrornode-db-export/$VERSION_NUMBER/" /path/to/db_export/
+gcloud storage rsync -r -x ".*_atma\.csv\.gz$" "gs://mirrornode-db-export/$VERSION_NUMBER/" "$DOWNLOAD_DIR/"
 ```
 
 ##### Download Full DB Data Files
@@ -197,18 +258,18 @@ gcloud storage rsync -r -x '.*_part_\d+_\d+_\d+_atma\.csv\.gz$' "gs://mirrornode
 Create a directory and download all files and subdirectories for the selected version:
 
 ```bash
-mkdir -p /path/to/db_export
+VERSION="<VERSION_NUMBER>"
+DOWNLOAD_DIR="</path/to/db_export>"
+mkdir -p "$DOWNLOAD_DIR"
 export CLOUDSDK_STORAGE_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS=1 && \
-VERSION_NUMBER=<VERSION_NUMBER> && \
-gcloud storage rsync -r "gs://mirrornode-db-export/$VERSION_NUMBER/" /path/to/db_export/
+gcloud storage rsync -r "gs://mirrornode-db-export/$VERSION_NUMBER/" "$DOWNLOAD_DIR/"
 ```
 
 For both options:
 
-- Replace `/path/to/db_export` with your desired directory path.
+- Replace `</path/to/db_export>` with your actual download path.
 - Replace `<VERSION_NUMBER>` with the version you selected (e.g., `0.111.0`).
 - Ensure all files and subdirectories are downloaded into this single parent directory.
-- **Note:** The `-m` flag enables parallel downloads to speed up the process.
 
 ### 4. Check Version Compatibility
 
@@ -216,19 +277,19 @@ After downloading the data, it's crucial to ensure version compatibility between
 
 **Steps:**
 
-1. **Locate the `MIRRORNODE_VERSION` File:**
+1. **Locate the `MIRRORNODE_VERSION.gz` File:**
 
-   - The downloaded data should include a file named `MIRRORNODE_VERSION` in the root of the `/path/to/db_export` directory.
+   - The downloaded data should include a file named `MIRRORNODE_VERSION.gz` in the root of the `/path/to/db_export` directory.
 
 2. **Check the Mirror Node Version:**
 
    ```bash
-   cat /path/to/db_export/MIRRORNODE_VERSION
+   zcat /path/to/db_export/MIRRORNODE_VERSION.gz
    ```
 
 3. **Ensure Version Compatibility:**
 
-   - The version number in the `MIRRORNODE_VERSION` file should match the name of the directory from which you downloaded the data, and should also be the version of the Mirror Node you are initializing with this export's data.
+   - The version number in the `MIRRORNODE_VERSION.gz` file should match the name of the directory from which you downloaded the data, and should also be the version of the Mirror Node you intend to run using this export's data.
 
 ### 5. Run the Bootstrap Script
 
@@ -250,37 +311,39 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
    For a minimal database import (default):
 
    ```bash
-   setsid ./bootstrap.sh 8 /path/to/db_export > /dev/null 2>> bootstrap.log &
+   setsid ./bootstrap.sh 8 /path/to/db_export 2>> bootstrap.log
    ```
 
    For a full database import:
 
    ```bash
-   setsid ./bootstrap.sh 8 --full /path/to/db_export > /dev/null 2>> bootstrap.log &
+   setsid ./bootstrap.sh 8 --full /path/to/db_export 2>> bootstrap.log
    ```
-
    - The script handles logging internally to `bootstrap.log`, and the execution command will also append stderr to the log file
    - `8` refers to the number of CPU cores to use for parallel processing. Adjust this number based on your system's resources.
    - `/path/to/db_export` is the directory where you downloaded the database export data.
-   - The script creates several tracking files:
+   - The script creates several tracking and logging files:
 
-     - `bootstrap.pid` stores the process ID used for cleanup of all child processes if interrupted
-     - `bootstrap_tracking.txt` tracks the progress of each file's import and hash verification
-     - `bootstrap_discrepancies.log` records any data verification issues
+     - `bootstrap.log`: Main log file for all script operations. Timestamps now use abbreviated month names (e.g., 'Apr' instead of '04').
+     - `bootstrap.pid`: Stores the process ID of the main script, used for managing the process group (e.g., for termination). The script performs an improved check at startup to avoid conflicts with unrelated processes that might share a stale PID.
+     - `bootstrap_tracking.txt`: Tracks the progress of each file's import and hash verification.
+     - `bootstrap_progress.log`: Displays real-time progress of active `psql COPY` operations (see Monitoring section).
+     - `bootstrap_discrepancies.log`: Records any data verification issues (e.g., row count mismatches). Only created if discrepancies are found.
 
-   - **Important**: The SKIP_DB_INIT flag file is automatically created by the script after a successful database initialization. Do not manually create or delete this file. If you need to force the script to reinitialize the database in future runs, remove the flag file using:
+   - **Important**: The `SKIP_DB_INIT` flag file is automatically created by the script after a successful database initialization. Do not manually create or delete this file. If you need to force the script to reinitialize the database in future runs, remove the flag file using:
 
      ```bash
-       rm -f SKIP_DB_INIT
+     rm -f SKIP_DB_INIT
      ```
 
 3. **Verify the Script is Running:**
 
    ```bash
    tail -f bootstrap.log
+   watch --color -n .1 "cat bootstrap_progress.log | tail -n $(($(tput lines) - 2))"
    ```
 
-   - Monitor the progress and check for any errors.
+   - Monitor the progress in the log and progress tracking files and check for any errors or warnings.
 
 4. **Disconnect Your SSH Session (Optional):**
 
@@ -290,14 +353,33 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
 
 #### **6.1. Monitoring the Import Process:**
 
-- **Check the Log File:**
+- **Check the Main Log File:**
 
   ```bash
   tail -f bootstrap.log
   ```
-
+  
   - The script logs all activity to `bootstrap.log`.
   - Note that the script processes files in parallel and asynchronously. Activities are logged as they occur, so log entries may appear in an arbitrary order.
+
+- **Check the Progress Log File:**
+
+  - To continuously view the latest progress with automatic screen refreshing, use the following `watch` command:
+  
+  ```bash
+  watch --color -n .1 "cat bootstrap_progress.log | tail -n $(($(tput lines) - 2))"
+  ```
+  
+  - This command uses `watch` to re-run the `cat | tail` command every 0.1 seconds. `$(($(tput lines) - 2))` calculates the number of lines in your current terminal and subtracts 2, and `tail -n` uses this value to display the most recent log lines that fit your screen height.
+  
+  - This file provides a real-time, formatted view of active import jobs. It typically updates every `$PROGRESS_INTERVAL` seconds (default: 10 seconds, configurable in `bootstrap.env`).
+  - Columns include:
+    - `Filename`: The data file being imported.
+    - `Rows_Processed`: Current count of rows processed by `psql COPY`.
+    - `Total_Rows`: Expected total rows for the file from the manifest.
+    - `Percentage`: Calculated completion percentage.
+    - `Rate(rows/s)`: Estimated import rate in rows per second based on recent progress.
+  - If the monitor cannot query the database or encounters issues, an error message will be displayed in this file. Check `bootstrap.log` for more details in that case.
 
 - **Check the Tracking File:**
 
@@ -307,19 +389,17 @@ The `bootstrap.sh` script initializes the database and imports the data. It is d
 
   - This file tracks the status of each file being imported.
   - Each line contains the file name, followed by two status indicators:
-
-    Import Status:
-
-    - `NOT_STARTED`: File has not begun importing
-    - `IN_PROGRESS`: File is currently being imported
-    - `IMPORTED`: File was successfully imported
-    - `FAILED_TO_IMPORT`: File import failed
-
-    Hash Verification Status:
-
-    - `HASH_UNVERIFIED`: BLAKE3 hash has not been verified yet
-    - `HASH_VERIFIED`: BLAKE3 hash verification passed
-    - `HASH_FAILED`: BLAKE3 hash verification failed
+    - Import Status:
+      - `NOT_STARTED`: File has not begun processing.
+      - `IN_PROGRESS`: File is currently being validated or imported.
+      - `IMPORTED`: File was successfully validated and imported.
+      - `FAILED_VALIDATION`: File failed size or hash check.
+      - `FAILED_TO_IMPORT`: File import process failed (e.g., `psql` error).
+    - Hash Verification Status:
+      - `HASH_UNVERIFIED`: BLAKE3 hash has not been verified yet.
+      - `HASH_VERIFIED`: BLAKE3 hash verification passed.
+      - `UNVERIFIED_COUNT`: (Fallback) Import completed, but row count query failed (e.g., couldn't extract partition info).
+      - `ROW_COUNT_UNVERIFIED`: (Fallback) Import completed, primary row count query failed, but a basic data existence check passed.
 
 #### **6.2. Stopping the Script**
 
@@ -331,8 +411,8 @@ If you need to stop the script before it completes:
    kill -TERM -- -$(cat bootstrap.pid)
    ```
 
-   - Sends the `SIGTERM` signal to the entire process group.
-   - Allows the script and all its background processes to perform cleanup and exit gracefully.
+   - Sends the `SIGTERM` signal to the entire process group identified by the PID in `bootstrap.pid`.
+   - Allows the script and all its background processes to perform cleanup (including removing temporary DB objects and files) and exit gracefully.
 
 2. **If the Script Doesn't Stop, Force Termination of the Process Group:**
 
@@ -341,63 +421,60 @@ If you need to stop the script before it completes:
    ```
 
    - Sends the `SIGKILL` signal to the entire process group.
-   - Immediately terminates the script, however may leave some background jobs running; It is recommended to use the first method.
-
-**Note:** Ensure that `bootstrap.sh` is designed to handle termination signals and clean up its child processes appropriately.
+   - Immediately terminates the script and its children. **Cleanup might not complete successfully.** This is generally discouraged unless graceful termination does not work.
 
 #### **6.3. Resuming the Import Process**
 
 - **Re-run the Bootstrap Script:**
 
   ```bash
-  setsid ./bootstrap.sh 8 /path/to/db_export > /dev/null 2>> bootstrap.log &
+  # Minimal DB
+  setsid ./bootstrap.sh 8 /path/to/db_export 2>> bootstrap.log
+  
+  # Full DB
+  setsid ./bootstrap.sh 8 --full /path/to/db_export 2>> bootstrap.log
   ```
 
   - The script will resume where it left off, skipping files that have already been imported successfully.
-  - Add the `--full` flag if you were using full database mode.
+  - Add the `--full` flag if you were performing a full database import previously.
 
 #### **6.4. Start the Mirrornode Importer**
 
-- Once the bootstrap process completes without errors, you may start the Mirrornode Importer.
+- Once the bootstrap process completes without errors (check `bootstrap.log` for a success message and verify `bootstrap_tracking.txt` shows all files as `IMPORTED HASH_VERIFIED`), you may start the Mirrornode Importer.
 
 ---
 
 ## Handling Failed Imports
 
-During the import process, the script generates a file named `bootstrap_tracking.txt`, which logs the status of each file import. Each line in this file contains the path and name of a file, followed by its import and hash verification status (see [Monitoring and Managing the Import Process](#6-monitoring-and-managing-the-import-process) for status descriptions).
+During the import process, the script generates `bootstrap_tracking.txt`, which logs the status of each file import (see Monitoring section for status descriptions). If any files end with `FAILED_VALIDATION` or `FAILED_TO_IMPORT`, the script will exit with an error status.
 
 **Example of `bootstrap_tracking.txt`:**
 
 ```
-/path/to/db_export/record_file.csv.gz IMPORTED HASH_VERIFIED
-/path/to/db_export/transaction/transaction_part_1.csv.gz IMPORTED HASH_VERIFIED
-/path/to/db_export/transaction/transaction_part_2.csv.gz FAILED_TO_IMPORT HASH_FAILED
-/path/to/db_export/account.csv.gz NOT_STARTED HASH_UNVERIFIED
+schema.sql.gz IMPORTED HASH_VERIFIED
+MIRRORNODE_VERSION.gz IMPORTED HASH_VERIFIED
+account_balance_p2024_01.csv.gz IMPORTED HASH_VERIFIED
+transaction_p2019_08.csv.gz FAILED_VALIDATION HASH_UNVERIFIED
+transaction_p2019_09.csv.gz FAILED_TO_IMPORT HASH_VERIFIED
+token_balance_p2024_01.csv.gz IMPORTED HASH_VERIFIED
 ```
 
 **Notes on Data Consistency:**
 
-- **Automatic Retry:** When you re-run the `bootstrap.sh` script, it will automatically attempt to import files marked as `NOT_STARTED`, `IN_PROGRESS`, or `FAILED_TO_IMPORT`.
-
-- **Data Integrity:** The script ensures that no partial data is committed in case of an import failure.
-
-- **Concurrent Write Safety:** The script uses file locking (`flock`) to safely handle concurrent writes to `bootstrap_tracking.txt`.
+- **Automatic Retry:** When you re-run the `bootstrap.sh` script, it will automatically attempt to import files marked NOT marked as "IMPORTED".
+- **Data Integrity:** The script uses single transactions for `psql COPY` operations, ensuring that no partial data is committed in case of an import failure for a specific file. Hash and size validation prevent corrupted data files from being imported.
+- **Concurrent Write Safety:** The script uses file locking (`flock`) to safely handle concurrent writes to tracking and log files.
 
 ---
 
 ## Additional Notes
 
 - **System Resources:**
-
   - Adjust the number of CPU cores used (`8` in the example) based on your system's capabilities.
-  - Monitor system resources during the import process to ensure optimal performance.
-
+  - Monitor system resources (CPU, memory, I/O) on both the client machine and the database server during the import process to identify potential bottlenecks.
 - **Security Considerations:**
-
   - Secure your `bootstrap.env` file and any other files containing sensitive information.
-
 - **Environment Variables:**
-
   - Ensure `bootstrap.env` is in the same directory as `bootstrap.sh`.
 
 ---
@@ -405,33 +482,24 @@ During the import process, the script generates a file named `bootstrap_tracking
 ## Troubleshooting
 
 - **Connection Errors:**
-
-  - Confirm that `PGHOST` in `bootstrap.env` is correctly set.
-  - Ensure that the database server allows connections from your client machine.
+  - Confirm that `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` in `bootstrap.env` are correctly set for the *initial connection* (usually as `postgres` user to the `postgres` database). The script switches credentials internally after initialization.
+  - Ensure that the database server allows connections from your client machine (check `pg_hba.conf` and firewall rules).
   - Verify that the database port (`PGPORT`) is correct and accessible.
-
 - **Import Failures:**
-
-  - Review `bootstrap.log` for detailed error messages.
-  - Check `bootstrap_tracking.txt` to identify which files failed to import.
-  - Check `bootstrap_discrepancies.log` for any data verification issues (this file is only created if discrepancies are found in file size, row count, or BLAKE3 hash verification).
+  - Review `bootstrap.log` for detailed error messages from `psql`, `b3sum`, decompressors, or the script itself.
+  - Check `bootstrap_tracking.txt` to identify which files failed validation or import.
+  - Check `bootstrap_discrepancies.log` for specific row count mismatches (this file is only created if discrepancies are found).
+  - Check `bootstrap_progress.log` for errors related to the progress monitor itself.
   - Re-run the `bootstrap.sh` script to retry importing failed files.
-
 - **Permission Denied Errors:**
-
-  - Ensure that the user specified in `PGUSER` has the necessary permissions to create databases and roles.
-  - Verify that file permissions allow the script to read and write to the necessary directories and files.
-
+  - Ensure that the initial user specified in `PGUSER` has superuser privileges or sufficient permissions to create databases and roles.
+  - Verify that file system permissions allow the script to read the data directory and write log/tracking files in the current directory.
 - **Environment Variable Issues:**
-
   - Double-check that all required variables in `bootstrap.env` are correctly set and exported.
-  - Ensure there are no typos or missing variables.
-
+  - Ensure there are no typos or missing variables. Check `bootstrap.log` for errors related to sourcing the environment file.
 - **Script Does Not Continue After SSH Disconnect:**
-
   - Ensure you used `setsid` when running the script.
   - Confirm that the script is running by checking the process list:
-
     ```bash
     ps -p $(cat bootstrap.pid)
     ```

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -34,47 +34,17 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
 
 ## Prerequisites
 
-1. **PostgreSQL 16** installed and running.
-
-2. Access to a machine where you can run the initialization and import scripts and connect to the PostgreSQL database.
-
+1. Access to a modern Linux machine (tested on Ubuntu 24.04 LTS) where you can run the initialization/bootstrap scripts and connect to the PostgreSQL database.
+2. **PostgreSQL 16** installed and running.
 3. Ensure the following tools are installed on your machine:
 
-   - `awk`
    - `b3sum`
-   - `basename`
-   - `bc`
-   - `cat`
-   - `chmod`
-   - `column`
    - `curl`
-   - `date`
-   - `dd`
-   - `find`
-   - `flock`
-   - `grep`
-   - `gunzip`
-   - `head`
-   - `mkdir`
-   - `mkfifo`
-   - `mktemp`
-   - `mv`
-   - `nproc`
-   - `pgrep`
-   - `pkill`
-   - `ps`
    - `psql`
    - `python3`
-   - `realpath`
-   - `rm`
-   - `sed`
-   - `sleep`
-   - `sort`
-   - `stat`
-   - `tail`
-   - `touch`
-   - `tr`
-   - `wc`
+
+   > [!NOTE]
+   > The `bootstrap.sh` script performs a check for all required command-line tools upon startup and will halt if any are missing. The complete list of checked tools can be found in the `REQUIRED_TOOLS` array variable within the `bootstrap.sh` script itself. Most tools listed there are standard core utilities and are typically included in common Linux distributions.
 
    ### 1. Optional High-Performance Decompressors
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -250,7 +250,7 @@ VERSION="<VERSION_NUMBER>"
 DOWNLOAD_DIR="</path/to/db_export>"
 mkdir -p "$DOWNLOAD_DIR"
 export CLOUDSDK_STORAGE_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS=1 && \
-gcloud storage rsync -r -x ".*_atma\.csv\.gz$" "gs://mirrornode-db-export/$VERSION_NUMBER/" "$DOWNLOAD_DIR/"
+gcloud storage rsync -r -x ".*_atma\.csv\.gz$" "gs://mirrornode-db-export/$VERSION/" "$DOWNLOAD_DIR/"
 ```
 
 ##### Download Full DB Data Files
@@ -262,7 +262,7 @@ VERSION="<VERSION_NUMBER>"
 DOWNLOAD_DIR="</path/to/db_export>"
 mkdir -p "$DOWNLOAD_DIR"
 export CLOUDSDK_STORAGE_SLICED_OBJECT_DOWNLOAD_MAX_COMPONENTS=1 && \
-gcloud storage rsync -r "gs://mirrornode-db-export/$VERSION_NUMBER/" "$DOWNLOAD_DIR/"
+gcloud storage rsync -r "gs://mirrornode-db-export/$VERSION/" "$DOWNLOAD_DIR/"
 ```
 
 For both options:

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -43,7 +43,15 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
    - `psql`
    - `python3`
 
-    **Note:** The `bootstrap.sh` script performs a check for all required command-line tools upon startup and will halt if any are missing. The complete list of checked tools can be found in the `REQUIRED_TOOLS` array variable within the `bootstrap.sh` script itself. Most tools listed there are standard core utilities and are typically included in common Linux distributions.
+   **Note:** The `bootstrap.sh` script performs a check for all required command-line tools upon startup and will halt if any are missing. The complete list of checked tools can be found in the `REQUIRED_TOOLS` array variable within the `bootstrap.sh` script itself. Most tools listed there are standard core utilities and are typically included in common Linux distributions.
+
+4. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), then authenticate:
+
+   ```bash
+   gcloud auth login
+   ```
+
+5. A Google Cloud Platform (GCP) account with a valid billing account attached (required for downloading data from a Requester Pays bucket). For detailed instructions on obtaining the necessary GCP information, refer to [Hedera's documentation](https://docs.hedera.com/hedera/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-gcs#id-1.-obtain-google-cloud-platform-requester-pay-information).
 
    ### 1. Optional High-Performance Decompressors
 
@@ -64,14 +72,6 @@ This guide provides step-by-step instructions for setting up a fresh PostgreSQL 
    - `export DECOMPRESSOR_THREADS=N` (Default: 2) - Number of threads used _only if_ `rapidgzip` or `igzip` is installed and selected by the script for decompression.
 
    **Note:** The default `gunzip` decompressor is single-threaded and is not affected by these environment variables. When setting these values, be mindful of the CPU resources on the machine _running the script_. Setting thread counts too high relative to available cores can lead to CPU overcontention and potentially slow down the overall process rather than speeding it up.
-
-4. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), then authenticate:
-
-   ```bash
-   gcloud auth login
-   ```
-
-5. A Google Cloud Platform (GCP) account with a valid billing account attached (required for downloading data from a Requester Pays bucket). For detailed instructions on obtaining the necessary GCP information, refer to [Hedera's documentation](https://docs.hedera.com/hedera/core-concepts/mirror-nodes/run-your-own-beta-mirror-node/run-your-own-mirror-node-gcs#id-1.-obtain-google-cloud-platform-requester-pay-information).
 
 ---
 

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
@@ -24,6 +24,5 @@ export WEB3_PASSWORD="SET_PASSWORD"
 export PROGRESS_INTERVAL=10
 
 # Parallelism for decompression and checksum calculation tools
-export IGZIP_THREADS=2      # Number of threads for igzip
-export RAPIDGZIP_THREADS=2  # Number of threads for rapidgzip
-export B3SUM_THREADS=2      # Number of threads for b3sum
+export DECOMPRESSOR_THREADS=2 # Number of threads for selected decompressor (rapidgzip or igzip)
+export B3SUM_THREADS=2        # Number of threads for b3sum

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
@@ -19,3 +19,11 @@ export REST_PASSWORD="SET_PASSWORD"
 export REST_JAVA_PASSWORD="SET_PASSWORD"
 export ROSETTA_PASSWORD="SET_PASSWORD"
 export WEB3_PASSWORD="SET_PASSWORD"
+
+# Progress tracking refresh interval in seconds
+export PROGRESS_INTERVAL=10
+
+# Parallelism for compression and checksum calculation
+export IGZIP_THREADS=2      # Number of threads for igzip
+export RAPIDGZIP_THREADS=2 # Number of threads for rapidgzip
+export B3SUM_THREADS=2      # Number of threads for b3sum

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
@@ -23,7 +23,7 @@ export WEB3_PASSWORD="SET_PASSWORD"
 # Progress tracking refresh interval in seconds
 export PROGRESS_INTERVAL=10
 
-# Parallelism for compression and checksum calculation
+# Parallelism for decompression and checksum calculation tools
 export IGZIP_THREADS=2      # Number of threads for igzip
-export RAPIDGZIP_THREADS=2 # Number of threads for rapidgzip
+export RAPIDGZIP_THREADS=2  # Number of threads for rapidgzip
 export B3SUM_THREADS=2      # Number of threads for b3sum

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
@@ -2,68 +2,97 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Save original stderr destination to FD 9 before any redirections
+exec 9>&2
+
 set -m # Start a new process group and detach from terminal
 exec 1>/dev/null 2>>bootstrap.log
 [[ -t 1 ]] && exec </dev/null >&0 2>&0
 
-# Global variables
-CLEANUP_IN_PROGRESS_FILE="bootstrap.cleanup"
-export CLEANUP_IN_PROGRESS_FILE
-
-# Save original stderr and redirect it to suppress job control messages
 exec 3>&2
 exec 2>/dev/null
 
-# Write script's PID to $PID_FILE for process management
 PID_FILE="bootstrap.pid"
+script_name=$(basename "$0")
+
+# Check if another instance of the script is already running
+if [[ -f "$PID_FILE" ]]; then
+  old_pid=$(cat "$PID_FILE" 2>/dev/null)
+  if [[ -n "$old_pid" && "$old_pid" =~ ^[0-9]+$ ]]; then
+    if ps -p "$old_pid" -o comm= | grep -q -E "^(bash|sh|$script_name|${script_name%.sh})$"; then
+      if [[ -f "/proc/$old_pid/cmdline" ]] && grep -q "$script_name" "/proc/$old_pid/cmdline"; then
+         echo "[ERROR] Another instance of $script_name is already running with PID: $old_pid. Exiting." >&9
+         exit 1
+      else
+         echo "[WARN] Stale PID file found ($PID_FILE) for PID $old_pid, but it's not a $script_name process. Removing stale file." >&9
+         rm -f "$PID_FILE"
+      fi
+    else
+      echo "[WARN] Stale PID file found ($PID_FILE) for non-existent process PID $old_pid. Removing stale file." >&9
+      rm -f "$PID_FILE"
+    fi
+  else
+    echo "[WARN] Stale PID file found ($PID_FILE) but contains invalid PID '$old_pid'. Removing stale file." >&9
+    rm -f "$PID_FILE"
+  fi
+fi
+
+# Write script's PID to $PID_FILE for process management
 echo $$ > "$PID_FILE"
 
 ####################################
 # Variables
 ####################################
 
-# Minimum required Bash version
 REQUIRED_BASH_MAJOR=4
 REQUIRED_BASH_MINOR=3
 
-# Status tracking and logging files
-LOG_FILE="bootstrap.log"                    # Main log file
-TRACKING_FILE="bootstrap_tracking.txt"      # Import status tracking
-LOCK_FILE="bootstrap_tracking.lock"         # File locking for thread safety
-DISCREPANCY_FILE="bootstrap_discrepancies.log"  # Verification failures
+DEBUG_MODE=${DEBUG_MODE:-false}
+
+LOG_FILE="bootstrap.log"
+LOG_FILE_LOCK="$LOG_FILE.lock"
+TRACKING_FILE="bootstrap_tracking.txt"
+LOCK_FILE="bootstrap_tracking.lock"
+DISCREPANCY_FILE="bootstrap_discrepancies.log"
+DISCREPANCY_FILE_LOCK="$DISCREPANCY_FILE.lock"
+PROGRESS_FILE="bootstrap_progress.log"
+PROGRESS_INTERVAL=${PROGRESS_INTERVAL:-10}
+PROGRESS_DB_TABLE="bootstrap_manifest_progress" 
+export MONITOR_STATE_FILE="/tmp/bootstrap_monitor_state.txt"
+MONITOR_STOP_SIGNAL_FILE="/tmp/bootstrap_monitor.stop"
 
 # Required system tools
 # Note: A decompressor (rapidgzip, igzip, or gunzip) is checked separately
-REQUIRED_TOOLS=("psql" "realpath" "flock" "curl" "b3sum")
+REQUIRED_TOOLS=("psql" "realpath" "flock" "curl" "b3sum" "awk" "python3" "find" "cat" \
+    "sed" "tr" "sort" "wc" "ps" "date" "basename" "mkdir" "rm" "touch" "grep" "bc" "column" \
+    "mktemp" "mkfifo" "nproc" "sleep" "pgrep" "pkill" "stat" "dd" "tail" "head" "mv" "chmod")
 
-# Initialize tracking variables
-export DECOMPRESS_TOOL=""          # Decompression tool to use (rapidgzip, igzip, or gunzip)
-export DECOMPRESS_FLAGS=""         # Flags for the decompression tool command
-export DECOMPRESSOR_CHECKED=false  # Track if decompressor check has been performed
-MISSING_TOOLS=()                   # List of missing required tools
+export DECOMPRESS_TOOL=""
+export DECOMPRESS_FLAGS=""
+export DECOMPRESSOR_CHECKED=false
+MISSING_TOOLS=()
 
-# Skip database initialization if this file exists
-export DB_SKIP_FLAG_FILE="SKIP_DB_INIT"    # Flag file to skip database initialization
+export DB_SKIP_FLAG_FILE="SKIP_DB_INIT"
+export CLEANUP_IN_PROGRESS_FILE="BOOTSTRAP_CLEANUP"
 
-# Manifest selection (manifest.csv or manifest.minimal.csv)
-USE_FULL_DB=""              # Use full manifest flag
-MANIFEST_FILE=""            # Path to the manifest file
+USE_FULL_DB=""
+MANIFEST_FILE=""
 
 # Parallel processing configuration
-B3SUM_NUM_THREADS=1         # Number of threads for BLAKE3 hash calculation
-MAX_JOBS=""                 # Maximum number of concurrent import jobs
+B3SUM_NUM_THREADS=${B3SUM_THREADS:-2}         # Number of threads for BLAKE3 hash calculation
+RAPIDGZIP_NUM_THREADS=${RAPIDGZIP_THREADS:-2} # Number of threads for rapidgzip decompression
+IGZIP_NUM_THREADS=${IGZIP_THREADS:-2}         # Number of threads for igzip decompression
+MAX_JOBS=""                                   # Maximum number of concurrent import jobs
 
 # Associative array for manifest row counts
-declare -A manifest_counts  # Map of filename to expected row count
-
-# Process tracking arrays
-declare -a pids=()          # List of background process IDs
+declare -A manifest_counts
+# Process tracking array
+declare -a pids=()
 
 ####################################
 # Functions
 ####################################
 
-# Enable/disable pipefail for error handling
 enable_pipefail() {
   set -euo pipefail
 }
@@ -74,10 +103,26 @@ disable_pipefail() {
 
 export -f enable_pipefail disable_pipefail
 
-# Log messages with UTC timestamps to $LOG_FILE
+with_lock() {
+  local lockfile="$1"
+  local cmd="$2"
+  
+  (
+    flock -x 200
+    eval "$cmd"
+  ) 200>"$lockfile"
+}
+
+export -f with_lock
+
 log() {
   local msg="$1"
   local level="${2:-INFO}"
+
+  # Print debug messages only when DEBUG_MODE="true"
+  if [[ "$DEBUG_MODE" == "false" && "$level" == "DEBUG" ]]; then
+    return
+  fi
 
   # During cleanup, only log messages from cleanup itself
   if [[ -f "$CLEANUP_IN_PROGRESS_FILE" && "$level" != "TERMINATE" ]]; then
@@ -85,12 +130,12 @@ log() {
   fi
 
   local timestamp
-  timestamp=$(date -u '+%Y-%m-%d %H:%M:%S')
-
-  echo "[$timestamp] [$level] $msg" >> "$LOG_FILE"
+  timestamp=$(date -u '+%Y-%b-%d %H:%M:%S')
+  local log_cmd="echo \"[$timestamp] [$level] $msg\" >> \"$LOG_FILE\""
+  
+  with_lock "$LOG_FILE_LOCK" "$log_cmd"
 }
 
-# Display usage instructions and command-line options directly to the terminal
 show_help() {
   cat > /dev/tty << EOF
 Usage: $0 DB_CPU_CORES [--full] IMPORT_DIR
@@ -114,7 +159,6 @@ Example:
 EOF
 }
 
-# Verify minimum required Bash version (4.3+)
 check_bash_version() {
   local current_major=${BASH_VERSINFO[0]}
   local current_minor=${BASH_VERSINFO[1]}
@@ -126,16 +170,13 @@ check_bash_version() {
   fi
 }
 
-# Verify presence of required system tools and optimal decompressors
 check_required_tools() {
-  # Check required tools
   for tool in "${REQUIRED_TOOLS[@]}"; do
     if ! command -v "$tool" &> /dev/null; then
         MISSING_TOOLS+=("$tool")
     fi
   done
 
-  # Always check for a decompressor (at minimum gunzip must exist)
   if ! $DECOMPRESSOR_CHECKED; then
     if ! determine_decompression_tool; then
       log "No decompression tool found - at minimum gunzip is required" "ERROR"
@@ -146,10 +187,8 @@ check_required_tools() {
     DECOMPRESSOR_CHECKED=true
   fi
 
-  # Report all missing tools at once if any
   if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
     log "The following required tools are not installed:" "ERROR"
-    # Use sort -u to remove duplicates
     printf "%s\n" "${MISSING_TOOLS[@]}" | sort -u | while read -r tool; do
       log "  - $tool" "ERROR"
     done
@@ -160,19 +199,18 @@ check_required_tools() {
   return 0
 }
 
-# Select fastest available decompression tool (rapidgzip > igzip > gunzip)
 determine_decompression_tool() {
   if command -v rapidgzip >/dev/null 2>&1; then
     DECOMPRESS_TOOL="rapidgzip"
-    DECOMPRESS_FLAGS=(-d -c -P1)
-    log "Using rapidgzip for decompression"
+    DECOMPRESS_FLAGS=(-d -c "-P${RAPIDGZIP_NUM_THREADS}")
+    log "Using rapidgzip with ${RAPIDGZIP_NUM_THREADS} threads for decompression"
     return 0
   fi
 
   if command -v igzip >/dev/null 2>&1; then
     DECOMPRESS_TOOL="igzip"
-    DECOMPRESS_FLAGS=(-d -c -T1)
-    log "Using igzip for decompression"
+    DECOMPRESS_FLAGS=(-d -c "-T${IGZIP_NUM_THREADS}")
+    log "Using igzip with ${IGZIP_NUM_THREADS} threads for decompression"
     return 0
   fi
 
@@ -183,12 +221,10 @@ determine_decompression_tool() {
     return 0
   fi
 
-  # No decompression tools found
   MISSING_TOOLS+=("gunzip")
   return 1
 }
 
-# Recursively terminate a process and all its child processes
 kill_descendants() {
   local pid="$1"
   local children
@@ -199,54 +235,70 @@ kill_descendants() {
   kill -9 "$pid" >/dev/null 2>&1
 }
 
-# Clean up resources and terminate child processes on script exit
 cleanup() {
   disable_pipefail
   local trap_type="$1"
+  
+  log "Cleanup function triggered with trap type: $trap_type"
 
-  if [[ "$trap_type" == "INT" || "$trap_type" == "TERM" ]]; then
-    # Redirect stderr to /dev/null for the remainder of cleanup
+  if [[ -f "$LOCK_FILE" ]]; then
+    rm -f "$LOCK_FILE"
+  fi
+
+  if [[ "$trap_type" == "INT" || "$trap_type" == "TERM" || "$trap_type" == "PIPE" ]]; then
     exec 2>/dev/null
     touch "$CLEANUP_IN_PROGRESS_FILE"
 
-    # If a tracking file update was in progress, complete it
     if [[ -f "${TRACKING_FILE}.tmp" ]]; then
       mv "${TRACKING_FILE}.tmp" "$TRACKING_FILE"
     fi
 
-    # First kill all psql processes to stop any active queries
-    pkill -9 psql
+    pkill -9 psql 2>/dev/null || true
 
-    # Kill all decompression tool processes
-    pkill -9 "$DECOMPRESS_TOOL"
+    if [[ -n "$DECOMPRESS_TOOL" ]]; then
+      pkill -9 "$DECOMPRESS_TOOL" 2>/dev/null || true
+    fi
 
-    # Kill all background jobs and their descendants
     for pid in "${pids[@]}"; do
       if kill -0 "$pid" 2>/dev/null; then
         kill_descendants "$pid"
       fi
     done
 
-    # Force kill any remaining children immediately
-    pkill -9 -P $$
+    pkill -9 -P $$ 2>/dev/null || true
 
     log "Script interrupted. All processes terminated." "TERMINATE"
 
-    wait  # Clean up any zombies
+    wait 2>/dev/null || true
 
-    # Remove files only after ensuring all processes are dead
-    rm -f "$PID_FILE" "$LOCK_FILE" "$CLEANUP_IN_PROGRESS_FILE"
+    if command -v psql >/dev/null 2>&1; then
+      log "Attempting final cleanup of temporary progress table..." "DEBUG"
 
-    # Exit with a non-zero status to indicate interruption
+      if [[ "$trap_type" != "EXIT" ]] || [[ $(jobs -rp | wc -l) -eq 0 ]]; then
+        psql -q -c "DROP TABLE IF EXISTS ${PROGRESS_DB_TABLE};" >/dev/null 2>&1 || true
+      else
+        log "Skipping table drop during EXIT trap as processes are still running" "DEBUG"
+      fi
+    fi
+
+    rm -f "$PID_FILE" "$CLEANUP_IN_PROGRESS_FILE" "$MONITOR_STATE_FILE" "$PROGRESS_FILE" "$LOG_FILE_LOCK"
+
     exit 1
   fi
 
-  # Normal cleanup actions (on EXIT)
-  rm -f "$PID_FILE" "$LOCK_FILE" "$CLEANUP_IN_PROGRESS_FILE"
+  if command -v psql >/dev/null 2>&1; then
+    log "Attempting final cleanup of temporary progress table..." "DEBUG"
+
+    if [[ "$trap_type" != "EXIT" ]] || [[ $(jobs -rp | wc -l) -eq 0 ]]; then
+      psql -q -c "DROP TABLE IF EXISTS ${PROGRESS_DB_TABLE};" >/dev/null 2>&1 || true
+    else
+      log "Skipping table drop during EXIT trap as processes are still running" "DEBUG"
+    fi
+  fi
+
+  rm -f "$PID_FILE" "$CLEANUP_IN_PROGRESS_FILE" "$PROGRESS_FILE" "$LOG_FILE_LOCK"
 }
 
-# Thread-safe update of the tracking file using flock
-# Format: filename status hash_status
 write_tracking_file() {
   local file="$1"
   local new_status="${2:-}"
@@ -254,50 +306,47 @@ write_tracking_file() {
   local basename_file
   basename_file=$(basename "$file")
 
-  (
-    flock -x 200
+  local cmd="
+    # Get the full existing line
+    local full_existing_line
+    full_existing_line=\$(grep \"^$basename_file \" \"$TRACKING_FILE\" 2>/dev/null | tail -n 1)
 
-    # Pull existing line (if any)
-    local existing_line
-    existing_line=$(read_tracking_status "$basename_file")
-
-    local old_status=""
-    local old_hash=""
-    if [[ -n "$existing_line" ]]; then
-      old_status=$(echo "$existing_line" | awk '{print $2}')
-      old_hash=$(echo "$existing_line" | awk '{print $3}')
+    local old_status=''
+    local old_hash=''
+    if [[ -n \"\$full_existing_line\" ]]; then
+      old_status=\$(echo \"\$full_existing_line\" | awk '{print \$2}')
+      old_hash=\$(echo \"\$full_existing_line\" | awk '{print \$3}')
     fi
 
     # If a line exists but no new import status was passed, keep the old import status
-    # otherwise default to NOT_STARTED for brand-new file
-    if [[ -z "$new_status" ]]; then
-      if [[ -n "$old_status" ]]; then
-        new_status="$old_status"
+    if [[ -z \"$new_status\" ]]; then
+      if [[ -n \"\$old_status\" ]]; then
+        new_status=\"\$old_status\"
       else
-        new_status="NOT_STARTED"
+        new_status=\"NOT_STARTED\"
       fi
     fi
 
     # If a line exists but no new hash status was passed, keep the old hash status
-    # otherwise default to HASH_UNVERIFIED for brand-new file
-    if [[ -z "$new_hash_status" ]]; then
-      if [[ -n "$old_hash" ]]; then
-        new_hash_status="$old_hash"
+    if [[ -z \"$new_hash_status\" ]]; then
+      if [[ -n \"\$old_hash\" ]]; then
+        new_hash_status=\"\$old_hash\"
       else
-        new_hash_status="HASH_UNVERIFIED"
+        new_hash_status=\"HASH_UNVERIFIED\"
       fi
     fi
 
     # Remove any existing entry for this file
-    grep -v "^$basename_file " "$TRACKING_FILE" > "${TRACKING_FILE}.tmp" 2>/dev/null || true
-    mv "${TRACKING_FILE}.tmp" "$TRACKING_FILE"
+    grep -v \"^$basename_file \" \"$TRACKING_FILE\" > \"${TRACKING_FILE}.tmp\" 2>/dev/null || true
+    mv \"${TRACKING_FILE}.tmp\" \"$TRACKING_FILE\"
 
     # Add the updated line with the final status and hash
-    echo "$basename_file $new_status $new_hash_status" >> "$TRACKING_FILE"
-  ) 200>"$LOCK_FILE"
+    echo \"$basename_file \$new_status \$new_hash_status\" >> \"$TRACKING_FILE\"
+  "
+
+  with_lock "$LOCK_FILE" "$cmd"
 }
 
-# Read current import status of a file from tracking file
 read_tracking_status() {
   local file="$1"
   local basename_file
@@ -305,7 +354,6 @@ read_tracking_status() {
   grep "^$basename_file " "$TRACKING_FILE" 2>/dev/null | tail -n 1 | awk '{print $2}' | tr -d '[:space:]'
 }
 
-# Find all .csv.gz files that need to be imported
 collect_import_tasks() {
   enable_pipefail
   trap 'disable_pipefail' RETURN
@@ -313,28 +361,34 @@ collect_import_tasks() {
   find "$IMPORT_DIR" -type f -name "*.csv.gz"
 }
 
-# Log file size, row count, or hash verification discrepancies into $DISCREPANCY_FILE
 write_discrepancy() {
   local file="$1"
   local expected_count="$2"
   local actual_count="$3"
 
-  # Only write if not already imported successfully and not in cleanup
-  discrepancy_entry="$file: expected $expected_count, got $actual_count rows"
   if [[ "$(read_tracking_status "$file")" != "IMPORTED" ]] && [[ ! -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
-    echo "$discrepancy_entry" >> "$DISCREPANCY_FILE"
+    local discrepancy_entry="$file: expected $expected_count, got $actual_count rows"
+    local cmd="echo \"$discrepancy_entry\" >> \"$DISCREPANCY_FILE\""
+    with_lock "$DISCREPANCY_FILE_LOCK" "$cmd"
   fi
 }
 
-# Load PostgreSQL connection settings from $BOOTSTRAP_ENV_FILE (local var)
+find_full_path() {
+  local basename_file="$1"
+  local result
+  result=$(find "$IMPORT_DIR" -type f -name "$basename_file" | head -1)
+  
+  echo "$result"
+}
+
+# Load PostgreSQL connection settings from $BOOTSTRAP_ENV_FILE
 # Required vars: PGUSER, PGPASSWORD, PGDATABASE, PGHOST, PGPORT
 source_bootstrap_env() {
-  # Declare the bootstrap environment file as a local variable
   local BOOTSTRAP_ENV_FILE="bootstrap.env"
 
   if [[ -f "$BOOTSTRAP_ENV_FILE" ]]; then
     log "Sourcing $BOOTSTRAP_ENV_FILE to set environment variables."
-    set -a  # Automatically export all variables
+    set -a
     source "$BOOTSTRAP_ENV_FILE"
     set +a
   else
@@ -343,8 +397,84 @@ source_bootstrap_env() {
   fi
 }
 
-# Parse $MANIFEST_FILE and prepare import tasks
-# Format: table_name,file_name,row_count,file_size,blake3_hash
+load_manifest_to_db() {
+  enable_pipefail
+  trap 'disable_pipefail' RETURN
+
+  log "Loading manifest counts into temporary DB table ${PROGRESS_DB_TABLE}..."
+
+  if [[ "$PGUSER" != "mirror_node" || "$PGDATABASE" != "mirror_node" ]]; then
+     log "load_manifest_to_db must run as mirror_node user in mirror_node DB. Current: $PGUSER@$PGDATABASE" "ERROR"
+     return 1
+  fi
+
+  psql -v ON_ERROR_STOP=1 -q -c "DROP TABLE IF EXISTS ${PROGRESS_DB_TABLE};" || {
+    log "Failed to drop existing ${PROGRESS_DB_TABLE} table." "ERROR"
+    return 1
+  }
+
+  # Create a temporary, unlogged table for progress tracking
+  psql -v ON_ERROR_STOP=1 -q -c """
+  CREATE UNLOGGED TABLE ${PROGRESS_DB_TABLE} (
+    filename TEXT PRIMARY KEY,
+    expected_count BIGINT
+  );
+  """ || {
+    log "Failed to create ${PROGRESS_DB_TABLE} table." "ERROR"
+    return 1
+  }
+
+  local insert_sql_file=$(mktemp)
+  echo "BEGIN;" > "$insert_sql_file"
+  
+  local filename count status
+  local inserted_count=0
+  log "Filtering manifest entries for non-IMPORTED files..." "DEBUG"
+  for filename in "${!manifest_counts[@]}"; do
+    count="${manifest_counts[$filename]}"
+    
+    status=$(read_tracking_status "$filename")
+    
+    if [[ "$status" != "IMPORTED" && "$count" =~ ^[0-9]+$ ]]; then
+      safe_filename=$(echo "$filename" | sed "s/'/''/g")
+      echo "INSERT INTO ${PROGRESS_DB_TABLE} (filename, expected_count) VALUES ('${safe_filename}', ${count});" >> "$insert_sql_file"
+      ((inserted_count++))
+    else
+      log "Skipping manifest entry for $filename (status: $status, count: $count)" "DEBUG"
+    fi
+  done
+  
+  echo "COMMIT;" >> "$insert_sql_file"
+  
+  if ! psql -v ON_ERROR_STOP=1 -q -f "$insert_sql_file"; then
+    log "Failed to load data into ${PROGRESS_DB_TABLE} table via INSERT statements." "ERROR"
+    psql -q -c "DROP TABLE IF EXISTS ${PROGRESS_DB_TABLE};" >/dev/null 2>&1
+    rm -f "$insert_sql_file"
+    return 1
+  fi
+  
+  rm -f "$insert_sql_file"
+  
+  log "Successfully loaded ${inserted_count} manifest entries into ${PROGRESS_DB_TABLE}."
+  
+  local table_exists
+  table_exists=$(psql -X -q -t -c "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '${PROGRESS_DB_TABLE}');" | tr -d ' ')
+  log "After load_manifest_to_db, table exists: $table_exists" "DEBUG"
+  
+  if [[ "$table_exists" == "t" ]]; then
+    local row_count
+    row_count=$(psql -X -q -t -c "SELECT COUNT(*) FROM ${PROGRESS_DB_TABLE};" | tr -d ' ')
+    log "Table ${PROGRESS_DB_TABLE} has ${row_count} rows" "DEBUG"
+    
+    if [[ "$row_count" -gt 0 ]]; then
+      log "Sample row from ${PROGRESS_DB_TABLE}:" "DEBUG"
+      psql -X -q -t -c "SELECT * FROM ${PROGRESS_DB_TABLE} LIMIT 1;" || log "Failed to retrieve sample row" "DEBUG"
+    fi
+  fi
+  
+  return 0
+}
+
 process_manifest() {
   enable_pipefail
   trap 'disable_pipefail' RETURN
@@ -358,18 +488,14 @@ process_manifest() {
 
   log "Using $B3SUM_NUM_THREADS thread(s) per BLAKE3 process."
 
-  # Check if the manifest file exists
   if [[ ! -f "$MANIFEST_FILE" ]]; then
     log "Manifest file '$MANIFEST_FILE' not found." "ERROR"
     exit 1
   fi
 
-  # Validate file count
   log "Validating file count"
-  # Count files in manifest (excluding header)
-  manifest_file_count=$(tail -n +2 "$MANIFEST_FILE" | wc -l)
+  manifest_file_count=$(awk 'NR>1' "$MANIFEST_FILE" | wc -l)
 
-  # Count actual files in IMPORT_DIR (recursively)
   actual_file_count=$(find "$IMPORT_DIR" -type f -name "*.gz" | wc -l)
 
   if [[ "$manifest_file_count" != "$actual_file_count" ]]; then
@@ -378,44 +504,33 @@ process_manifest() {
   fi
   log "File count validation successful, Manifest: $manifest_file_count, Directory: $actual_file_count"
 
-  # Populate manifest_counts, manifest_tables, and run file validations
+  manifest_content=$(tail -n +2 "$MANIFEST_FILE" 2>/dev/null)
+  if [[ -z "$manifest_content" ]]; then
+    log "Failed to read manifest content with tail" "ERROR"
+    return 1
+  fi
+
   while IFS=',' read -r filename expected_count expected_size expected_blake3_hash; do
-    # Skip header line
     if [[ "$filename" == "filename" ]]; then
       continue
     fi
 
-    # Build file_path based on directory layout
-    # Large table part files reside in "$IMPORT_DIR/<table>/$filename"
-    if [[ "$filename" =~ ^(.+)_part_ ]]; then
-      table_prefix="${filename%%_part_*}"
-      file_path="$IMPORT_DIR/$table_prefix/$filename"
-    else
-      # Small table files reside directly in $IMPORT_DIR/
-      file_path="$IMPORT_DIR/$filename"
-    fi
+    file_path="$IMPORT_DIR/$filename"
 
     if [[ -f "$file_path" ]]; then
-      # Skip validation if file is already imported successfully
       if [[ "$(read_tracking_status "$file_path")" == "IMPORTED" ]]; then
         continue
       fi
 
-      # Skip non-data files and entries with 'N/A' expected count
       if [[ "$expected_count" != "N/A" ]]; then
         manifest_counts["$filename"]="$expected_count"
 
-        # Extract table name only for data files
-        if [[ "$filename" =~ ^([^/]+)_part_ ]]; then
-          table="${BASH_REMATCH[1]}"
-        elif [[ "$filename" =~ ^([^/]+)\.csv\.gz$ ]]; then
-          table="${BASH_REMATCH[1]}"
-        else
+        table=$(get_table_name_from_filename "$filename")
+        if [[ -z "$table" ]]; then
           log "Could not determine table name from filename: $filename" "ERROR"
           continue
         fi
 
-        # Store table name in manifest_tables
         manifest_tables["$table"]=1
       fi
       manifest_sizes["$filename"]="$expected_size"
@@ -423,27 +538,45 @@ process_manifest() {
     else
       missing_files+=("$filename")
     fi
-  done < "$MANIFEST_FILE"
+  done < <(tr -d '\r' < "$MANIFEST_FILE")
 
   MANIFEST_SIZES_SERIALIZED=$(declare -p manifest_sizes)
   MANIFEST_HASHES_SERIALIZED=$(declare -p manifest_hashes)
   export MANIFEST_SIZES_SERIALIZED MANIFEST_HASHES_SERIALIZED
 
-  # Handle missing files
   if [[ ${#missing_files[@]} -gt 0 ]]; then
     log "The following files are listed in the manifest but are missing from the data directory:" "ERROR"
     for missing_file in "${missing_files[@]}"; do
-      log "- $missing_file" "ERROR"
+      log "  - $missing_file" "ERROR"
     done
     exit 1
   fi
+
+  if [[ -f "$LOCK_FILE" ]]; then
+    rm -f "$LOCK_FILE"
+  fi
+
+  if [[ "$PGUSER" == "mirror_node" && "$PGDATABASE" == "mirror_node" ]]; then
+      psql -q -c "DROP TABLE IF EXISTS ${PROGRESS_DB_TABLE};" >/dev/null 2>&1 || true
+  fi
 }
 
-# Validate a file's size and BLAKE3 hash against manifest values
+get_table_name_from_filename() {
+  local filename="$1"
+  local basename_file
+  
+  basename_file=$(basename "$filename")
+  
+  if [[ "$basename_file" =~ _p[0-9]{4}_[0-9]{2}\.csv\.gz$ ]]; then
+    echo "${basename_file%_p*}"
+  else
+    basename "$basename_file" .csv.gz
+  fi
+}
+
 validate_file() {
   local file="$1"
   local filename="$2"
-  local failures=()
 
   if [[ ! -f "$file" ]]; then
     log "Missing required file: $file" "ERROR"
@@ -454,23 +587,26 @@ validate_file() {
   expected_size="${manifest_sizes["$filename"]}"
 
   if [[ "$actual_size" != "$expected_size" ]]; then
-    log "SIZE_MISMATCH: Expected $expected_size bytes, Actual $actual_size bytes" "ERROR"
+    log "SIZE_MISMATCH for $file: Expected $expected_size bytes, Actual $actual_size bytes" "ERROR"
     return 1
   fi
 
+  log "Starting BLAKE3 hash calculation for $file..." "DEBUG"
   actual_b3sum=$(b3sum --num-threads "$B3SUM_NUM_THREADS" --no-names "$file")
+  log "Finished BLAKE3 hash calculation for $file." "DEBUG"
+
   expected_blake3_hash="${manifest_hashes["$filename"]}"
 
   if [[ "$actual_b3sum" != "$expected_blake3_hash" ]]; then
-    log "HASH_MISMATCH: Expected $expected_blake3_hash, Actual $actual_b3sum" "ERROR"
+    log "HASH_MISMATCH for $file: Expected $expected_blake3_hash, Actual $actual_b3sum" "ERROR"
     return 1
   fi
 
   return 0
 }
 
-# Validate special files that are required before import can begin
 validate_special_files() {
+  log "Entering validate_special_files" "DEBUG"
   enable_pipefail
   trap 'disable_pipefail' RETURN
 
@@ -480,27 +616,25 @@ validate_special_files() {
 
   for filename in "${special_files[@]}"; do
     local file="$IMPORT_DIR/$filename"
-    # Check if the file has already been imported by checking the tracking file
     if [[ "$(read_tracking_status "$filename")" == "IMPORTED" ]]; then
       log "Special file '$filename' already verified. Skipping."
       continue
     fi
 
-    local validation_result
-    if ! validation_result=$(validate_file "$file" "$filename"); then
-      failures+=("$filename: $validation_result")
+    if ! validate_file "$file" "$filename"; then
+      failures+=("$filename")
       validation_failed=true
       write_tracking_file "$filename" "FAILED_VALIDATION"
     else
       log "Successfully validated special file: $filename"
-      write_tracking_file "$filename" "IMPORTED"
+      write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
     fi
   done
 
   if [[ "$validation_failed" == "true" ]]; then
     log "Special file validation failed:" "ERROR"
     for failure in "${failures[@]}"; do
-      log "  - $failure" "ERROR"
+      log "  - Failed validation for: $failure" "ERROR"
     done
     return 1
   fi
@@ -508,30 +642,105 @@ validate_special_files() {
   return 0
 }
 
-# Import CSV file into database table with post import verification
-# Verifies: file size, row count, and BLAKE3 hash
-import_file() {
-  # Don't start new imports during cleanup
-  if [[ -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
+retry_query() {
+  local query="$1"
+  local description="$2"
+  local retries=3
+  local delay=2
+  local result
+  local status
+  local current_pid=$BASHPID
+  
+  result=$(PGAPPNAME="bootstrap_$current_pid" psql -v ON_ERROR_STOP=1 -q -Atc "$query")
+  status=$?
+  
+  for ((i=1; i<retries; i++)); do
+    if [ $status -eq 0 ]; then
+      break
+    fi
+    
+    sleep "$delay"
+    delay=$((delay * 2))
+    result=$(PGAPPNAME="bootstrap_$current_pid" psql -v ON_ERROR_STOP=1 -q -Atc "$query")
+    status=$?
+  done
+
+  echo "${result}:${status}"
+}
+
+get_partition_timestamps() {
+  local filename="$1"
+  local basename_file=$(basename "$filename")
+  
+  if [[ "$basename_file" =~ _p([0-9]{4})_([0-9]{2})\.csv\.gz$ ]]; then
+    local year="${BASH_REMATCH[1]}"
+    local month="${BASH_REMATCH[2]}"
+    
+    # Calculate start timestamp (first day of month) as nanoseconds
+    local start_ts=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT (EXTRACT(EPOCH FROM TIMESTAMP '${year}-${month}-01 00:00:00.000000000') * 1000000000)::bigint;")
+    
+    # Calculate end timestamp (last day of the month)
+    local end_day
+    if [[ "$month" == "02" ]]; then
+      # Handle February differently for leap years
+      # Leap year if: divisible by 4 AND (not divisible by 100 OR divisible by 400)
+      if (( year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) )); then
+        end_day=29
+      else
+        end_day=28
+      fi
+    elif [[ "$month" == "04" || "$month" == "06" || "$month" == "09" || "$month" == "11" ]]; then
+      end_day=30
+    else
+      end_day=31
+    fi
+    
+    # Calculate end timestamp (last day of month, end of day) as nanoseconds
+    local end_ts=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT (EXTRACT(EPOCH FROM TIMESTAMP '${year}-${month}-${end_day} 23:59:59.999999999') * 1000000000)::bigint;")
+    
+    if [[ -n "$start_ts" && -n "$end_ts" ]]; then
+      echo "${start_ts}:${end_ts}:${year}:${month}"
+    fi
+  fi
+}
+
+verify_postgres_connection() {
+  log "Verifying PostgreSQL connection..."
+  
+  if ! psql -c "SELECT version();" > /dev/null 2>&1; then
+    log "Failed to connect to PostgreSQL database!" "ERROR"
+    log "Connection details: host=$PGHOST port=$PGPORT dbname=$PGDATABASE user=$PGUSER" "ERROR"
     return 1
   fi
 
+  return 0
+}
+
+import_file() {
+  if [[ $# -ne 1 ]]; then
+    log "Usage: import_file filename" "ERROR"
+    return 1
+  fi
+
+  if [[ -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
+    return 1
+  fi
+  
   enable_pipefail
   trap 'disable_pipefail' RETURN
 
-  local file="$1"
+  local filename="$1"
   local table
-  local filename
-  local expected_count
-  local actual_count
-  local is_small_table
   local absolute_file
-  local start_ts=""
-  local end_ts=""
-  local data_suffix=""
+  local is_partitioned
+  local file=$(basename "$filename")
+  local relative_path
   local current_pid=$BASHPID
 
-  # Declare manifest_counts, manifest_sizes, and manifest_hashes as associative arrays
+  export PGAPPNAME="bootstrap_copy_$file"
+  export PGOPTIONS="--client-min-messages=warning"
+
+  # Reconstruct associative arrays from serialized data
   declare -A manifest_counts
   declare -A manifest_sizes
   declare -A manifest_hashes
@@ -539,180 +748,350 @@ import_file() {
   eval "$MANIFEST_SIZES_SERIALIZED"
   eval "$MANIFEST_HASHES_SERIALIZED"
 
-  # Get filename and ensure absolute paths
-  absolute_file="$(realpath "$file")"
-  filename=$(basename "$absolute_file")
-  expected_count="${manifest_counts[$filename]}"
+  if [[ "$filename" != /* && ! -f "$filename" ]]; then
+    absolute_file=$(find_full_path "$(basename "$filename")")
+  else
+    absolute_file=$(realpath "$filename")
+  fi
 
-  # Perform BLAKE3 and file-size validations
-  local validation_result
-  if ! validation_result=$(validate_file "$file" "$filename"); then
-    if [[ ! -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
-      log "Validation failed for $filename: $validation_result" "ERROR"
-    fi
-    write_tracking_file "$filename" "FAILED_VALIDATION"
+  file=$(basename "$absolute_file")
+  export PGAPPNAME="bootstrap_copy_$file"
+
+  if [[ -z "$absolute_file" || ! -f "$absolute_file" ]]; then
+    log "Invalid file path or file not found: $file" "ERROR"
     return 1
   fi
 
-  log "Successfully validated file-size and BLAKE3 hash for $filename"
+  if [[ "$absolute_file" == "$IMPORT_DIR"* ]]; then
+    relative_path=${absolute_file#"$IMPORT_DIR/"}
+  else
+    relative_path="$file"
+  fi
+  
+  expected_count="${manifest_counts[$relative_path]}"
+  
+  # Perform BLAKE3 and file-size validations
+  local validation_result
+  if ! validation_result=$(validate_file "$absolute_file" "$relative_path"); then
+    if [[ ! -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
+      log "Validation failed for $file: $validation_result" "ERROR"
+    fi
+    write_tracking_file "$filename" "FAILED_VALIDATION"
+    ((failed_imports++))
+    return 1
+  fi
+
+  log "Successfully validated file-size and BLAKE3 hash for $file"
   write_tracking_file "$filename" "NOT_STARTED" "HASH_VERIFIED"
 
-  # Skip non-table files after validation
+  # Skip non-table/special files after validation
   if [[ "$filename" == "MIRRORNODE_VERSION.gz" || "$filename" == "schema.sql.gz" ]]; then
-    log "Successfully validated non-table file: $filename"
-    current_status=$(read_tracking_status "$file")
-    if [[ "$current_status" != "IMPORTED" ]]; then
-      return 0
-    fi
+    log "Successfully validated non-table file: $file"
+    write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
+    return 0
   fi
 
-  # Determine if this is a small table by checking filename pattern
-  is_small_table=false  # default to large table part
-  if [[ ! "$filename" =~ ^(.+)_part_ ]]; then
-    is_small_table=true  # small table
-    table=$(basename "$file" .csv.gz)
+  table=$(get_table_name_from_filename "$filename")
+  if [[ -z "$table" ]]; then
+    log "Could not determine table name from filename: $file" "ERROR"
+    return 1
+  fi
+
+  # Determine which timestamp column to use for queries
+  # record_file table is a special case that uses consensus_end column for timestamps
+  # instead of consensus_timestamp which is used by all other tables
+  local timestamp_column="consensus_timestamp"
+  if [[ "$table" == "record_file" ]]; then
+    timestamp_column="consensus_end"
+  fi
+
+  if [[ "$file" =~ _p[0-9]{4}_[0-9]{2}\.csv\.gz$ ]]; then
+    is_partitioned=true
   else
-    # Extract table name - everything before _part_ (can contain underscores)
-    table="${filename%%_part_*}"
-
-    # Get everything after _part_ and split into components
-    part_suffix="${filename#*_part_}"  # Remove everything up to and including _part_
-    start_ts=$(echo "$part_suffix" | cut -d'_' -f2)    # Second field after _part_
-    end_ts=$(echo "$part_suffix" | cut -d'_' -f3)      # Third field after _part_
-    data_suffix=$(echo "$part_suffix" | cut -d'_' -f4 | cut -d'.' -f1)  # Fourth field, remove extension
+    is_partitioned=false
   fi
 
-  # Log import start and update status
   log "Importing into table $table from $filename, PID: $current_pid"
   write_tracking_file "$filename" "IN_PROGRESS"
 
-  # Execute the import within a transaction
-  local psql_error
-  if ! psql_error=$("$DECOMPRESS_TOOL" "${DECOMPRESS_FLAGS[@]}" "$file" 2>/dev/null | PGAPPNAME="bootstrap_$current_pid" \
-    psql -v ON_ERROR_STOP=1 --single-transaction -q -c "COPY $table FROM STDIN WITH CSV HEADER;" 2>&1); then
-    if [[ ! -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
-      log "Error importing data for $file: $psql_error" "ERROR"
-    fi
+  
+  local stdout_file=$(mktemp)
+  local stderr_file=$(mktemp)
+  local decomp_err_file=$(mktemp)
+
+  # Create a named pipe for data transfer
+  local csv_fifo=$(mktemp -u)
+  mkfifo "$csv_fifo"
+  log "Created named pipe for data transfer: $csv_fifo" "DEBUG"
+
+  local row_counter=$(mktemp)
+  local csv_header=$("$DECOMPRESS_TOOL" "${DECOMPRESS_FLAGS[@]}" "$absolute_file" | python3 -c 'import sys; print(next(sys.stdin, "").rstrip("\r\n"))')
+  
+  if [[ -z "$csv_header" ]]; then
+    log "Could not read header from $file" "ERROR"
     write_tracking_file "$filename" "FAILED_TO_IMPORT"
+    ((failed_imports++))
+    return 1
+  fi
+  
+  # Safely generate column list from CSV header using Python
+  local columns=$(python3 -c "
+import sys
+
+try:
+    # Convert header to properly quoted column list for SQL
+    header = '$csv_header'
+    columns = header.split(',')
+    quoted_columns = [\"\\\"\"+col+\"\\\"\" for col in columns]
+    print(','.join(quoted_columns))
+except Exception as e:
+    print(f'Error: {str(e)}', file=sys.stderr)
+    sys.exit(1)
+")
+  
+  if [[ $? -ne 0 || -z "$columns" ]]; then
+    log "Failed to generate column list from CSV header" "ERROR"
+    write_tracking_file "$filename" "FAILED_TO_IMPORT"
+    ((failed_imports++))
+    return 1
+  fi
+  
+  log "Using $file column list from CSV header: $columns" "DEBUG"
+  
+  local db_columns=$(psql -t -c "SELECT STRING_AGG(column_name, ',' ORDER BY ordinal_position) FROM information_schema.columns WHERE table_name = '$table' AND table_schema = 'public'")
+  db_columns=$(echo "$db_columns" | tr -d ' ')
+  
+  local csv_column_count=$(echo "$csv_header" | tr ',' '\n' | wc -l)
+  local db_column_count=$(echo "$db_columns" | awk -F, '{print NF}')
+  
+  if [[ "$csv_column_count" != "$db_column_count" ]]; then
+    log "Column count mismatch for $table: CSV has $csv_column_count columns, DB table has $db_column_count columns. Using CSV header for mapping." "WARN"
+  else
+    log "Column count matches between CSV and database for $table ($csv_column_count columns)" "DEBUG"
+  fi
+
+  # Start decompression in background, writing to named pipe with on-the-fly hash calculation
+  log "Starting decompression process for $file..." "DEBUG"
+  "$DECOMPRESS_TOOL" "${DECOMPRESS_FLAGS[@]}" "$absolute_file" > "$csv_fifo" 2>"$decomp_err_file" &
+  local decompress_pid=$!
+
+  # Import using named pipe, with explicit column mapping for all tables
+  log "Starting import process for $file..." "DEBUG"
+  # Count rows using Python to handle quoted fields and embedded newlines in the CSV
+  cat "$csv_fifo" | tee >(python3 -c '
+import sys
+import csv
+import traceback
+
+try:
+    # Set field size limit to 1GB to correctly read large data rows from some files
+    csv.field_size_limit(1024 * 1024 * 1024)
+
+    counter = 0
+    reader = csv.reader(sys.stdin)
+    for row in reader:
+        counter += 1
+
+    # Print final count to stdout for capturing in the row_counter file
+    print(counter)
+
+except Exception as e:
+    print(f"Error in Python counter: {str(e)}", file=sys.stderr)
+    print(traceback.format_exc(), file=sys.stderr)
+    if counter > 0:
+        print(counter)
+    else:
+        print(0)
+' > "$row_counter") 2>/dev/null | \
+    dd bs=16M iflag=fullblock status=none 2>/dev/null | \
+    PGAPPNAME="$PGAPPNAME" \
+    psql -v ON_ERROR_STOP=1 --single-transaction \
+    -q -c "COPY $table ($columns) FROM STDIN WITH CSV HEADER DELIMITER ',';" \
+    >"$stdout_file" 2>"$stderr_file"
+  psql_exit_code=$?
+
+  wait $decompress_pid
+  decompress_exit_code=$?
+
+  if jobs -p | grep -q .; then
+      log "Waiting for background processes to complete..." "DEBUG"
+      wait
+  fi
+
+  local total_lines=$(cat "$row_counter")
+  local import_pipe_row_count=$((total_lines - 1))
+  log "Import pipeline row count for $file: $import_pipe_row_count (total lines including header: $total_lines)" "DEBUG"
+
+  log "Decompression exit code: $decompress_exit_code, PSQL exit code: $psql_exit_code for $file" "DEBUG"
+
+  cat "$stdout_file" >> "$LOG_FILE"
+  cat "$stderr_file" >> "$LOG_FILE"
+  cat "$decomp_err_file" >> "$LOG_FILE"
+
+  rm -f "$stdout_file" "$stderr_file" "$decomp_err_file"
+
+  # Clean up named pipe and row counter
+  rm -f "$csv_fifo" "$row_counter"
+
+  # Check for decompression errors (ignoring SIGPIPE which is exit code 141)
+  if [ $decompress_exit_code -ne 0 ] && [ $decompress_exit_code -ne 141 ]; then
+    log "Decompression failed for $file, exit code: $decompress_exit_code" "ERROR"
+    write_tracking_file "$filename" "FAILED_TO_IMPORT"
+    ((failed_imports++))
     return 1
   fi
 
+  # Check for psql errors
+  if [ $psql_exit_code -ne 0 ]; then
+    log "Import failed for file: $file, psql exit code: $psql_exit_code" "ERROR"
+
+    if [[ -s "$stderr_file" ]]; then
+      log "PostgreSQL error: $(cat "$stderr_file")" "ERROR"
+    fi
+
+    # Try to diagnose common issues
+    log "Diagnosing import issue for $file..."
+    if grep -q "does not exist" "$stderr_file" 2>/dev/null; then
+      log "Table or column does not exist. Check if the table schema matches the CSV header." "ERROR"
+    elif grep -q "invalid input syntax" "$stderr_file" 2>/dev/null; then
+      log "Invalid input syntax detected. Data may not match column types." "ERROR" 
+    elif grep -q "violates" "$stderr_file" 2>/dev/null; then
+      log "Constraint violation detected. Data may violate table constraints." "ERROR"
+    fi
+
+    write_tracking_file "$filename" "FAILED_TO_IMPORT"
+    ((failed_imports++))
+    return 1
+  fi
+
+  log "Successfully imported $file"
+
   if [[ -z "$expected_count" || "$expected_count" == "N/A" ]]; then
-    log "No expected row count for $filename in manifest, skipping verification."
+    log "No expected row count for $file in manifest, skipping verification."
     write_tracking_file "$filename" "IMPORTED"
     return 0
   fi
 
-  # Execute count query with retry logic
-  local retries=3
-  local delay=2
-  local psql_status
-  if [[ "$is_small_table" == "true" ]]; then
-    actual_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table};")
-    psql_status=$?
-  else
-    actual_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table} WHERE consensus_timestamp BETWEEN '$start_ts' AND '$end_ts';")
-    psql_status=$?
-  fi
-
-  # retry row-count if psql count command fails
-  for ((i=0; i<=retries; i++)); do
-    if [ $psql_status -eq 0 ]; then
-      break
-    fi
-    if [ $i -lt $retries ]; then
-      log "Count query attempt $((i+1)) failed for ${file}, retrying in ${delay}s" "WARN"
-      sleep "$delay"
-      delay=$((delay * 2))
-      if [[ "$is_small_table" == "true" ]]; then
-        actual_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table};")
-        psql_status=$?
-      else
-        actual_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table} WHERE consensus_timestamp BETWEEN '$start_ts' AND '$end_ts';")
-        psql_status=$?
-      fi
-    fi
-  done
-
-  # Fallback boundary check
-  if [ $psql_status -ne 0 ]; then
-    log "Count query failed after ${retries} retries, trying fallback boundary check" "WARN"
-
-    # Only perform boundary check for large table parts
-    if [[ "$is_small_table" != "true" ]]; then
-      boundary_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table} WHERE consensus_timestamp IN ('$start_ts', '$end_ts');")
-      boundary_status=$?
-
-      if [ $boundary_status -eq 0 ]; then
-        # Check if both boundary timestamps exist (count should be 2)
-        if [ "$boundary_count" -eq 2 ]; then
-          log "Boundary check successful for ${file}, both start and end timestamps found"
-          # Set psql_status to success and use expected_count for actual_count
-          # This assumes all rows in between exist
-          psql_status=0
-          actual_count=$expected_count
-          log "Using manifest row count ${expected_count} based on boundary verification"
-        else
-          log "Boundary check found ${boundary_count}/2 boundary timestamps for ${file}" "ERROR"
-        fi
-      else
-        log "Fallback boundary check failed for ${file}" "ERROR"
-      fi
-    fi
-  fi
-
-  # Check the exit status of the count query
-  if [ $psql_status -ne 0 ]; then
-    log "Final count query failure for ${file} after ${retries} retries, but continuing" "WARN"
-    write_discrepancy "${file}" "ROW_COUNT_QUERY_FAILURE" "${expected_count}"
-
-    # Mark the row count as unverified but don't fail the import
-    write_tracking_file "$filename" "IMPORTED" "ROW_COUNT_UNVERIFIED"
-
-    # Log an error and proceed with the import
-    log "Import process continuing despite row count verification failure for $filename" "ERROR"
+  if [[ "$import_pipe_row_count" == "$expected_count" ]]; then
+    log "Row count verified for $file using import pipeline counter: $import_pipe_row_count (expected: $expected_count)"
+    write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
     return 0
-  fi
-
-  # Verify the count matches expected
-  if [[ "$actual_count" != "$expected_count" ]]; then
-    if [[ ! -f "$CLEANUP_IN_PROGRESS_FILE" ]]; then
-      log "Row count mismatch for $file. Expected: $expected_count, Actual: $actual_count" "ERROR"
-    fi
-    write_discrepancy "$file" "$expected_count" "$actual_count"
-    write_tracking_file "$filename" "FAILED_TO_IMPORT"
-    return 1
   else
-    log "Row count verified, successfully imported $file"
-    if validate_file "$file" "$filename"; then
-        write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
+    log "Import pipeline row count ($import_pipe_row_count) doesn't match expected count ($expected_count) for $file, falling back to DB row count verification..." "WARN"
+  fi
+
+  # Verify row count from database as a fallback
+  local actual_count
+  local query_result
+
+  log "Starting DB row count verification query for $file..." "DEBUG"
+  if [[ "$is_partitioned" == "true" ]]; then
+    # For partitioned tables, extract time range from filename
+    local timestamp_info=$(get_partition_timestamps "$filename")
+    
+    if [[ -n "$timestamp_info" ]]; then
+      IFS=':' read -r start_ts end_ts year month <<< "$timestamp_info"
+      query_result=$(retry_query "SELECT COUNT(*) FROM ${table} WHERE ${timestamp_column} BETWEEN ${start_ts} AND ${end_ts};" "Timestamp-based count query for ${file}")
     else
-        write_tracking_file "$filename" "IMPORTED" "HASH_UNVERIFIED"
+      log "Could not extract timestamp information from filename: ${file}" "ERROR"
+      write_tracking_file "$filename" "IMPORTED" "UNVERIFIED_COUNT"
+      return 0
+    fi
+  else
+    # For non-partitioned tables, use a simple SELECT COUNT(*)
+    query_result=$(retry_query "SELECT COUNT(*) FROM ${table};" "Count query for ${file}")
+  fi
+  log "Finished DB row count verification query for $file." "DEBUG"
+
+  IFS=':' read -r actual_count psql_status <<< "$query_result"
+
+  if [ $psql_status -eq 0 ]; then
+    if [[ "$actual_count" == "$expected_count" ]]; then
+      log "Row count verified from database: $actual_count (expected: $expected_count)"
+      write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
+      return 0
+    else
+      log "Row count mismatch for $file. Expected: $expected_count, Actual: $actual_count" "ERROR"
+      write_discrepancy "$file" "ROW_COUNT_MISMATCH" "$expected_count" "$actual_count"
+      write_tracking_file "$filename" "FAILED_TO_IMPORT"
+      ((failed_imports++))
+      return 1
     fi
   fi
 
-  return 0
+  # In case the SELECT COUNT(*) failed
+  log "Failed to verify row count from DB for $file, falling back to boundary check..." "ERROR"
+
+  # For partitioned tables, try boundary check as a fallback
+  if [[ "$is_partitioned" == "true" && -n "$timestamp_info" ]]; then
+    log "Attempting boundary check for partitioned file: ${file}"
+
+    local boundary_count
+    local boundary_status
+    log "Starting boundary check query for $file..." "DEBUG"
+    boundary_count=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT COUNT(*) FROM ${table} WHERE ${timestamp_column} IN (${start_ts}, ${end_ts});")
+    boundary_status=$?
+    log "Finished boundary check query for $file." "DEBUG"
+
+    if [ $boundary_status -eq 0 ]; then
+      # Check if both boundary timestamps exist (count should be 2)
+      if [ "$boundary_count" -eq 2 ]; then
+        log "Boundary check successful for ${file}, both start and end timestamps found"
+        log "Using manifest row count ${expected_count} based on boundary verification"
+        write_tracking_file "$filename" "IMPORTED" "HASH_VERIFIED"
+        return 0
+      else
+        log "Boundary check found ${boundary_count}/2 boundary timestamps for ${file}" "WARN"
+      fi
+    else
+      log "Fallback boundary check failed for ${file}" "ERROR"
+    fi
+  else
+    log "Skipping boundary check: is_partitioned=${is_partitioned}, timestamp_info=${timestamp_info}" "WARN"
+  fi
+    
+  # If boundary check failed, try a simple EXISTS check as a last resort
+  log "Final count query failure for ${file}, attempting existence check as a last resort..." "WARN"
+
+  local existence_check
+  log "Starting existence check query for $file..." "DEBUG"
+  existence_check=$(psql -v ON_ERROR_STOP=1 -q -Atc "SELECT EXISTS(SELECT 1 FROM ${table} LIMIT 1);")
+  local existence_status=$?
+  log "Finished existence check query for $file." "DEBUG"
+
+  if [ $existence_status -eq 0 ]; then
+    if [ "$existence_check" == "t" ]; then
+      log "Existence verification successful for ${file}, table ${table} contains data (existence check)" "WARN"
+      write_tracking_file "$filename" "IMPORTED" "ROW_COUNT_UNVERIFIED"
+      return 0
+    else
+      log "Existence verification failed: table ${table} appears to be empty" "ERROR"
+    fi
+  else
+    log "Existence verification failed: could not query table ${table}" "ERROR"
+  fi
+
+  log "All verification methods failed for $file" "ERROR"
+  write_tracking_file "$filename" "FAILED_TO_IMPORT"
+  ((failed_imports++))
+  return 1
 }
 
-# Initialize an empty database schema using init.sh
 initialize_database() {
   enable_pipefail
   trap 'disable_pipefail' RETURN
 
-  # Reconstruct manifest_tables
+  # Reconstruct manifest_tables from serialized data
   declare -A manifest_tables
   eval "$MANIFEST_TABLES_SERIALIZED"
 
-  # Check for schema.sql
   if [[ ! -f "$IMPORT_DIR/schema.sql" ]]; then
     log "schema.sql not found in $IMPORT_DIR." "ERROR"
     exit 1
   fi
 
-  # Construct the URL for init.sh
   INIT_SH_URL="https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/refs/heads/main/hedera-mirror-importer/src/main/resources/db/scripts/init.sh"
 
-  # Download init.sh
   log "Downloading init.sh from $INIT_SH_URL"
 
   if curl -fSLs -o "init.sh" "$INIT_SH_URL"; then
@@ -722,10 +1101,8 @@ initialize_database() {
     exit 1
   fi
 
-  # Make init.sh executable
   chmod +x init.sh
 
-  # Run init.sh to initialize the database and capture its output
   log "Initializing the database using init.sh"
   if ./init.sh >> "$LOG_FILE" 2>&1; then
     log "Database initialized successfully"
@@ -739,11 +1116,8 @@ initialize_database() {
   export PGDATABASE="mirror_node"
   export PGPASSWORD="$OWNER_PASSWORD"
 
-  log "Updated PostgreSQL environment variables to connect to 'mirror_node' database as user 'mirror_node'"
-
-  # Execute schema.sql
   log "Executing schema.sql from $IMPORT_DIR"
-  if psql -v ON_ERROR_STOP=1 -f "$IMPORT_DIR/schema.sql" >> "$LOG_FILE" 2>&1; then
+  if psql -v ON_ERROR_STOP=1 -q -f "$IMPORT_DIR/schema.sql" >> "$LOG_FILE" 2>&1; then
     log "schema.sql executed successfully"
   else
     log "Failed to execute schema.sql. Check $LOG_FILE for details." "ERROR"
@@ -751,7 +1125,6 @@ initialize_database() {
   fi
 
   # Check that each table exists in the database
-  # Test database connectivity
   if ! psql -v ON_ERROR_STOP=1 -c '\q' >/dev/null 2>&1; then
     log "Unable to connect to the PostgreSQL database." "ERROR"
     exit 1
@@ -765,15 +1138,13 @@ initialize_database() {
   for table in "${!manifest_tables[@]}"; do
     log "Verifying existence of table: $table"
 
-    # Avoid duplicate checks
     if [[ -n "${checked_tables_map["$table"]:-}" ]]; then
       log "Table $table has already been checked. Skipping."
       continue
     fi
     checked_tables_map["$table"]=1
 
-    # Check if the table exists in the database, with a timeout
-    if ! timeout 10 psql -v ON_ERROR_STOP=1 -qt -c "SELECT 1 FROM pg_class WHERE relname = '$table' AND relnamespace = 'public'::regnamespace;" | grep -q 1; then
+    if ! psql -v ON_ERROR_STOP=1 -qt -c "SELECT 1 FROM pg_class WHERE relname = '$table' AND relnamespace = 'public'::regnamespace;" | grep -q 1; then
       missing_tables+=("$table")
       log "$table missing from database" "ERROR"
     else
@@ -781,7 +1152,6 @@ initialize_database() {
     fi
   done
 
-  # If any tables are missing, report and exit
   if [[ ${#missing_tables[@]} -gt 0 ]]; then
     log "====================================================" "ERROR"
     log "The following tables are missing in the database:" "ERROR"
@@ -793,33 +1163,248 @@ initialize_database() {
   else
     log "All tables exist in the database."
   fi
+
+  return 0
+}
+
+# Background function to monitor import progress
+monitor_progress() {
+  local p_user="$1"
+  local p_database="$2"
+  local p_host="$3"
+  local p_port="$4"
+  local p_password="$5"
+
+  export PGUSER="$p_user"
+  export PGDATABASE="$p_database"
+  export PGHOST="$p_host"
+  export PGPORT="$p_port"
+  export PGPASSWORD="$p_password"
+  
+  # Set locale for proper number formatting with thousands separators
+  export LC_NUMERIC="en_US.UTF-8"
+  
+  sleep 5
+  log "Starting progress monitor (Interval: ${PROGRESS_INTERVAL}s, Output: ${PROGRESS_FILE})"
+
+  touch "$MONITOR_STATE_FILE"
+
+  if [[ ! -s "$MONITOR_STATE_FILE" ]]; then
+    echo -e "initialization\t0\t$(date +%s)" > "$MONITOR_STATE_FILE"
+  fi
+
+  # Ensure signal file does not exist at start
+  rm -f "$MONITOR_STOP_SIGNAL_FILE"
+
+  while true; do
+    # Check for stop signal
+    if [[ -f "$MONITOR_STOP_SIGNAL_FILE" ]]; then
+      log "Monitor stop signal received. Exiting monitor loop." "INFO"
+      break
+    fi
+
+    local current_timestamp=$(date +%s)
+    
+    declare -A prev_counts
+    declare -A prev_times
+    if [[ -f "$MONITOR_STATE_FILE" && -s "$MONITOR_STATE_FILE" ]]; then
+      while IFS=$'\t' read -r filename prev_count prev_time; do
+        prev_counts["$filename"]=$prev_count
+        prev_times["$filename"]=$prev_time
+      done < "$MONITOR_STATE_FILE"
+    fi
+    
+    local table_check
+    table_check=$(psql -X -q -t -c "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '${PROGRESS_DB_TABLE}');" | tr -d ' ')
+    
+    if [[ "$table_check" != "t" ]]; then
+      log "Progress table ${PROGRESS_DB_TABLE} does not exist, creating an empty version" "WARN"
+      
+      # Create a basic version of the table so the query doesn't fail
+      if ! psql -v ON_ERROR_STOP=1 -q -c """
+      CREATE UNLOGGED TABLE IF NOT EXISTS ${PROGRESS_DB_TABLE} (
+        filename TEXT PRIMARY KEY,
+        expected_count BIGINT
+      );
+      """; then
+        log "Failed to create ${PROGRESS_DB_TABLE} table" "ERROR"
+        echo "Error: Failed to create progress monitoring table. See bootstrap.log for details." > "$PROGRESS_FILE"
+        sleep "$PROGRESS_INTERVAL"
+        continue
+      fi
+    fi
+    
+    local stderr_file=$(mktemp)
+    local temp_data=$(mktemp)
+    
+    psql -X -q -v ON_ERROR_STOP=1 <<EOF > "$temp_data" 2>"$stderr_file"
+\\pset format unaligned
+\\pset fieldsep '|'
+\\pset tuples_only on
+\\pset footer off
+
+WITH app_names AS (
+  SELECT 
+    a.pid,
+    application_name,
+    substring(application_name from '^bootstrap_copy_(.*)$') AS filename,
+    COALESCE(c.tuples_processed, 0) as tuples_processed
+  FROM pg_stat_activity a
+  LEFT JOIN pg_stat_progress_copy c ON a.pid = c.pid
+  WHERE a.state = 'active'
+  AND a.application_name LIKE 'bootstrap_copy_%'
+)
+SELECT 
+  app.filename,
+  app.tuples_processed,
+  COALESCE(m.expected_count, 0) as expected_count
+FROM app_names app
+LEFT JOIN ${PROGRESS_DB_TABLE} m ON 
+  app.filename = SPLIT_PART(m.filename, '/', array_length(string_to_array(m.filename, '/'), 1))
+ORDER BY app.filename;
+EOF
+
+    local psql_status=$?
+    
+    if [[ $psql_status -ne 0 ]]; then
+      log "Progress monitor query failed with status: $psql_status" "ERROR"
+      
+      if [[ -s "$stderr_file" ]]; then
+        log "PostgreSQL query error: $(cat "$stderr_file")" "ERROR"
+      fi
+      
+      echo "ERROR: Progress monitoring query failed, progress monitor will not be displayed" > "$PROGRESS_FILE"
+      
+      rm -f "$temp_data"
+      rm -f "$stderr_file" 
+      sleep "$PROGRESS_INTERVAL"
+      continue
+    fi
+    
+    {
+      printf "%-32s %-18s %-16s %-15s %-15s\n" "Filename" "Rows_Processed" "Total_Rows" "Percentage" "Rate(rows/s)"
+      printf "%-32s %-18s %-16s %-15s %-15s\n" "$(printf -- '-%.0s' {1..32})" "$(printf -- '-%.0s' {1..18})" "$(printf -- '-%.0s' {1..16})" "$(printf -- '-%.0s' {1..15})" "$(printf -- '-%.0s' {1..15})"
+      
+      local new_state=$(mktemp)
+      
+      while IFS='|' read -r filename tuples_processed expected_count; do
+        if [[ -z "$filename" ]]; then
+          continue
+        fi
+        
+        # Format numbers with commas
+        local formatted_processed=$(printf "%'d" "$tuples_processed")
+        local formatted_expected=$(printf "%'d" "$expected_count")
+        
+        # Calculate percentage
+        local percentage="0%"
+        if [[ $expected_count -gt 0 ]]; then
+          percentage=$(printf "%.2f%%" "$(echo "scale=4; $tuples_processed * 100 / $expected_count" | bc)")
+        fi
+        
+        # Calculate rate per second
+        local rate="calculating..."
+        basename_filename=$(basename "$filename" 2>/dev/null || echo "$filename")
+        
+        if [[ -n "${prev_counts[$basename_filename]}" && -n "${prev_times[$basename_filename]}" ]]; then
+          local prev_count="${prev_counts[$basename_filename]}"
+          local prev_time="${prev_times[$basename_filename]}"
+          
+          if [[ $current_timestamp -gt $prev_time && 
+                $(( tuples_processed - prev_count )) -ge 0 && 
+                $(( current_timestamp - prev_time )) -gt 0 ]]; then
+            local diff_rows=$(( tuples_processed - prev_count ))
+            local diff_time=$(( current_timestamp - prev_time ))
+            rate=$(printf "%'d" "$(( diff_rows / diff_time ))")
+          fi
+        fi
+        
+        echo -e "$basename_filename\t$tuples_processed\t$current_timestamp" >> "$new_state"
+        
+        # All columns left-aligned with increased spacing
+        printf "%-32s %-18s %-16s %-15s %-15s\n" \
+          "$filename" "$formatted_processed" "$formatted_expected" "$percentage" "$rate"
+      done < "$temp_data"
+      
+    } > "$PROGRESS_FILE"
+    
+    if [[ -s "$new_state" ]]; then
+      mv "$new_state" "$MONITOR_STATE_FILE"
+    else
+      rm -f "$new_state"
+    fi
+    
+    rm -f "$temp_data"
+    rm -f "$stderr_file"
+
+    sleep "$PROGRESS_INTERVAL"
+  done
+
+  rm -f "$MONITOR_STOP_SIGNAL_FILE"
+}
+
+print_final_statistics() {
+  log "===================================================="
+  log "Import statistics:"
+  log "Total files processed: $((total_jobs + skipped_jobs))"
+  log "Files skipped (already imported): $skipped_jobs"
+  log "Files attempted to import: $total_jobs"
+  log "Files completed: $completed_jobs"
+  log "Files failed: $failed_imports"
+  log "Files with inconsistent status: $inconsistent_files"
+  log "Total files with issues: $((failed_imports + inconsistent_files))"
+  log "===================================================="
+
+  # Summarize discrepancies
+  if [[ -s "$DISCREPANCY_FILE" ]]; then
+    overall_success=false
+    log "===================================================="
+    log "Discrepancies detected during import:"
+    log "The following files failed the row count verification:"
+    log ""
+    while read -r line; do
+      log "- $line"
+    done < "$DISCREPANCY_FILE"
+    log "===================================================="
+  else
+    log "No discrepancies detected during import."
+  fi
+
+  # Log the final status of the import process
+  if [[ $overall_success = true ]]; then
+    log "===================================================="
+    log "DB import completed successfully."
+    log "The database is fully identical to the data files."
+    log "===================================================="
+  else
+    log "===================================================="
+    log "The database import process encountered errors and is incomplete." "ERROR"
+    log "Mirrornode requires a fully synchronized database." "ERROR"
+    log "Please review the discrepancies above." "ERROR"
+    log "===================================================="
+  fi
 }
 
 ####################################
 # Execution
 ####################################
 
-# Trap SIGINT and SIGTERM for graceful shutdown
 trap 'cleanup INT' SIGINT
 trap 'cleanup TERM' SIGTERM
-# Trap EXIT for normal cleanup without interruption logging
+trap 'cleanup PIPE' SIGPIPE
 trap 'cleanup EXIT' EXIT
 
-# Perform the Bash version check
 check_bash_version
 
-# Log the Process Group ID
 PGID=$(ps -o pgid= $$ | tr -d ' ')
 log "Script Process Group ID: $PGID"
 
-# Display help if no arguments are provided
 if [[ $# -eq 0 ]]; then
   log "No arguments provided. Use --help or -h for usage information." "ERROR"
   show_help
   exit 1
 fi
 
-# Parse help first, then options
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   -h | --help | -H)
@@ -833,11 +1418,9 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-# Assign script arguments
 DB_CPU_CORES="$1"
 shift
 
-# Process additional options
 while [[ $# -gt 0 ]]; do
   case $1 in
     --full)
@@ -851,38 +1434,36 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Check if required arguments are supplied and valid
 if [[ -z "$DB_CPU_CORES" || -z "$IMPORT_DIR" ]]; then
     log "Missing required arguments. Use --help or -h for usage information" "ERROR"
     exit 1
 fi
 
-# Validate DB_CPU_CORES is a positive integer
 if ! [[ "$DB_CPU_CORES" =~ ^[1-9][0-9]*$ ]]; then
     log "DB_CPU_CORES must be a positive integer" "ERROR"
     exit 1
 fi
 
-# Convert IMPORT_DIR to an absolute path
 IMPORT_DIR="$(realpath "$IMPORT_DIR")"
 
-# Calculate available CPU cores
-AVAILABLE_CORES=$(($(nproc) - 1))        # Leave one core free for the local system
-DB_AVAILABLE_CORES=$((DB_CPU_CORES - 1)) # Leave one core free for the DB instance
+if [[ ! -d "$IMPORT_DIR" ]]; then
+  log "IMPORT_DIR '$IMPORT_DIR' does not exist or is not a directory" "ERROR"
+  exit 1
+fi
+
+AVAILABLE_CORES=$(nproc)
+DB_AVAILABLE_CORES=$((DB_CPU_CORES))
 if (( DB_AVAILABLE_CORES <= 0 )); then
   DB_AVAILABLE_CORES=1  # Minimum 1 core
 fi
 log "DB_AVAILABLE_CORES set to: $DB_AVAILABLE_CORES"
 
-# Source bootstrap environment variables early
 source_bootstrap_env
 
-# Check for all required tools before proceeding
 if ! check_required_tools; then
     exit 1
 fi
 
-# Set file paths
 if [[ -n "$USE_FULL_DB" ]]; then
     MANIFEST_FILE="${IMPORT_DIR}/manifest.csv"
 else
@@ -891,30 +1472,25 @@ fi
 MIRRORNODE_VERSION_FILE="$IMPORT_DIR/MIRRORNODE_VERSION"
 log "Using manifest file: $MANIFEST_FILE"
 
-# Check if IMPORT_DIR exists and is a directory
-if [[ ! -d "$IMPORT_DIR" ]]; then
-  log "IMPORT_DIR '$IMPORT_DIR' does not exist or is not a directory" "ERROR"
+if [[ ! -f "$MANIFEST_FILE" ]]; then
+  log "Manifest file not found: $MANIFEST_FILE" "ERROR"
   exit 1
 fi
 
-# Calculate optimal number of parallel jobs
 if [[ $AVAILABLE_CORES -lt $DB_AVAILABLE_CORES ]]; then
   MAX_JOBS="$AVAILABLE_CORES"
 else
   MAX_JOBS="$DB_AVAILABLE_CORES"
 fi
+MAX_JOBS=$((MAX_JOBS - 1))
 
-# Process the manifest and check for missing files
 process_manifest
 
-# Validate special files first
 if ! validate_special_files; then
   exit 1
 fi
 
-# Decompress schema.sql and MIRRORNODE_VERSION
 for file in "$IMPORT_DIR/schema.sql.gz" "$IMPORT_DIR/MIRRORNODE_VERSION.gz"; do
-  # Create a new array with the -c flag replaced with -k
   decompress_flags_keep=("${DECOMPRESS_FLAGS[@]}")
   for i in "${!decompress_flags_keep[@]}"; do
     if [[ "${decompress_flags_keep[$i]}" == "-c" ]]; then
@@ -922,7 +1498,6 @@ for file in "$IMPORT_DIR/schema.sql.gz" "$IMPORT_DIR/MIRRORNODE_VERSION.gz"; do
     fi
   done
 
-  # Add -f flag to the command (as it was in the original)
   if ! "$DECOMPRESS_TOOL" "${decompress_flags_keep[@]}" -f "$file" 2>/dev/null; then
     log "Error decompressing $file using $DECOMPRESS_TOOL" "ERROR"
     exit 1
@@ -933,7 +1508,6 @@ done
 MANIFEST_COUNTS_SERIALIZED=$(declare -p manifest_counts)
 MANIFEST_TABLES_SERIALIZED=$(declare -p manifest_tables)
 
-# Extract and validate mirrornode version
 if [[ -f "$MIRRORNODE_VERSION_FILE" ]]; then
   MIRRORNODE_VERSION=$(tr -d '[:space:]' < "$MIRRORNODE_VERSION_FILE")
   log "Compatible Mirrornode version: $MIRRORNODE_VERSION"
@@ -942,62 +1516,68 @@ else
   exit 1
 fi
 
-# Log the start of the import process
 log "Starting DB import."
 
-# Initialize the database unless the flag file exists
 if [[ ! -f "$DB_SKIP_FLAG_FILE" ]]; then
   initialize_database
   touch "$DB_SKIP_FLAG_FILE" # Create a flag to skip subsequent runs from running db init after it succeeded once
 else
-  # Set PostgreSQL environment variables
   export PGUSER="mirror_node"
   export PGDATABASE="mirror_node"
   export PGPASSWORD="$OWNER_PASSWORD"
-
   log "Set PGUSER, PGDATABASE, and PGPASSWORD for PostgreSQL."
 
-  # Test database connectivity
-  if ! psql -v ON_ERROR_STOP=1 -c '\q' >/dev/null 2>&1; then
-    log "Database is not initialized. Cannot skip database initialization." "ERROR"
+  if ! verify_postgres_connection; then
     exit 1
   fi
   log "Database is already initialized, skipping initialization."
+fi
+
+if ! load_manifest_to_db; then
+  log "Failed to load manifest counts to DB on subsequent run. Cannot start progress monitor." "ERROR"
+else
+  log "Starting background progress monitor..."
+  monitor_progress "$PGUSER" "$PGDATABASE" "$PGHOST" "$PGPORT" "$PGPASSWORD" &
+  monitor_pid=$!
+  pids+=("$monitor_pid")
+  log "Progress monitor started with PID: $monitor_pid"
 fi
 
 # Get the list of files to import
 mapfile -t files < <(collect_import_tasks)
 
 # Initialize the tracking file with all files as NOT_STARTED and HASH_UNVERIFIED
-(
-  flock -x 200
-  for file in "${files[@]}"; do
-    # Only add if not already in tracking file
-    if [[ -z "$(read_tracking_status "$file")" ]]; then
-      echo "$(basename "$file") NOT_STARTED HASH_UNVERIFIED" >> "$TRACKING_FILE"
-    fi
-  done
-) 200>"$LOCK_FILE"
+init_cmd="for file in \"\${files[@]}\"; do
+  # Only add if not already in tracking file
+  if [[ -z \"\$(read_tracking_status \"\$(basename \"\$file\")\")\" ]]; then
+    echo \"\$(basename \"\$file\") NOT_STARTED HASH_UNVERIFIED\" >> \"$TRACKING_FILE\"
+  fi
+done"
+
+with_lock "$LOCK_FILE" "$init_cmd"
 
 # Initialize variables for background processes
 overall_success=true
-failed_imports=0
+# Initialize as a shared variable accessible to all subprocesses
+export failed_imports=0
+declare -a import_pids=() # Array specifically for import job PIDs
 
 # Export required functions and variables for subshell usage
 export -f \
   log show_help check_bash_version check_required_tools \
   determine_decompression_tool kill_descendants cleanup write_tracking_file read_tracking_status \
   collect_import_tasks write_discrepancy source_bootstrap_env process_manifest validate_file \
-  validate_special_files initialize_database import_file
+  validate_special_files initialize_database import_file get_table_name_from_filename retry_query get_partition_timestamps \
+  find_full_path verify_postgres_connection with_lock print_final_statistics
 
 export \
   DECOMPRESS_TOOL DECOMPRESS_FLAGS BOOTSTRAP_ENV_FILE DISCREPANCY_FILE \
-  IMPORT_DIR LOG_FILE MANIFEST_FILE TRACKING_FILE LOCK_FILE MAX_JOBS
+  IMPORT_DIR LOG_FILE MANIFEST_FILE TRACKING_FILE LOCK_FILE MAX_JOBS \
+  PID_FILE LOG_FILE_LOCK DISCREPANCY_FILE_LOCK PROGRESS_FILE PROGRESS_INTERVAL \
+  PROGRESS_DB_TABLE MONITOR_STATE_FILE MONITOR_STOP_SIGNAL_FILE
 
-# Initialize PID tracking
 declare -A pid_to_file
 
-# Process files in parallel up to $MAX_JOBS
 total_jobs=0
 completed_jobs=0
 skipped_jobs=0
@@ -1011,10 +1591,8 @@ for file in "${files[@]}"; do
     continue
   fi
 
-  # Mark file as IN_PROGRESS atomically in the tracking file
   write_tracking_file "$base_file" "IN_PROGRESS"
 
-  # Wait if we've reached max concurrent jobs
   while [[ $(jobs -rp | wc -l) -ge $MAX_JOBS ]]; do
     sleep 1
   done
@@ -1024,59 +1602,129 @@ for file in "${files[@]}"; do
   pid=$!
   pid_to_file["$pid"]="$file"
   pids+=("$pid")
+  import_pids+=("$pid") # Add to import-specific PID array
   total_jobs=$((total_jobs + 1))
 done
 
-# Wait for all remaining jobs to finish
-for pid in "${pids[@]}"; do
-  if ! wait "$pid"; then
-    overall_success=false
-    failed_file="${pid_to_file[$pid]}"
-    log "Import failed for file: $failed_file" "ERROR"
-    ((failed_imports++))
+log "All import jobs started. Total jobs: $total_jobs, PIDs count: ${#pids[@]}"
+
+# Wait for all import jobs to finish (excluding monitor)
+log "Waiting for all import jobs to complete..."
+for pid in "${import_pids[@]}"; do
+  target_file="${pid_to_file[$pid]}"
+  base_file=$(basename "$target_file")
+
+  current_hash_status=$(grep "^$base_file " "$TRACKING_FILE" 2>/dev/null | awk '{print $3}')
+  if [[ -z "$current_hash_status" ]]; then
+      log "Could not read current hash status for $base_file from tracking file, defaulting to HASH_UNVERIFIED." "WARN"
+      current_hash_status="HASH_UNVERIFIED"
+  fi
+
+  # Check if the process still exists before waiting
+  if kill -0 "$pid" 2>/dev/null; then
+    if ! wait "$pid"; then
+      exit_status=$?
+      overall_success=false
+      log "Import job failed for file: '$base_file' (PID: $pid, Exit Status: $exit_status)" "ERROR"
+
+      stderr_file="$LOG_DIR/${base_file}.stderr"
+      if [[ -s "$stderr_file" ]]; then
+          log "--- Stderr for $base_file (PID: $pid) ---" "ERROR"
+          log "$(sed 's/^/    /' "$stderr_file")" "ERROR"
+          log "--- End Stderr for $base_file (PID: $pid) ---" "ERROR"
+      else
+          log "Stderr file '$stderr_file' not found or empty for failed job (PID: $pid)." "WARN"
+      fi
+
+      write_tracking_file "$base_file" "FAILED_TO_IMPORT"
+      ((failed_imports++))
+    else
+      log "Import job completed successfully for file: '$base_file' (PID: $pid)"
+      write_tracking_file "$base_file" "IMPORTED"
+      ((completed_jobs++))
+    fi
   else
-    ((completed_jobs++))
+    log "Process $pid (File: $base_file) already finished before wait." "DEBUG"
+    current_status=$(read_tracking_status "$base_file")
+
+    # If it was marked IN_PROGRESS, assume success and update. import_file handles explicit failures.
+    if [[ "$current_status" == "IN_PROGRESS" ]]; then
+        log "Updating status for already finished process $pid (File: $base_file) from IN_PROGRESS to IMPORTED." "DEBUG"
+	write_tracking_file "$base_file" "IMPORTED"
+        ((completed_jobs++))
+    elif [[ "$current_status" == "IMPORTED" ]]; then
+         log "Status for already finished process $pid (File: $base_file) is already IMPORTED." "DEBUG"
+         # Avoid double counting completed jobs if reconciling later
+         ((completed_jobs++))
+    elif [[ "$current_status" == "FAILED_TO_IMPORT" || "$current_status" == "FAILED_VALIDATION" ]]; then
+         log "Status for already finished process $pid (File: $base_file) was already FAILED ($current_status)." "WARN"
+         # Avoid double counting failed jobs
+         ((failed_imports++))
+    else
+        log "Status for already finished process $pid (File: $base_file) is '$current_status'. Not updating status, but counting as completed for now." "WARN"
+        # Assume completed for statistical purposes, reconcile later if needed.
+        ((completed_jobs++))
+    fi
   fi
 done
+log "Finished waiting for all import jobs to complete. Jobs: total=$total_jobs, completed=$completed_jobs, failed=$failed_imports"
 
-# Summarize import statistics
-log "===================================================="
-log "Import statistics:"
-log "Total files processed: $((total_jobs + skipped_jobs))"
-log "Files skipped (already imported): $skipped_jobs"
-log "Files attempted to import: $total_jobs"
-log "Files completed: $completed_jobs"
-log "Files failed: $failed_imports"
-log "===================================================="
+# Signal the monitor process to stop
+log "Signaling monitor process (PID: $monitor_pid) to stop..."
+touch "$MONITOR_STOP_SIGNAL_FILE"
 
-# Summarize discrepancies
-if [[ -s "$DISCREPANCY_FILE" ]]; then
+# Wait for the monitor process to exit gracefully
+if [[ -n "$monitor_pid" && "$monitor_pid" -gt 0 ]]; then
+  log "Waiting for monitor process (PID: $monitor_pid) to exit..."
+  if wait "$monitor_pid"; then
+    log "Monitor process (PID: $monitor_pid) exited successfully."
+  else
+    log "Monitor process (PID: $monitor_pid) exited with status $?." "WARN"
+  fi
+else
+  log "Monitor PID not found or invalid, cannot wait for it." "WARN"
+fi
+
+# Make sure there are no remaining background processes before printing statistics
+wait
+
+log "Performing state consistency check..."
+incomplete_count=$(grep -v -E "IMPORTED|FAILED_TO_IMPORT|FAILED_VALIDATION" "$TRACKING_FILE" | wc -l)
+if [[ $incomplete_count -gt 0 ]]; then
   overall_success=false
-  log "===================================================="
-  log "Discrepancies detected during import:"
-  log "The following files failed the row count verification:"
-  log ""
-  while read -r line; do
-    log "- $line"
-  done < "$DISCREPANCY_FILE"
-  log "===================================================="
+  log "Found $incomplete_count files with incomplete status:" "ERROR"
+  grep -v -E "IMPORTED|FAILED_TO_IMPORT|FAILED_VALIDATION" "$TRACKING_FILE"
+
+  # Adjust statistics to account for incomplete files, and prevent negative values
+  completed_jobs=$((completed_jobs - incomplete_count))
+  if [[ $completed_jobs -lt 0 ]]; then
+    log "Correcting completed_jobs value from $completed_jobs to 0 (cannot be negative)" "DEBUG"
+    completed_jobs=0
+  fi
+
+  inconsistent_files=$incomplete_count
 else
-  log "No discrepancies detected during import."
+  inconsistent_files=0
 fi
 
-# Log the final status of the import process
-if [[ $overall_success = true ]]; then
-  log "===================================================="
-  log "DB import completed successfully."
-  log "The database is fully identical to the data files."
-  log "===================================================="
-else
-  log "===================================================="
-  log "The database import process encountered errors and is incomplete." "ERROR"
-  log "Mirrornode requires a fully synchronized database." "ERROR"
-  log "Please review the discrepancies above." "ERROR"
-  log "===================================================="
+tracking_failures=$(grep -c -E "FAILED_VALIDATION|FAILED_TO_IMPORT" "$TRACKING_FILE" || true)
+if [[ $tracking_failures -gt $failed_imports ]]; then
+  log "Found discrepancy in failure count: tracking file shows $tracking_failures failures but counted $failed_imports during processing" "WARN"
+  log "Using higher count ($tracking_failures) for accuracy" "WARN"
+  failed_imports=$tracking_failures
+  overall_success=false
 fi
 
-# Exit with the appropriate status
+print_final_statistics
+
+# Force cleanup of any remaining background processes for a clean exit
+if [ "$(jobs -rp | wc -l)" -gt 0 ]; then
+  log "Cleaning up remaining background jobs before exit..."
+  for job_pid in $(jobs -rp); do
+    kill -9 "$job_pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+fi
+
+log "Script execution complete."
 exit $((1 - overall_success))

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-# Save original stderr destination to FD 9 before any redirections
 exec 9>&2
 
 set -m # Start a new process group and detach from terminal

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
@@ -62,9 +62,9 @@ MONITOR_STOP_SIGNAL_FILE="/tmp/bootstrap_monitor.stop"
 
 # Required system tools
 # Note: A decompressor (rapidgzip, igzip, or gunzip) is checked separately
-REQUIRED_TOOLS=("psql" "realpath" "flock" "curl" "b3sum" "awk" "python3" "find" "cat" \
-    "sed" "tr" "sort" "wc" "ps" "date" "basename" "mkdir" "rm" "touch" "grep" "bc" "column" \
-    "mktemp" "mkfifo" "nproc" "sleep" "pgrep" "pkill" "stat" "dd" "tail" "head" "mv" "chmod")
+REQUIRED_TOOLS=("awk" "b3sum" "basename" "bc" "cat" "chmod" "column" "curl" "date" "dd" "find" "flock"
+    "grep" "head" "mkdir" "mkfifo" "mktemp" "mv" "nproc" "pgrep" "pkill" "ps" "psql" "python3"
+    "realpath" "rm" "sed" "sleep" "sort" "stat" "tail" "touch" "tr" "wc")
 
 export DECOMPRESS_TOOL=""
 export DECOMPRESS_FLAGS=""
@@ -78,10 +78,9 @@ USE_FULL_DB=""
 MANIFEST_FILE=""
 
 # Parallel processing configuration
-B3SUM_NUM_THREADS=${B3SUM_THREADS:-2}         # Number of threads for BLAKE3 hash calculation
-RAPIDGZIP_NUM_THREADS=${RAPIDGZIP_THREADS:-2} # Number of threads for rapidgzip decompression
-IGZIP_NUM_THREADS=${IGZIP_THREADS:-2}         # Number of threads for igzip decompression
-MAX_JOBS=""                                   # Maximum number of concurrent import jobs
+B3SUM_NUM_THREADS=${B3SUM_THREADS:-2}               # Number of threads for BLAKE3 hash calculation
+DECOMPRESSOR_NUM_THREADS=${DECOMPRESSOR_THREADS:-2} # Number of threads for the selected decompressor (rapidgzip or igzip)
+MAX_JOBS=""                                         # Maximum number of concurrent import jobs
 
 # Associative array for manifest row counts
 declare -A manifest_counts
@@ -202,15 +201,15 @@ check_required_tools() {
 determine_decompression_tool() {
   if command -v rapidgzip >/dev/null 2>&1; then
     DECOMPRESS_TOOL="rapidgzip"
-    DECOMPRESS_FLAGS=(-d -c "-P${RAPIDGZIP_NUM_THREADS}")
-    log "Using rapidgzip with ${RAPIDGZIP_NUM_THREADS} threads for decompression"
+    DECOMPRESS_FLAGS=(-d -c "-P${DECOMPRESSOR_NUM_THREADS}")
+    log "Using rapidgzip with ${DECOMPRESSOR_NUM_THREADS} threads for decompression"
     return 0
   fi
 
   if command -v igzip >/dev/null 2>&1; then
     DECOMPRESS_TOOL="igzip"
-    DECOMPRESS_FLAGS=(-d -c "-T${IGZIP_NUM_THREADS}")
-    log "Using igzip with ${IGZIP_NUM_THREADS} threads for decompression"
+    DECOMPRESS_FLAGS=(-d -c "-T${DECOMPRESSOR_NUM_THREADS}")
+    log "Using igzip with ${DECOMPRESSOR_NUM_THREADS} threads for decompression"
     return 0
   fi
 


### PR DESCRIPTION
**Description**:

This was quite a large rework, I've also taken the opportunity to do some overall improvements to it while I was at it.
Below are the highlights :

- Added a check that prevents the script from running a new instance if another is already running.
- Created a full list of the tools required to be checked as the script starts-up (REQUIRED_TOOLS var)
- Added env vars to bootstrap.env to give users an easy way to control the CPU thread-count assigned to `rapidgzip`, `igzip`, and `b3sum`; Defaults to 2 threads per tool.
- Implemented interval-based progress tracking, added `PROGRESS_INTERVAL` to the bootstrap.env file for easy control over the interval; Defaults to every 10 seconds.
- Added DEBUG_MODE var, support for printing "DEBUG" level messages in the log() function only when the mode is enabled, and added a big bunch of these "DEBUG" level log messages all around the script, they've helped me debug various issues and I left some of them in to be able to collect more verbose information in the future if we need to; Defaults to `false`
- Added a with_lock() function that streamlines thread-safe file writes.
- Removed a lot of redundant/obvious comments to cut down on the line count of an already very long script; I left in mostly the more important comments.
- Various bug fixes and increased overall sturdiness by adding escape characters and checks/validations in issues I ran into while reworking and testing the script.
- Added a load_manifest_to_db() function which is used by the progress tracking and creates a temporary unlogged table (which is subsequently gets removed up on every termination of the script during cleanup) with the total row-counts and filenames from the manifest.
- Added the creation of an explicit column-list from each data file's header, which is then used by the COPY command as the data is copied into the DB.
- Added utility functions, such as retry_query(), get_partition_timestamp(), verify_postgres_connection(), and print_final_statistics()
- Added special handling for the `record_file` which uses `consensus_end` column instead of `consensus_timestamp` in all other tables
- Converted CSV row-handling to utilize Python3 in order to retain the integrity of all rows, including those with special characters and embedded newlines.
- Moved the counting of each data files' row-count to be part of the import data pipeline, a Python counter now counts rows as the stream of each file flows through it, then at the end of the data copy into the DB, the row-count verification is done against the manifest, removing the need for a long db table row-count. Major time saver.
- Given the change to the way row-counting is now done, I've reworked the fallback verification methods to keep the same idea as before, a fallback will be used only if the verification/fallback method that came before it fails.
- Updated `bootstrap.md`

**Related issue(s)**:

Fixes https://github.com/hashgraph/infrastructure/issues/7626

**Notes for reviewer**:
The script currently fully supports and tested against the `minimal-db` flavor only.
Once released in its current form, which is the type most people are likely to want, I'll continue working on finalizing and testing support for `full-db`.
I've added `Warning` sections to the bootstrap.md user-guide that warn about full-db being not-supported in this version.

Do NOT merge after approval, I need to copy the 0.125.0 data files dir into the proper location in the bucket right before this script goes live.

**Checklist**

- [x] Documented (Code comments, bootstrap.md user-guide)
- [x] Tested: 
  - [x] Minimal-db bootstrap into postgres 16
  - [x] Start-up of mirror-importer against that DB
  - [x] Verification that the 0.125.0 files in the GCS bucket are identical to the local copy of the them I used to test bootstrap with.
  - [x] Validated the script's resumption logic and that progress tracking works correctly on resumption.