### PR TITLE
Fix `NullPointerException` on missing account key

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -3,6 +3,7 @@
 package com.hedera.mirror.web3.state;
 
 import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.mirror.common.CommonProperties;
 import com.hedera.mirror.common.util.DomainUtils;
@@ -18,6 +19,8 @@ public class Utils {
 
     public static final long DEFAULT_AUTO_RENEW_PERIOD = 7776000L;
     public static final int EVM_ADDRESS_LEN = 20;
+    public static final Key EMPTY_KEY_LIST =
+            Key.newBuilder().keyList(KeyList.DEFAULT).build();
 
     public static Key parseKey(final byte[] keyBytes) {
         try {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -5,6 +5,7 @@ package com.hedera.mirror.web3.state.keyvalue;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
+import static com.hedera.mirror.web3.state.Utils.EMPTY_KEY_LIST;
 import static com.hedera.mirror.web3.state.Utils.parseKey;
 import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toTokenId;
@@ -132,14 +133,21 @@ public class AccountReadableKVState extends AbstractReadableKVState<AccountID, A
 
     private Key getKey(final Entity entity, final boolean isSmartContract) {
         final var key = parseKey(entity.getKey());
-        if (key == null && isSmartContract) {
-            return Key.newBuilder()
-                    .contractID(ContractID.newBuilder()
-                            .shardNum(entity.getShard())
-                            .realmNum(entity.getRealm())
-                            .contractNum(entity.getNum())
-                            .build())
-                    .build();
+        if (key == null) {
+            if (isSmartContract) {
+                return Key.newBuilder()
+                        .contractID(ContractID.newBuilder()
+                                .shardNum(entity.getShard())
+                                .realmNum(entity.getRealm())
+                                .contractNum(entity.getNum())
+                                .build())
+                        .build();
+            } else {
+                // In hedera.app there isn't a case in which an account does not have a key set in the state - it is
+                // either valid, or it is an empty KeyList as the one below. This key is added in the account state in
+                // the mirror node for consistency as well as to prevent from potential NullPointerException.
+                return EMPTY_KEY_LIST;
+            }
         }
         return key;
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -567,14 +567,14 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
 
     @Test
     void ethCallWithValueAndNotExistingSenderAddress() {
+        // Given
         final var receiverEntity = accountEntityWithEvmAddressPersist();
         final var receiverAddress = getAliasAddressFromEntity(receiverEntity);
         final var notExistingAccountAddress = toAddress(domainBuilder.entityId());
-        persistRewardAccounts();
-
         final var serviceParameters =
                 getContractExecutionParametersWithValue(Bytes.EMPTY, notExistingAccountAddress, receiverAddress, 10L);
 
+        // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             assertThatThrownBy(() -> contractExecutionService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class)
@@ -584,6 +584,23 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
             assertThat(result).isEqualTo(HEX_PREFIX);
         }
 
+        assertGasLimit(serviceParameters);
+    }
+
+    @Test
+    void ethCallWithValueAndSenderWithoutKey() {
+        // Given
+        final var receiverEntity = accountEntityWithEvmAddressPersist();
+        final var receiverAddress = getAliasAddressFromEntity(receiverEntity);
+        final var senderEntity = accountEntityPersistCustomizable(e -> e.key(null));
+        final var serviceParameters = getContractExecutionParametersWithValue(
+                Bytes.EMPTY, toAddress(senderEntity.toEntityId()), receiverAddress, 10L);
+
+        // When
+        final var result = contractExecutionService.processCall(serviceParameters);
+
+        // Then
+        assertThat(result).isEqualTo(HEX_PREFIX);
         assertGasLimit(serviceParameters);
     }
 


### PR DESCRIPTION
**Description**:
In the consensus node there are no missing account keys in the state and if there are this is treated as a catastrophic failure. In a previous PR we added a default key for contracts. In this PR we add a default key for accounts. With this change we should be in sync with the consensus node. An integration test was added, as well as 2 junit tests that verify that the default account/contract keys are returned as expected.

Fixes #10989 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
