### PR TITLE
Enable REST API response cache by default in chart

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -262,6 +262,13 @@ redis:
     create: true
 
 rest:
+  config:
+    hedera:
+      mirror:
+        rest:
+          cache:
+            response:
+              enabled: true
   db:
     password: ""  # Randomly generated if left blank
     username: mirror_rest


### PR DESCRIPTION
**Description**:

This PR enables REST API response cache by default in chart

**Related issue(s)**:

Fixes #10820

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
