### PR TITLE
Fix gha deprecated cache issue (0.127)

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -86,6 +86,7 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+          version: latest
 
       - name: Build and push images
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
@@ -94,6 +95,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{env.CONTEXT}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           platforms: linux/amd64, linux/arm64
           provenance: false
           push: true

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -87,6 +87,7 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+          version: latest
 
       - name: Build and push images
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
@@ -96,6 +97,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{env.CONTEXT}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           platforms: linux/amd64, linux/arm64
           provenance: false
           push: true

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -65,6 +65,7 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+          version: latest
 
       - name: Build Image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
@@ -73,6 +74,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ./hedera-mirror-rosetta/container
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           load: true
           provenance: false
           push: false


### PR DESCRIPTION
**Description**:

Cherry pick of #10869 to `release/0.127`

* Fix GHA deprecated cache issue by using latest buildx
* Use GITHUB_TOKEN in docker/build-push-action to avoid rate limiting

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
