### PR TITLE
Generate valid evm-compatible address in acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -168,6 +168,7 @@ import org.bouncycastle.util.encoders.Hex;
 public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
     private static final long FIRST_NFT_SERIAL_NUMBER = 1;
+    private static final long NUM_MAX_SIZE = 274877906943L;
     private final CommonProperties commonProperties;
     private final TokenClient tokenClient;
     private final AccountClient accountClient;
@@ -980,11 +981,11 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     }
 
     @Then("I call estimateGas with delete function for invalid token address")
-    public void deleteTokenRandomAddressEstimateGas() {
+    public void deleteTokenInvalidAddressEstimateGas() {
         String address = Hex.toHexString(ByteBuffer.allocate(20)
                 .putInt((int) commonProperties.getShard())
                 .putLong(commonProperties.getRealm())
-                .putLong(new SecureRandom().nextLong(2345, 1234567))
+                .putLong(new SecureRandom().nextLong(NUM_MAX_SIZE / 100, NUM_MAX_SIZE))
                 .array());
 
         var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(address));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -117,9 +117,9 @@ import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddressArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asByteArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asLongArray;
+import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.generateRandomEvmAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nextBytes;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nftAmount;
-import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.to32BytesString;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.util.Strings;
@@ -159,17 +159,13 @@ import java.util.function.Consumer;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.tuweni.bytes.Bytes;
 
 @CustomLog
 @RequiredArgsConstructor
 public class EstimatePrecompileFeature extends AbstractEstimateFeature {
-    private static final String HEX_DIGITS = "0123456789abcdef";
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
-
-    private static final String RANDOM_ADDRESS =
-            to32BytesString(RandomStringUtils.secure().next(40, HEX_DIGITS));
+    private static final String RANDOM_ADDRESS = generateRandomEvmAddress();
     private static final long FIRST_NFT_SERIAL_NUMBER = 1;
     private final TokenClient tokenClient;
     private final AccountClient accountClient;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -117,7 +117,6 @@ import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddressArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asByteArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asLongArray;
-import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.generateRandomEvmAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nextBytes;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nftAmount;
 
@@ -132,6 +131,7 @@ import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TokenUpdateTransaction;
+import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.rest.model.ContractCallResponse;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum;
@@ -149,6 +149,7 @@ import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -160,13 +161,14 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.encoders.Hex;
 
 @CustomLog
 @RequiredArgsConstructor
 public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
-    private static final String RANDOM_ADDRESS = generateRandomEvmAddress();
     private static final long FIRST_NFT_SERIAL_NUMBER = 1;
+    private final CommonProperties commonProperties;
     private final TokenClient tokenClient;
     private final AccountClient accountClient;
     private final Web3Properties web3Properties;
@@ -979,7 +981,13 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with delete function for invalid token address")
     public void deleteTokenRandomAddressEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(RANDOM_ADDRESS));
+        String address = Hex.toHexString(ByteBuffer.allocate(20)
+                .putInt((int) commonProperties.getShard())
+                .putLong(commonProperties.getRealm())
+                .putLong(new SecureRandom().nextLong(2345, 1234567))
+                .array());
+
+        var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(address));
 
         assertContractCallReturnsBadRequest(data, DELETE_TOKEN.actualGas, estimatePrecompileContractSolidityAddress);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -239,6 +239,42 @@ public class TestUtil {
         return Instant.ofEpochSecond(seconds, nanos);
     }
 
+    /**
+     * Generate random long-zero address (evm-compatible address that can be converted to a validly formatted Entity ID)
+     *
+     * @return long-zero address
+     */
+    public static String generateRandomLongZeroAddress() {
+        SecureRandom random = new SecureRandom();
+        byte[] explicit = new byte[20];
+
+        // Generate valid shard (10-bit, max 1023)
+        int shard = random.nextInt(1 << 10);
+        explicit[2] = (byte) ((shard >>> 8) & 0xFF);
+        explicit[3] = (byte) (shard & 0xFF);
+
+        // Generate valid realm (16-bit, max 65535)
+        int realm = random.nextInt(1 << 16);
+        explicit[10] = (byte) ((realm >>> 8) & 0xFF);
+        explicit[11] = (byte) (realm & 0xFF);
+
+        // Generate valid num (38-bit max)
+        long num = random.nextLong() & ((1L << 38) - 1);
+        explicit[15] = (byte) ((num >>> 32) & 0xFF);
+        explicit[16] = (byte) ((num >>> 24) & 0xFF);
+        explicit[17] = (byte) ((num >>> 16) & 0xFF);
+        explicit[18] = (byte) ((num >>> 8) & 0xFF);
+        explicit[19] = (byte) (num & 0xFF);
+
+        // Convert to hex string
+        StringBuilder hex = new StringBuilder();
+        for (byte b : explicit) {
+            hex.append(String.format("%02x", b));
+        }
+
+        return hex.toString();
+    }
+
     public static class TokenTransferListBuilder {
         private Tuple tokenTransferList;
         private Address token;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -239,42 +239,6 @@ public class TestUtil {
         return Instant.ofEpochSecond(seconds, nanos);
     }
 
-    /**
-     * Generate random long-zero address (evm-compatible address that can be converted to a validly formatted Entity ID)
-     *
-     * @return long-zero address
-     */
-    public static String generateRandomLongZeroAddress() {
-        SecureRandom random = new SecureRandom();
-        byte[] explicit = new byte[20];
-
-        // Generate valid shard (10-bit, max 1023)
-        int shard = random.nextInt(1 << 10);
-        explicit[2] = (byte) ((shard >>> 8) & 0xFF);
-        explicit[3] = (byte) (shard & 0xFF);
-
-        // Generate valid realm (16-bit, max 65535)
-        int realm = random.nextInt(1 << 16);
-        explicit[10] = (byte) ((realm >>> 8) & 0xFF);
-        explicit[11] = (byte) (realm & 0xFF);
-
-        // Generate valid num (38-bit max)
-        long num = random.nextLong() & ((1L << 38) - 1);
-        explicit[15] = (byte) ((num >>> 32) & 0xFF);
-        explicit[16] = (byte) ((num >>> 24) & 0xFF);
-        explicit[17] = (byte) ((num >>> 16) & 0xFF);
-        explicit[18] = (byte) ((num >>> 8) & 0xFF);
-        explicit[19] = (byte) (num & 0xFF);
-
-        // Convert to hex string
-        StringBuilder hex = new StringBuilder();
-        for (byte b : explicit) {
-            hex.append(String.format("%02x", b));
-        }
-
-        return hex.toString();
-    }
-
     public static class TokenTransferListBuilder {
         private Tuple tokenTransferList;
         private Address token;


### PR DESCRIPTION
**Description**:
During estimatePrecompile.feature execution we are trying to generate random evm-compatible address that will be used in a test using non-existing address. When going through the following code in services:

```
private TransactionBody bodyForClassic(@NonNull final HtsCallAttempt attempt) {
    final var call = DELETE_TOKEN.decodeCall(attempt.inputBytes());
    final var token = ConversionUtils.asTokenId(call.get(0));
    return TransactionBody.newBuilder()
            .tokenDeletion(
                    TokenDeleteTransactionBody.newBuilder().token(token).build())
            .build();
}

public static TokenID asTokenId(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
    final var explicit = explicitFromHeadlong(address);
    return TokenID.newBuilder()
            .shardNum(shardOfLongZero(explicit))
            .realmNum(realmOfLongZero(explicit))
            .tokenNum(numberOfLongZero(explicit))
            .build();
}
```

shardOfLongZero, realmOfLongZero and numberOfLongZero can return negative numbers if the randomly generated address/hex value doesn’t fit in a signed long(-2^63 to 2^63 - 1) . That's why we should generate addresses that never encode values ≥ 2^63.
Also the shard, realm and num have size restrictions, for example the shard should have value between 0 and 1023, according to the following logic in services:

```
        if (shard > SHARD_MASK || shard < 0 || realm > REALM_MASK || realm < 0 || num > NUM_MASK || num < 0) {
            throw new InvalidEntityException("Invalid entity ID: " + shard + "." + realm + "." + num);
        }
```

This should be considered during the evm-compatible address generation process if we want to be able to convert to a validly formatted Entity ID.

**Related issue(s)**:

Fixes #10627 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
