### PR TITLE
Add the missing contract key in the state

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -10,10 +10,13 @@ import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toTokenId;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountApprovalForAllAllowance;
 import com.hedera.hapi.node.state.token.AccountCryptoAllowance;
 import com.hedera.hapi.node.state.token.AccountFungibleTokenAllowance;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.SystemEntity;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -60,6 +63,7 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
     private final TokenAccountRepository tokenAccountRepository;
     private final TokenAllowanceRepository tokenAllowanceRepository;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
+    private final CommonProperties commonProperties = CommonProperties.getInstance();
 
     public AccountReadableKVState(
             CommonEntityAccessor commonEntityAccessor,
@@ -101,6 +105,7 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
         } else if (entity.getAlias() != null && entity.getAlias().length > 0) {
             alias = entity.getAlias();
         }
+        final boolean isSmartContract = CONTRACT.equals(entity.getType());
 
         return Account.newBuilder()
                 .accountId(EntityIdUtils.toAccountId(entity.toEntityId()))
@@ -114,17 +119,31 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
                 .ethereumNonce(Objects.requireNonNullElse(entity.getEthereumNonce(), 0L))
                 .expirationSecond(TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS))
                 .expiredAndPendingRemoval(false)
-                .key(parseKey(entity.getKey()))
+                .key(getKey(entity, isSmartContract))
                 .maxAutoAssociations(Objects.requireNonNullElse(entity.getMaxAutomaticTokenAssociations(), 0))
                 .memo(entity.getMemo())
                 .numberAssociations(() -> tokenAccountBalances.get().all())
                 .numberOwnedNfts(getOwnedNfts(entity.getId(), timestamp))
                 .numberPositiveBalances(() -> tokenAccountBalances.get().positive())
                 .receiverSigRequired(entity.getReceiverSigRequired() != null && entity.getReceiverSigRequired())
-                .smartContract(CONTRACT.equals(entity.getType()))
+                .smartContract(isSmartContract)
                 .tinybarBalance(getAccountBalance(entity, timestamp))
                 .tokenAllowances(getFungibleTokenAllowances(entity.getId(), timestamp))
                 .build();
+    }
+
+    private Key getKey(final Entity entity, final boolean isSmartContract) {
+        final var key = parseKey(entity.getKey());
+        if (key == null && isSmartContract) {
+            return Key.newBuilder()
+                    .contractID(ContractID.newBuilder()
+                            .shardNum(commonProperties.getShard())
+                            .realmNum(commonProperties.getRealm())
+                            .contractNum(entity.getNum())
+                            .build())
+                    .build();
+        }
+        return key;
     }
 
     private Supplier<Long> getOwnedNfts(Long accountId, final Optional<Long> timestamp) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -16,7 +16,6 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountApprovalForAllAllowance;
 import com.hedera.hapi.node.state.token.AccountCryptoAllowance;
 import com.hedera.hapi.node.state.token.AccountFungibleTokenAllowance;
-import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.domain.SystemEntity;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -63,7 +62,6 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
     private final TokenAccountRepository tokenAccountRepository;
     private final TokenAllowanceRepository tokenAllowanceRepository;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
-    private final CommonProperties commonProperties = CommonProperties.getInstance();
 
     public AccountReadableKVState(
             CommonEntityAccessor commonEntityAccessor,
@@ -137,8 +135,8 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
         if (key == null && isSmartContract) {
             return Key.newBuilder()
                     .contractID(ContractID.newBuilder()
-                            .shardNum(commonProperties.getShard())
-                            .realmNum(commonProperties.getRealm())
+                            .shardNum(entity.getShard())
+                            .realmNum(entity.getRealm())
                             .contractNum(entity.getNum())
                             .build())
                     .build();


### PR DESCRIPTION
**Description**:
This PR is a workaround for the following scenario: a contract with a null key was deployed and imported in the mirror node DB (before the fix in https://github.com/hiero-ledger/hiero-consensus-node/issues/15990). The parent transaction has a payer which is the one set as a sender in the transaction. The key verification is fine. A child transaction is created from the contract call. The latter transaction has a payer set to the contract and its key is verified against the contract's key which is null, hence the error in this issue.

This was resolved in services by adding a default key from `ContractID(shard, realm, num)`. This PR in the mirror node mocks this logic until we have a real DB migration - when an account is read in the `AccountReadableKVState` its key is set before the account is put in the state as an object. If the key is null and the entity is of type 'contract' now a dummy key is added from `ContractID(shard, realm, num)` as if the migration was already run.

_Note: the contracts following the fix in services do not have this issue._

**Related issue(s)**: https://github.com/hiero-ledger/hiero-consensus-node/issues/15990

Fixes #10900 
