### PR TITLE
Fix storage slot value removal issue

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
@@ -63,7 +63,7 @@ import java.util.function.Supplier;
  *                         account has a valid auto-renew account, and is not deleted upon expiration.
  *                         If this is not provided in an allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
  *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.,
- * @param contractKvPairsNumberSupplier <b>(27)</b> If this account is a smart-contract, number of key-value pairs stored on the contract in a supplier.
+ * @param contractKvPairsNumber <b>(27)</b> If this account is a smart-contract, number of key-value pairs stored on the contract.
  *                              This is used to determine the storage rent for the contract.,
  * @param cryptoAllowancesSupplier <b>(28)</b> (Optional) List of crypto allowances approved by the account in a supplier.
  *  *                         It contains account number for which the allowance is approved to and
@@ -118,7 +118,7 @@ public record Account(
         long stakeAtStartOfLastRewardedPeriod,
         @Nullable AccountID autoRenewAccountId,
         long autoRenewSeconds,
-        Supplier<Integer> contractKvPairsNumberSupplier,
+        int contractKvPairsNumber,
         @Nonnull Supplier<List<AccountCryptoAllowance>> cryptoAllowancesSupplier,
         @Nonnull Supplier<List<AccountApprovalForAllAllowance>> approveForAllNftAllowancesSupplier,
         @Nonnull Supplier<List<AccountFungibleTokenAllowance>> tokenAllowancesSupplier,
@@ -199,7 +199,7 @@ public record Account(
                 stakeAtStartOfLastRewardedPeriod,
                 autoRenewAccountId,
                 autoRenewSeconds,
-                () -> contractKvPairsNumber,
+                contractKvPairsNumber,
                 () -> cryptoAllowances,
                 () -> approveForAllNftAllowances,
                 () -> tokenAllowances,
@@ -309,10 +309,8 @@ public record Account(
         if (autoRenewSeconds != DEFAULT.autoRenewSeconds) {
             result = 31 * result + Long.hashCode(autoRenewSeconds);
         }
-        if (contractKvPairsNumberSupplier != null
-                && DEFAULT.contractKvPairsNumberSupplier != null
-                && !contractKvPairsNumberSupplier.get().equals(DEFAULT.contractKvPairsNumberSupplier.get())) {
-            result = 31 * result + Integer.hashCode(contractKvPairsNumberSupplier.get());
+        if (contractKvPairsNumber != DEFAULT.contractKvPairsNumber) {
+            result = 31 * result + Integer.hashCode(contractKvPairsNumber);
         }
 
         for (Object o : cryptoAllowancesSupplier.get()) {
@@ -496,15 +494,7 @@ public record Account(
         if (autoRenewSeconds != thatObj.autoRenewSeconds) {
             return false;
         }
-
-        if (contractKvPairsNumberSupplier == null && thatObj.contractKvPairsNumberSupplier != null) {
-            return false;
-        }
-        if (contractKvPairsNumberSupplier != null && thatObj.contractKvPairsNumberSupplier == null) {
-            return false;
-        }
-        if (contractKvPairsNumberSupplier != null
-                && !contractKvPairsNumberSupplier.get().equals(thatObj.contractKvPairsNumberSupplier.get())) {
+        if (contractKvPairsNumber != thatObj.contractKvPairsNumber) {
             return false;
         }
         if (!cryptoAllowancesSupplier.get().equals(thatObj.cryptoAllowancesSupplier.get())) {
@@ -902,7 +892,7 @@ public record Account(
                 stakeAtStartOfLastRewardedPeriod,
                 autoRenewAccountId,
                 autoRenewSeconds,
-                contractKvPairsNumberSupplier,
+                contractKvPairsNumber,
                 cryptoAllowancesSupplier,
                 approveForAllNftAllowancesSupplier,
                 tokenAllowancesSupplier,
@@ -927,10 +917,6 @@ public record Account(
 
     public long numberOwnedNfts() {
         return numberOwnedNftsSupplier.get();
-    }
-
-    public int contractKvPairsNumber() {
-        return contractKvPairsNumberSupplier.get();
     }
 
     public List<AccountCryptoAllowance> cryptoAllowances() {
@@ -1081,7 +1067,7 @@ public record Account(
         private AccountID autoRenewAccountId = null;
 
         private long autoRenewSeconds = 0;
-        private Supplier<Integer> contractKvPairsNumberSupplier = DEFAULT_INTEGER_SUPPLIER;
+        private int contractKvPairsNumber = 0;
 
         @Nonnull
         private Supplier<List<AccountCryptoAllowance>> cryptoAllowancesSupplier = Collections::emptyList;
@@ -1147,7 +1133,7 @@ public record Account(
          *                         account has a valid auto-renew account, and is not deleted upon expiration.
          *                         If this is not provided in an allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
          *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.,
-         * @param contractKvPairsNumberSupplier <b>(27)</b> If this account is a smart-contract, number of key-value pairs stored on the contract in a supplier.
+         * @param contractKvPairsNumber <b>(27)</b> If this account is a smart-contract, number of key-value pairs stored on the contract.
          *                              This is used to determine the storage rent for the contract.,
          * @param cryptoAllowancesSupplier <b>(28)</b> (Optional) List of crypto allowances approved by the account in a supplier.
          *  *                         It contains account number for which the allowance is approved to and
@@ -1205,7 +1191,7 @@ public record Account(
                 long stakeAtStartOfLastRewardedPeriod,
                 AccountID autoRenewAccountId,
                 long autoRenewSeconds,
-                Supplier<Integer> contractKvPairsNumberSupplier,
+                int contractKvPairsNumber,
                 Supplier<List<AccountCryptoAllowance>> cryptoAllowancesSupplier,
                 Supplier<List<AccountApprovalForAllAllowance>> approveForAllNftAllowancesSupplier,
                 Supplier<List<AccountFungibleTokenAllowance>> tokenAllowancesSupplier,
@@ -1239,7 +1225,7 @@ public record Account(
             this.stakeAtStartOfLastRewardedPeriod = stakeAtStartOfLastRewardedPeriod;
             this.autoRenewAccountId = autoRenewAccountId;
             this.autoRenewSeconds = autoRenewSeconds;
-            this.contractKvPairsNumberSupplier = contractKvPairsNumberSupplier;
+            this.contractKvPairsNumber = contractKvPairsNumber;
             this.cryptoAllowancesSupplier =
                     cryptoAllowancesSupplier == null ? Collections::emptyList : cryptoAllowancesSupplier;
             this.approveForAllNftAllowancesSupplier = approveForAllNftAllowancesSupplier == null
@@ -1286,7 +1272,7 @@ public record Account(
                     stakeAtStartOfLastRewardedPeriod,
                     autoRenewAccountId,
                     autoRenewSeconds,
-                    contractKvPairsNumberSupplier,
+                    contractKvPairsNumber,
                     cryptoAllowancesSupplier,
                     approveForAllNftAllowancesSupplier,
                     tokenAllowancesSupplier,
@@ -1716,23 +1702,11 @@ public record Account(
          * <b>(26)</b> If this account is a smart-contract, number of key-value pairs stored on the contract.
          * This is used to determine the storage rent for the contract.
          *
-         * @param contractKvPairsNumberSupplier value to set
-         * @return builder to continue building with
-         */
-        public Builder contractKvPairsNumber(Supplier<Integer> contractKvPairsNumberSupplier) {
-            this.contractKvPairsNumberSupplier = contractKvPairsNumberSupplier;
-            return this;
-        }
-
-        /**
-         * <b>(26)</b> If this account is a smart-contract, number of key-value pairs stored on the contract.
-         * This is used to determine the storage rent for the contract.
-         *
          * @param contractKvPairsNumber value to set
          * @return builder to continue building with
          */
         public Builder contractKvPairsNumber(int contractKvPairsNumber) {
-            this.contractKvPairsNumberSupplier = () -> contractKvPairsNumber;
+            this.contractKvPairsNumber = contractKvPairsNumber;
             return this;
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
@@ -45,4 +45,25 @@ public interface ContractStateRepository extends CrudRepository<ContractState, L
             """,
             nativeQuery = true)
     Optional<byte[]> findStorageByBlockTimestamp(long id, byte[] slot, long blockTimestamp);
+
+    @Query(
+            value =
+                    """
+            select count(*)
+            from contract_state
+            where contract_id = ?1
+            """,
+            nativeQuery = true)
+    int countSlotsByContractId(long contractId);
+
+    @Query(
+            value =
+                    """
+            select count(distinct slot)
+            from contract_state_change
+            where contract_id = ?1
+            and consensus_timestamp <= ?2
+            """,
+            nativeQuery = true)
+    int countDistinctSlotsByContractIdAndTimestamp(long contractId, long blockTimestamp);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
@@ -45,25 +45,4 @@ public interface ContractStateRepository extends CrudRepository<ContractState, L
             """,
             nativeQuery = true)
     Optional<byte[]> findStorageByBlockTimestamp(long id, byte[] slot, long blockTimestamp);
-
-    @Query(
-            value =
-                    """
-            select count(*)
-            from contract_state
-            where contract_id = ?1
-            """,
-            nativeQuery = true)
-    int countSlotsByContractId(long contractId);
-
-    @Query(
-            value =
-                    """
-            select count(distinct slot)
-            from contract_state_change
-            where contract_id = ?1
-            and consensus_timestamp <= ?2
-            """,
-            nativeQuery = true)
-    int countDistinctSlotsByContractIdAndTimestamp(long contractId, long blockTimestamp);
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdFromEvmAddress;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.web3.web3j.generated.StorageContract;
+import java.math.BigInteger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class StorageContractTest extends AbstractContractCallServiceHistoricalTest {
+
+    @Test
+    void testUpdateSlot0() {
+        final var contract = testWeb3jService.deployWithoutPersist(StorageContract::deploy);
+        final var entity = persistContract(
+                testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
+
+        var zeroSlot = DomainUtils.leftPadBytes(BigInteger.ZERO.toByteArray(), 32);
+        var oneValue = DomainUtils.leftPadBytes(BigInteger.ONE.toByteArray(), 32);
+
+        domainBuilder
+                .contractState()
+                .customize(c -> c.contractId(entity.toEntityId().getId())
+                        .slot(UInt256.fromBytes(Bytes.wrap(zeroSlot)).toArray())
+                        .value(UInt256.fromBytes(Bytes.wrap(oneValue)).toArray()))
+                .persist();
+        final var functionCall = contract.send_setSlot0(BigInteger.ZERO);
+        assertDoesNotThrow(functionCall::send);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {100, 150, 200})
+    void testUpdateSlot1Historical(long blockNumber) {
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var contract = testWeb3jService.deployWithoutPersist(StorageContract::deploy);
+        final var entity = persistHistoricalContract(
+                testWeb3jService.getContractRuntime(),
+                Address.fromHexString(contract.getContractAddress()),
+                historicalRange);
+        domainBuilder
+                .contractStateChange()
+                .customize(c -> c.contractId(entity.toEntityId().getId())
+                        .slot(BigInteger.ONE.toByteArray())
+                        .valueRead(BigInteger.ONE.toByteArray())
+                        .valueWritten(BigInteger.ONE.toByteArray())
+                        .consensusTimestamp(historicalRange.lowerEndpoint()))
+                .persist();
+        final var functionCall = contract.send_setSlot1(BigInteger.ZERO);
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    private Entity persistContract(final byte[] runtimeBytecode, final Address contractAddress) {
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+        final var evmAddress = toEvmAddress(contractEntityId);
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.id(contractEntityId.getId())
+                        .num(contractEntityId.getNum())
+                        .evmAddress(evmAddress)
+                        .type(CONTRACT)
+                        .balance(1500L))
+                .persist();
+        domainBuilder
+                .contract()
+                .customize(c -> c.id(contractEntityId.getId()).runtimeBytecode(runtimeBytecode))
+                .persist();
+        domainBuilder.recordFile().customize(f -> f.bytes(runtimeBytecode)).persist();
+        return entity;
+    }
+
+    private Entity persistHistoricalContract(
+            final byte[] runtimeBytecode, final Address contractAddress, final Range<Long> historicalRange) {
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+        final var evmAddress = toEvmAddress(contractEntityId);
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.id(contractEntityId.getId())
+                        .num(contractEntityId.getNum())
+                        .evmAddress(evmAddress)
+                        .type(CONTRACT)
+                        .createdTimestamp(historicalRange.lowerEndpoint())
+                        .timestampRange(historicalRange)
+                        .balance(1500L))
+                .persist();
+        domainBuilder
+                .contract()
+                .customize(c -> c.id(contractEntityId.getId()).runtimeBytecode(runtimeBytecode))
+                .persist();
+        domainBuilder
+                .recordFile()
+                .customize(f -> f.bytes(runtimeBytecode).consensusEnd(historicalRange.lowerEndpoint()))
+                .persist();
+        return entity;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
@@ -74,12 +74,8 @@ class StorageContractTest extends AbstractContractCallServiceHistoricalTest {
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
         final var evmAddress = toEvmAddress(contractEntityId);
         final var entity = domainBuilder
-                .entity()
-                .customize(e -> e.id(contractEntityId.getId())
-                        .num(contractEntityId.getNum())
-                        .evmAddress(evmAddress)
-                        .type(CONTRACT)
-                        .balance(1500L))
+                .entity(contractEntityId)
+                .customize(e -> e.evmAddress(evmAddress).type(CONTRACT).balance(1500L))
                 .persist();
         domainBuilder
                 .contract()
@@ -94,10 +90,8 @@ class StorageContractTest extends AbstractContractCallServiceHistoricalTest {
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
         final var evmAddress = toEvmAddress(contractEntityId);
         final var entity = domainBuilder
-                .entity()
-                .customize(e -> e.id(contractEntityId.getId())
-                        .num(contractEntityId.getNum())
-                        .evmAddress(evmAddress)
+                .entity(contractEntityId)
+                .customize(e -> e.evmAddress(evmAddress)
                         .type(CONTRACT)
                         .createdTimestamp(historicalRange.lowerEndpoint())
                         .timestampRange(historicalRange)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/StorageContractTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class StorageContractTest extends AbstractContractCallServiceHistoricalTest {
 
     @Test
-    void testUpdateSlot0() {
+    void testRemoveSlot0() {
         final var contract = testWeb3jService.deployWithoutPersist(StorageContract::deploy);
         final var entity = persistContract(
                 testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
@@ -37,6 +37,15 @@ class StorageContractTest extends AbstractContractCallServiceHistoricalTest {
                         .value(UInt256.fromBytes(Bytes.wrap(oneValue)).toArray()))
                 .persist();
         final var functionCall = contract.send_setSlot0(BigInteger.ZERO);
+        assertDoesNotThrow(functionCall::send);
+    }
+
+    @Test
+    void testUpdateSlot0() {
+        final var contract = testWeb3jService.deployWithoutPersist(StorageContract::deploy);
+        persistContract(testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
+
+        final var functionCall = contract.send_updateStorage(BigInteger.ONE, BigInteger.valueOf(10));
         assertDoesNotThrow(functionCall::send);
     }
 

--- a/hedera-mirror-web3/src/test/solidity/StorageContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/StorageContract.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 contract StorageContract {
+    uint256 public slot0;
+    uint256 public slot1;
     mapping(uint256 => uint256) public storageMap;
     uint256 public storedValue;
 
@@ -11,5 +13,13 @@ contract StorageContract {
 
     function updateSingleValue(uint256 value) public {
         storedValue = value; // SSTORE operation
+    }
+
+    function setSlot0(uint256 value) public {
+        slot0 = value;
+    }
+
+    function setSlot1(uint256 value) public {
+        slot1 = value;
     }
 }


### PR DESCRIPTION
**Description**:
This PR fixes storage slot value removal in modularized flow.

When the account is a contract we need to populate `contractKvPairsNumber` base on its storage values.

Currently it is always 0 and when we try to make a storage slot update where we set value to 0 we get an error.

`Account` - set contractKvPairsNumber 
`AccountReadableKVState` - set `contractKvPairsNumber` to the `Account` model
`StorageContractTest` - add tests for the previously failing scenarios

Fixes #10895

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
