### PR TITLE
Fix mainnet-na rest monitor by setting contract id

### DIFF
--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -63,6 +63,10 @@ spec:
       env:
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
+      monitor:
+        config:
+          contract:
+            contractId: "0.0.2283226"
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "mainnet"


### PR DESCRIPTION
**Description**:

This PR sets contract id for rest-monitor to workaround the issue hit during upgrade.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

There is an existing ticket: 
https://github.com/hiero-ledger/hiero-mirror-node/issues/9423 

when hit during upgrade, rest-monitor test will fail, thus helmrelease fails and java monitor reports DOWN

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
