### PR TITLE
Add exception handling for invalid sender

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
@@ -5,6 +5,7 @@ package com.hedera.mirror.web3.service;
 import static com.hedera.mirror.web3.convert.BytesDecoder.maybeDecodeSolidityErrorStringToReadableMessage;
 import static com.hedera.mirror.web3.state.Utils.isMirror;
 import static com.hedera.mirror.web3.validation.HexValidator.HEX_PREFIX;
+import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
@@ -26,10 +27,12 @@ import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracer;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
+import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.AliasesReadableKVState;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import jakarta.inject.Named;
 import java.time.Instant;
 import java.util.List;
@@ -49,6 +52,7 @@ public class TransactionExecutionService {
     private static final Duration TRANSACTION_DURATION = new Duration(15);
     private static final long CONTRACT_CREATE_TX_FEE = 100_000_000L;
 
+    private final AccountReadableKVState accountReadableKVState;
     private final AliasesReadableKVState aliasesReadableKVState;
     private final CommonProperties commonProperties;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
@@ -192,6 +196,19 @@ public class TransactionExecutionService {
         }
 
         final var senderAddress = params.getSender().canonicalAddress();
+        final var accountID = accountIdFromEvmAddress(senderAddress);
+        if (!accountReadableKVState.contains(AccountID.newBuilder()
+                .accountNum(accountID.getAccountNum())
+                .shardNum(accountID.getShardNum())
+                .realmNum(accountID.getRealmNum())
+                .build())) {
+            throw new MirrorEvmTransactionException(
+                    ResponseCodeEnum.INVALID_ACCOUNT_ID,
+                    "Sender account not found",
+                    StringUtils.EMPTY,
+                    params.isModularized());
+        }
+
         if (isMirror(senderAddress)) {
             var entityId = DomainUtils.fromEvmAddress(senderAddress.toArrayUnsafe());
             return EntityIdUtils.toAccountId(entityId);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -2,7 +2,7 @@
 
 package com.hedera.mirror.web3.service;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.exception.BlockNumberNotFoundException.UNKNOWN_BLOCK_NUMBER;
@@ -578,7 +578,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             assertThatThrownBy(() -> contractExecutionService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class)
-                    .hasMessage(PAYER_ACCOUNT_NOT_FOUND.name());
+                    .hasMessage(INVALID_ACCOUNT_ID.name());
         } else {
             final var result = contractExecutionService.processCall(serviceParameters);
             assertThat(result).isEqualTo(HEX_PREFIX);


### PR DESCRIPTION
**Description**:
Invalid sender leads to 500 internal server error, because of pre-handle check failure in services, which is not properly handled in the StandaloneDispatchFactory, and as a result null pointer is returned to the mirror node. The current pr is workaround to the issue that is present in services.

After the changes:
Result with invalid sender:
<img width="1081" alt="Screenshot 2025-04-16 at 16 58 34" src="https://github.com/user-attachments/assets/55adb51a-7fb2-4e92-aaae-149c72c74a95" />

Result with valid sender:
<img width="1083" alt="Screenshot 2025-04-16 at 16 58 54" src="https://github.com/user-attachments/assets/df92597d-e231-4d28-9cf9-e3ef75677fa4" />

**Related issue(s)**:

Fixes #10931 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
