### PR TITLE
Adapt state to check for new state keys in hedera-app

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -45,6 +45,7 @@ public class SchemaRegistryImpl implements SchemaRegistry {
 
     private final Collection<SingletonState<?>> singletons;
     private final SchemaApplications schemaApplications;
+    private final StateKeyRegistry stateKeyRegistry;
 
     /**
      * The ordered set of all schemas registered by the service
@@ -209,13 +210,13 @@ public class SchemaRegistryImpl implements SchemaRegistry {
                 var singleton = singletonMap.computeIfAbsent(def.stateKey(), DefaultSingleton::new);
                 stateDataSources.put(singleton.getKey(), singleton);
             } else if (def.queue()) {
-                if (StateKeyRegistry.contains(def.stateKey())) {
+                if (stateKeyRegistry.contains(def.stateKey())) {
                     stateDataSources.put(def.stateKey(), new ConcurrentLinkedDeque<>());
                 } else {
                     throw new UnsupportedOperationException("Unsupported state key for queue: " + def.stateKey());
                 }
             } else {
-                if (StateKeyRegistry.contains(def.stateKey())) {
+                if (stateKeyRegistry.contains(def.stateKey())) {
                     stateDataSources.put(def.stateKey(), new ConcurrentHashMap<>());
                 } else {
                     throw new UnsupportedOperationException("Unsupported state key: " + def.stateKey());

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -9,6 +9,7 @@ import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFIN
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.web3.state.MirrorNodeState;
 import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.mirror.web3.state.keyvalue.StateKeyRegistry;
 import com.hedera.mirror.web3.state.singleton.DefaultSingleton;
 import com.hedera.mirror.web3.state.singleton.SingletonState;
 import com.hedera.node.app.state.merkle.SchemaApplications;
@@ -208,9 +209,17 @@ public class SchemaRegistryImpl implements SchemaRegistry {
                 var singleton = singletonMap.computeIfAbsent(def.stateKey(), DefaultSingleton::new);
                 stateDataSources.put(singleton.getKey(), singleton);
             } else if (def.queue()) {
-                stateDataSources.put(def.stateKey(), new ConcurrentLinkedDeque<>());
+                if (StateKeyRegistry.contains(def.stateKey())) {
+                    stateDataSources.put(def.stateKey(), new ConcurrentLinkedDeque<>());
+                } else {
+                    throw new UnsupportedOperationException("Unsupported state key for queue: " + def.stateKey());
+                }
             } else {
-                stateDataSources.put(def.stateKey(), new ConcurrentHashMap<>());
+                if (StateKeyRegistry.contains(def.stateKey())) {
+                    stateDataSources.put(def.stateKey(), new ConcurrentHashMap<>());
+                } else {
+                    throw new UnsupportedOperationException("Unsupported state key: " + def.stateKey());
+                }
             }
         });
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
@@ -2,6 +2,7 @@
 
 package com.hedera.mirror.web3.state.components;
 
+import com.hedera.mirror.web3.state.keyvalue.StateKeyRegistry;
 import com.hedera.mirror.web3.state.singleton.SingletonState;
 import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.state.merkle.SchemaApplications;
@@ -21,6 +22,7 @@ public class ServicesRegistryImpl implements ServicesRegistry {
 
     private final SortedSet<Registration> entries = new TreeSet<>();
     private final Collection<SingletonState<?>> singletons;
+    private final StateKeyRegistry stateKeyRegistry;
 
     @Nonnull
     @Override
@@ -30,7 +32,7 @@ public class ServicesRegistryImpl implements ServicesRegistry {
 
     @Override
     public void register(@Nonnull Service service) {
-        final var registry = new SchemaRegistryImpl(singletons, new SchemaApplications());
+        final var registry = new SchemaRegistryImpl(singletons, new SchemaApplications(), stateKeyRegistry);
         service.registerSchemas(registry);
         entries.add(new ServicesRegistryImpl.Registration(service, registry));
     }
@@ -39,7 +41,7 @@ public class ServicesRegistryImpl implements ServicesRegistry {
     @Override
     public ServicesRegistry subRegistryFor(@Nonnull String... serviceNames) {
         final var selections = Set.of(serviceNames);
-        final var subRegistry = new ServicesRegistryImpl(singletons);
+        final var subRegistry = new ServicesRegistryImpl(singletons, stateKeyRegistry);
         subRegistry.entries.addAll(entries.stream()
                 .filter(registration -> selections.contains(registration.serviceName()))
                 .toList());

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
@@ -8,24 +8,17 @@ import com.hedera.node.app.service.schedule.impl.schemas.V0570ScheduleSchema;
 import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.app.state.recordcache.schemas.V0490RecordCacheSchema;
 import com.hedera.node.app.state.recordcache.schemas.V0540RecordCacheSchema;
+import com.swirlds.state.spi.ReadableKVState;
+import jakarta.inject.Named;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public enum StateKeyRegistry {
-    ;
-    private static final Set<String> keys = Stream.of(
-                    // Implemented
-                    AccountReadableKVState.KEY,
-                    AirdropsReadableKVState.KEY,
-                    AliasesReadableKVState.KEY,
-                    ContractBytecodeReadableKVState.KEY,
-                    ContractStorageReadableKVState.KEY,
-                    FileReadableKVState.KEY,
-                    NftReadableKVState.KEY,
-                    TokenReadableKVState.KEY,
-                    TokenRelationshipReadableKVState.KEY,
-                    // Not implemented but not needed
+@Named
+public class StateKeyRegistry {
+    private static final Set<String> DEFAULT_IMPLEMENTATIONS = Stream.of(
                     V0490TokenSchema.STAKING_INFO_KEY,
                     V0490FileSchema.UPGRADE_DATA_KEY,
                     V0490RecordCacheSchema.TXN_RECORD_QUEUE,
@@ -40,10 +33,18 @@ public enum StateKeyRegistry {
                     V0490ScheduleSchema.SCHEDULES_BY_ID_KEY)
             .collect(Collectors.toSet());
 
-    public static boolean contains(final String stateKey) {
+    private final Set<String> stateKeys;
+
+    public StateKeyRegistry(final Collection<ReadableKVState<?, ?>> keyValues) {
+        this.stateKeys = keyValues.stream()
+                .map(ReadableKVState::getStateKey)
+                .collect(Collectors.toCollection(() -> new HashSet<>(DEFAULT_IMPLEMENTATIONS)));
+    }
+
+    public boolean contains(final String stateKey) {
         if (stateKey != null && stateKey.startsWith("UPGRADE_DATA")) {
-            return keys.contains(V0490FileSchema.UPGRADE_DATA_KEY);
+            return stateKeys.contains(V0490FileSchema.UPGRADE_DATA_KEY);
         }
-        return keys.contains(stateKey);
+        return stateKeys.contains(stateKey);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.state.keyvalue;
+
+import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
+import com.hedera.node.app.service.schedule.impl.schemas.V0490ScheduleSchema;
+import com.hedera.node.app.service.schedule.impl.schemas.V0570ScheduleSchema;
+import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
+import com.hedera.node.app.state.recordcache.schemas.V0490RecordCacheSchema;
+import com.hedera.node.app.state.recordcache.schemas.V0540RecordCacheSchema;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StateKeyRegistry {
+    private static final Set<String> keys = Stream.of(
+                    // Implemented
+                    AccountReadableKVState.KEY,
+                    AirdropsReadableKVState.KEY,
+                    AliasesReadableKVState.KEY,
+                    ContractBytecodeReadableKVState.KEY,
+                    ContractStorageReadableKVState.KEY,
+                    FileReadableKVState.KEY,
+                    NftReadableKVState.KEY,
+                    TokenReadableKVState.KEY,
+                    TokenRelationshipReadableKVState.KEY,
+                    // Not implemented but not needed
+                    V0490TokenSchema.STAKING_INFO_KEY,
+                    V0490FileSchema.UPGRADE_DATA_KEY,
+                    V0490RecordCacheSchema.TXN_RECORD_QUEUE,
+                    V0540RecordCacheSchema.TXN_RECEIPT_QUEUE,
+                    V0490ScheduleSchema.SCHEDULES_BY_EXPIRY_SEC_KEY,
+                    V0490ScheduleSchema.SCHEDULES_BY_EQUALITY_KEY,
+                    V0570ScheduleSchema.SCHEDULED_COUNTS_KEY,
+                    V0570ScheduleSchema.SCHEDULED_ORDERS_KEY,
+                    V0570ScheduleSchema.SCHEDULE_ID_BY_EQUALITY_KEY,
+                    V0570ScheduleSchema.SCHEDULED_USAGES_KEY,
+                    // Not implemented but needed
+                    V0490ScheduleSchema.SCHEDULES_BY_ID_KEY)
+            .collect(Collectors.toSet());
+
+    public static boolean contains(final String stateKey) {
+        if (stateKey != null && stateKey.startsWith("UPGRADE_DATA")) {
+            return keys.contains(V0490FileSchema.UPGRADE_DATA_KEY);
+        }
+        return keys.contains(stateKey);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/StateKeyRegistry.java
@@ -12,7 +12,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class StateKeyRegistry {
+public enum StateKeyRegistry {
+    ;
     private static final Set<String> keys = Stream.of(
                     // Implemented
                     AccountReadableKVState.KEY,

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
@@ -2,13 +2,8 @@
 
 package com.hedera.mirror.web3.state.singleton;
 
-import com.hedera.node.app.fees.schemas.V0490FeeSchema;
-import com.hedera.node.app.ids.schemas.V0490EntityIdSchema;
-import com.hedera.node.app.ids.schemas.V0590EntityIdSchema;
-import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
 import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.app.service.token.impl.schemas.V0610TokenSchema;
-import com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -19,17 +14,8 @@ import lombok.RequiredArgsConstructor;
 public class DefaultSingleton extends AtomicReference<Object> implements SingletonState<Object> {
 
     private static final Set<String> keys = Stream.of(
-                    // Implemented
-                    V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY,
-                    V0490CongestionThrottleSchema.CONGESTION_LEVEL_STARTS_STATE_KEY,
-                    V0490CongestionThrottleSchema.THROTTLE_USAGE_SNAPSHOTS_STATE_KEY,
-                    V0490EntityIdSchema.ENTITY_ID_STATE_KEY,
-                    V0590EntityIdSchema.ENTITY_COUNTS_KEY,
-                    V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY,
-                    V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY,
                     // Not implemented but not needed
-                    V0490TokenSchema.STAKING_NETWORK_REWARDS_KEY,
-                    V0610TokenSchema.NODE_REWARDS_KEY)
+                    V0490TokenSchema.STAKING_NETWORK_REWARDS_KEY, V0610TokenSchema.NODE_REWARDS_KEY)
             .collect(Collectors.toSet());
     private final String key;
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
@@ -2,13 +2,41 @@
 
 package com.hedera.mirror.web3.state.singleton;
 
+import com.hedera.node.app.fees.schemas.V0490FeeSchema;
+import com.hedera.node.app.ids.schemas.V0490EntityIdSchema;
+import com.hedera.node.app.ids.schemas.V0590EntityIdSchema;
+import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
+import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
+import com.hedera.node.app.service.token.impl.schemas.V0610TokenSchema;
+import com.hedera.node.app.throttle.schemas.V0490CongestionThrottleSchema;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.Getter;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 public class DefaultSingleton extends AtomicReference<Object> implements SingletonState<Object> {
 
+    private static final Set<String> keys = Stream.of(
+                    // Implemented
+                    V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY,
+                    V0490CongestionThrottleSchema.CONGESTION_LEVEL_STARTS_STATE_KEY,
+                    V0490CongestionThrottleSchema.THROTTLE_USAGE_SNAPSHOTS_STATE_KEY,
+                    V0490EntityIdSchema.ENTITY_ID_STATE_KEY,
+                    V0590EntityIdSchema.ENTITY_COUNTS_KEY,
+                    V0490FeeSchema.MIDNIGHT_RATES_STATE_KEY,
+                    V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY,
+                    // Not implemented but not needed
+                    V0490TokenSchema.STAKING_NETWORK_REWARDS_KEY,
+                    V0610TokenSchema.NODE_REWARDS_KEY)
+            .collect(Collectors.toSet());
     private final String key;
+
+    public String getKey() {
+        if (keys.contains(key)) {
+            return key;
+        }
+        throw new UnsupportedOperationException("Unsupported singleton key: " + key);
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -16,6 +16,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.web3.state.MirrorNodeState;
 import com.hedera.mirror.web3.state.core.MapWritableStates;
 import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
+import com.hedera.mirror.web3.state.keyvalue.StateKeyRegistry;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.app.state.merkle.SchemaApplicationType;
@@ -65,12 +66,15 @@ class SchemaRegistryImplTest {
     @Mock
     private Codec<String> mockCodec;
 
+    @Mock
+    private StateKeyRegistry stateKeyRegistry;
+
     private Configuration config;
     private SchemaRegistryImpl schemaRegistry;
 
     @BeforeEach
     void initialize() {
-        schemaRegistry = new SchemaRegistryImpl(List.of(), schemaApplications);
+        schemaRegistry = new SchemaRegistryImpl(List.of(), schemaApplications, stateKeyRegistry);
         config = new ConfigProviderImpl().getConfiguration();
     }
 
@@ -133,6 +137,8 @@ class SchemaRegistryImplTest {
 
         when(schema.statesToCreate(config))
                 .thenReturn(Set.of(stateDefinitionSingleton, stateDefinitionQueue, stateDefinition));
+        when(stateKeyRegistry.contains(V0490TokenSchema.STAKING_INFO_KEY)).thenReturn(true);
+        when(stateKeyRegistry.contains(AccountReadableKVState.KEY)).thenReturn(true);
 
         schemaRegistry.register(schema);
         schemaRegistry.migrate(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -5,6 +5,7 @@ package com.hedera.mirror.web3.state.components;
 import static java.util.Collections.EMPTY_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -14,7 +15,9 @@ import static org.mockito.Mockito.when;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.web3.state.MirrorNodeState;
 import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
 import com.hedera.node.app.config.ConfigProviderImpl;
+import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.app.state.merkle.SchemaApplicationType;
 import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.hedera.pbj.runtime.Codec;
@@ -121,9 +124,12 @@ class SchemaRegistryImplTest {
         when(schemaApplications.computeApplications(any(), any(), any(), any()))
                 .thenReturn(EnumSet.of(SchemaApplicationType.STATE_DEFINITIONS, SchemaApplicationType.MIGRATION));
 
-        var stateDefinitionSingleton = new StateDefinition<>("KEY", mockCodec, mockCodec, 123, false, true, false);
-        var stateDefinitionQueue = new StateDefinition<>("KEY_QUEUE", mockCodec, mockCodec, 123, false, false, true);
-        var stateDefinition = new StateDefinition<>("STATE", mockCodec, mockCodec, 123, true, false, false);
+        var stateDefinitionSingleton = new StateDefinition<>(
+                V0490TokenSchema.STAKING_NETWORK_REWARDS_KEY, mockCodec, mockCodec, 123, false, true, false);
+        var stateDefinitionQueue =
+                new StateDefinition<>(V0490TokenSchema.STAKING_INFO_KEY, mockCodec, mockCodec, 123, false, false, true);
+        var stateDefinition =
+                new StateDefinition<>(AccountReadableKVState.KEY, mockCodec, mockCodec, 123, true, false, false);
 
         when(schema.statesToCreate(config))
                 .thenReturn(Set.of(stateDefinitionSingleton, stateDefinitionQueue, stateDefinition));
@@ -136,6 +142,82 @@ class SchemaRegistryImplTest {
         verify(schema).migrate(any());
         verify(writableStates, times(1)).commit();
         verify(mirrorNodeState, times(1)).addService(any(), any());
+    }
+
+    @Test
+    void testMigrateWithStateDefinitionsMissingSingleton() {
+        when(mirrorNodeState.getReadableStates(serviceName)).thenReturn(readableStates);
+        when(schemaApplications.computeApplications(any(), any(), any(), any()))
+                .thenReturn(EnumSet.of(SchemaApplicationType.STATE_DEFINITIONS, SchemaApplicationType.MIGRATION));
+
+        final var singletonKey = "KEY";
+        var stateDefinitionSingleton =
+                new StateDefinition<>(singletonKey, mockCodec, mockCodec, 123, false, true, false);
+
+        when(schema.statesToCreate(config)).thenReturn(Set.of(stateDefinitionSingleton));
+
+        schemaRegistry.register(schema);
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> schemaRegistry.migrate(
+                        serviceName,
+                        mirrorNodeState,
+                        previousVersion,
+                        config,
+                        config,
+                        new HashMap<>(),
+                        startupNetworks));
+        assertThat(exception.getMessage()).isEqualTo("Unsupported singleton key: " + singletonKey);
+    }
+
+    @Test
+    void testMigrateWithStateDefinitionsMissingStateKeyQueue() {
+        when(mirrorNodeState.getReadableStates(serviceName)).thenReturn(readableStates);
+        when(schemaApplications.computeApplications(any(), any(), any(), any()))
+                .thenReturn(EnumSet.of(SchemaApplicationType.STATE_DEFINITIONS, SchemaApplicationType.MIGRATION));
+
+        final var stateKey = "KEY_QUEUE";
+        var stateDefinitionSingleton = new StateDefinition<>(stateKey, mockCodec, mockCodec, 123, false, false, true);
+
+        when(schema.statesToCreate(config)).thenReturn(Set.of(stateDefinitionSingleton));
+
+        schemaRegistry.register(schema);
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> schemaRegistry.migrate(
+                        serviceName,
+                        mirrorNodeState,
+                        previousVersion,
+                        config,
+                        config,
+                        new HashMap<>(),
+                        startupNetworks));
+        assertThat(exception.getMessage()).isEqualTo("Unsupported state key for queue: " + stateKey);
+    }
+
+    @Test
+    void testMigrateWithStateDefinitionsMissingStateKey() {
+        when(mirrorNodeState.getReadableStates(serviceName)).thenReturn(readableStates);
+        when(schemaApplications.computeApplications(any(), any(), any(), any()))
+                .thenReturn(EnumSet.of(SchemaApplicationType.STATE_DEFINITIONS, SchemaApplicationType.MIGRATION));
+
+        final var stateKey = "STATE_KEY";
+        var stateDefinitionSingleton = new StateDefinition<>(stateKey, mockCodec, mockCodec, 123, false, false, false);
+
+        when(schema.statesToCreate(config)).thenReturn(Set.of(stateDefinitionSingleton));
+
+        schemaRegistry.register(schema);
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> schemaRegistry.migrate(
+                        serviceName,
+                        mirrorNodeState,
+                        previousVersion,
+                        config,
+                        config,
+                        new HashMap<>(),
+                        startupNetworks));
+        assertThat(exception.getMessage()).isEqualTo("Unsupported state key: " + stateKey);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
@@ -4,20 +4,25 @@ package com.hedera.mirror.web3.state.components;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.mirror.web3.state.keyvalue.StateKeyRegistry;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
 import com.swirlds.state.lifecycle.Service;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
 class ServicesRegistryImplTest {
+
+    @Mock
+    private StateKeyRegistry stateKeyRegistry;
 
     private ServicesRegistryImpl servicesRegistry;
 
     @BeforeEach
     void setUp() {
-        servicesRegistry = new ServicesRegistryImpl(List.of());
+        servicesRegistry = new ServicesRegistryImpl(List.of(), stateKeyRegistry);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR introduces helper methods and a `StateKeyRegistry` class that lists all supported state and singleton keys for the current hedera-app version. During schema initialization, we now validate that all keys are known.

If hedera-app is upgraded and introduces new state keys that aren't present in `StateKeyRegistry` or missing in `DefaultSingleton` list of keys, an `UnsupportedOperationException` will be thrown. This helps catch unimplemented state logic early when bumping hedera-app versions.

Fixes #11003

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
