### PR TITLE
Transition HTTP chart repositories to OCI

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
+  - bitnami=oci://registry-1.docker.io/bitnamicharts
   - loki=https://grafana.github.io/helm-charts
   - prometheus=https://prometheus-community.github.io/helm-charts
   - traefik=https://helm.traefik.io/traefik

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 chart-repos:
-  - bitnami=oci://registry-1.docker.io/bitnamicharts
   - loki=https://grafana.github.io/helm-charts
-  - prometheus=https://prometheus-community.github.io/helm-charts
-  - traefik=https://helm.traefik.io/traefik
 check-version-increment: false
 validate-maintainers: false

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -14,17 +14,17 @@ dependencies:
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
-    repository: https://prometheus-community.github.io/helm-charts
+    repository: oci://ghcr.io/prometheus-community/charts
     version: 4.14.1
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
-    repository: https://prometheus-community.github.io/helm-charts
+    repository: oci://ghcr.io/prometheus-community/charts
     version: 70.4.2
   - name: promtail
     condition: promtail.enabled
     version: 6.16.6
-    repository: https://grafana.github.io/helm-charts
+    repository: oci://ghcr.io/grafana/helm-charts
   - alias: stackgres
     condition: stackgres.enabled
     name: stackgres-operator
@@ -32,7 +32,7 @@ dependencies:
     version: 1.15.0
   - condition: traefik.enabled
     name: traefik
-    repository: https://helm.traefik.io/traefik
+    repository: oci://ghcr.io/traefik/helm
     version: 35.0.0
   - alias: zfs
     condition: zfs.enabled

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - alias: minio
     condition: minio.enabled
     name: minio
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 16.0.7
   - name: loki
     condition: loki.enabled

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -30,11 +30,11 @@ dependencies:
   - alias: postgresql
     condition: postgresql.enabled
     name: postgresql-ha
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 15.3.12
   - condition: redis.enabled
     name: redis
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 20.11.5
   - alias: rest
     condition: rest.enabled


### PR DESCRIPTION
**Description**:

* Fix deployment due to Bitnami using OCI URLs in index.yaml and FluxCD not supporting this
* Transition all HTTP chart repositories to OCI
* Remove repositories from ct config since Helm doesn't require adding the repo for OCI

**Related issue(s)**:

https://github.com/bitnami/charts/issues/30110

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
