### PR TITLE
Remove redundant code in SchemaRegistryImpl

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -13,7 +13,6 @@ import com.hedera.mirror.web3.state.singleton.DefaultSingleton;
 import com.hedera.mirror.web3.state.singleton.SingletonState;
 import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.SchemaRegistry;
@@ -40,8 +39,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SchemaRegistryImpl implements SchemaRegistry {
 
-    public static final SemanticVersion CURRENT_VERSION = new SemanticVersion(0, 47, 0, "SNAPSHOT", "");
-
     private final Collection<SingletonState<?>> singletons;
     private final SchemaApplications schemaApplications;
 
@@ -56,15 +53,6 @@ public class SchemaRegistryImpl implements SchemaRegistry {
         schemas.remove(schema);
         schemas.add(schema);
         return this;
-    }
-
-    @SuppressWarnings("rawtypes")
-    public void migrate(
-            @Nonnull final String serviceName,
-            @Nonnull final MirrorNodeState state,
-            @Nonnull final StartupNetworks startupNetworks) {
-        final var config = ConfigurationBuilder.create().build();
-        migrate(serviceName, state, CURRENT_VERSION, config, config, new HashMap<>(), startupNetworks);
     }
 
     @SuppressWarnings("java:S107")

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -6,7 +6,6 @@ import static java.util.Collections.EMPTY_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,12 +75,6 @@ class SchemaRegistryImplTest {
         schemaRegistry.register(schema);
         SortedSet<Schema> schemas = schemaRegistry.getSchemas();
         assertThat(schemas).contains(schema);
-    }
-
-    @Test
-    void testMigrateWithNoSchemas() {
-        schemaRegistry.migrate(serviceName, mirrorNodeState, startupNetworks);
-        verify(mirrorNodeState, never()).getWritableStates(any());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
The PR removes hardcoded constant and unused migrate method in `SchemaRegistryImpl`

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
