### PR TITLE
Upgrade integration-docker to 0.128.0-rc1

### DIFF
--- a/clusters/preprod/integration-docker/helmrelease.yaml
+++ b/clusters/preprod/integration-docker/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '0.127.0-rc2'
+      version: '0.128.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common

--- a/clusters/preprod/integration/helmrelease.yaml
+++ b/clusters/preprod/integration/helmrelease.yaml
@@ -59,9 +59,6 @@ spec:
           enabled: false
     postgresql:
       enabled: false
-    rest:
-      env:
-        HEDERA_MIRROR_REST_CACHE_RESPONSE_ENABLED: "true"
     rosetta:
       enabled: true
     test:


### PR DESCRIPTION
**Description**:

* Remove redis cache override in integration
* Upgrade integration-docker to 0.128.0-rc1

**Related issue(s)**:

**Notes for reviewer**:

Depends on #10957

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
