### PR TITLE
Modify findByIdAndTimestamp query

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
@@ -131,7 +131,7 @@ public interface TokenAccountRepository extends CrudRepository<TokenAccount, Abs
                             order by timestamp_range desc
                             limit 1
                     ) as ta
-                    left join token as t using (token_id)
+                    left join (select * from token where token_id = :tokenId) as t on true;
                     """,
             nativeQuery = true)
     Optional<TokenAccount> findByIdAndTimestamp(long accountId, long tokenId, long blockTimestamp);


### PR DESCRIPTION
**Description**:
It was observed that the findByIdAndTimestamp query tends to execute slower that expected, so this PR proposes a query optimization. In the original query the left join joins the entire token table to the subquery using the token_id.
The optimizer has to evaluate the whole table or at least use an index scan on token_id. The larger the token table, the larger in impact on the performance. In the new solution only 1 row is joined to the subquery.

**Related issue(s)**:

Fixes #10888 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
