### PR TITLE
Add acceptance test for topic update, to remove the custom fees 

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -100,7 +100,7 @@ public class TopicClient extends AbstractNetworkClient {
         return response;
     }
 
-    public NetworkTransactionResponse updateTopic(TopicId topicId, Key FeeSchedulekey) {
+    public NetworkTransactionResponse updateTopic(TopicId topicId, Key feeSchedulekey) {
         String memo = getMemo("Update Topic");
         TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
@@ -112,7 +112,7 @@ public class TopicClient extends AbstractNetworkClient {
                 .clearFeeExemptKeys()
                 .clearCustomFees();
 
-        var keyList = KeyList.of(FeeSchedulekey);
+        var keyList = KeyList.of(feeSchedulekey);
         var response = executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction, keyList);
         log.info("Updated topic {} with memo '{}' via {}", topicId, memo, response.getTransactionId());
         return response;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -100,16 +100,20 @@ public class TopicClient extends AbstractNetworkClient {
         return response;
     }
 
-    public NetworkTransactionResponse updateTopic(TopicId topicId) {
+    public NetworkTransactionResponse updateTopic(TopicId topicId, Key FeeSchedulekey) {
         String memo = getMemo("Update Topic");
         TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
                 .setTopicMemo(memo)
                 .setAutoRenewPeriod(autoRenewPeriod)
                 .clearAutoRenewAccountId()
-                .setTransactionMemo(memo);
+                .setTransactionMemo(memo)
+                .clearFeeScheduleKey()
+                .clearFeeExemptKeys()
+                .clearCustomFees();
 
-        var response = executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction);
+        var keyList = KeyList.of(FeeSchedulekey);
+        var response = executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction, keyList);
         log.info("Updated topic {} with memo '{}' via {}", topicId, memo, response.getTransactionId());
         return response;
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -183,9 +183,15 @@ public class TopicFeature extends AbstractFeature {
 
     @When("I successfully update an existing topic")
     public void updateTopic() {
-        networkTransactionResponse = topicClient.updateTopic(consensusTopicId);
+        networkTransactionResponse = topicClient.updateTopic(consensusTopicId, privateKey);
         assertNotNull(networkTransactionResponse.getReceipt());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
+        var getTopicResponse = mirrorClient.getTopic(consensusTopicId.toString());
+        assertThat(getTopicResponse).isNotNull();
+        assertThat(getTopicResponse.getFeeScheduleKey().getType()).isEqualTo(TypeEnum.PROTOBUF_ENCODED);
+        assertThat(getTopicResponse.getFeeScheduleKey().getKey()).isEqualTo("3200");
+        assertThat(getTopicResponse.getCustomFees().getFixedFees()).isEmpty();
+        assertThat(getTopicResponse.getFeeExemptKeyList()).isEmpty();
     }
 
     @When("I successfully delete the topic")


### PR DESCRIPTION
We already have acceptance tests for topic with custom fees, but die to an issue in SDK we were not able to add a tests for update of topic to remove the custom fees 
Now since the SDK team fixed the issue we have to add the update test

**Related issue(s)**:

Fixes #11010 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
