### PR TITLE
Simplify treasury and autorenew accounts retrieval in token kv state

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -6,7 +6,6 @@ import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
 import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toTokenId;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Fraction;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenSupplyType;
@@ -19,7 +18,6 @@ import com.hedera.hapi.node.transaction.FractionalFee;
 import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.mirror.common.domain.SystemEntity;
 import com.hedera.mirror.common.domain.entity.Entity;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
@@ -100,7 +98,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
         return Token.newBuilder()
                 .accountsFrozenByDefault(token.getFreezeDefault())
                 .adminKey(Utils.parseKey(entity.getKey()))
-                .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId()))
+                .autoRenewAccountId(EntityIdUtils.toAccountId(entity.getAutoRenewAccountId()))
                 .autoRenewSeconds(
                         entity.getAutoRenewPeriod() != null ? entity.getAutoRenewPeriod() : DEFAULT_AUTO_RENEW_PERIOD)
                 .customFees(getCustomFees(token.getTokenId(), timestamp))
@@ -123,7 +121,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
                 .tokenId(toTokenId(entity.getId()))
                 .tokenType(TokenType.valueOf(token.getType().name()))
                 .totalSupply(getTotalSupply(token, timestamp))
-                .treasuryAccountId(getTreasury(token.getTreasuryAccountId()))
+                .treasuryAccountId(EntityIdUtils.toAccountId(token.getTreasuryAccountId()))
                 .wipeKey(Utils.parseKey(token.getWipeKey()))
                 .accountsKycGrantedByDefault(token.getKycStatus() == TokenKycStatusEnum.GRANTED)
                 .build();
@@ -145,20 +143,6 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
         } else {
             return nftRepository.findNftTotalSupplyByTokenIdAndTimestamp(tokenId, timestamp);
         }
-    }
-
-    private AccountID getAutoRenewAccount(Long autoRenewAccountId) {
-        if (autoRenewAccountId == null) {
-            return null;
-        }
-        return EntityIdUtils.toAccountId(autoRenewAccountId);
-    }
-
-    private AccountID getTreasury(EntityId treasuryId) {
-        if (treasuryId == null) {
-            return null;
-        }
-        return EntityIdUtils.toAccountId(treasuryId);
     }
 
     private Supplier<List<CustomFee>> getCustomFees(Long tokenId, final Optional<Long> timestamp) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -100,7 +100,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
         return Token.newBuilder()
                 .accountsFrozenByDefault(token.getFreezeDefault())
                 .adminKey(Utils.parseKey(entity.getKey()))
-                .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId(), timestamp))
+                .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId()))
                 .autoRenewSeconds(
                         entity.getAutoRenewPeriod() != null ? entity.getAutoRenewPeriod() : DEFAULT_AUTO_RENEW_PERIOD)
                 .customFees(getCustomFees(token.getTokenId(), timestamp))
@@ -123,7 +123,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
                 .tokenId(toTokenId(entity.getId()))
                 .tokenType(TokenType.valueOf(token.getType().name()))
                 .totalSupply(getTotalSupply(token, timestamp))
-                .treasuryAccountId(getTreasury(token.getTreasuryAccountId(), timestamp))
+                .treasuryAccountId(getTreasury(token.getTreasuryAccountId()))
                 .wipeKey(Utils.parseKey(token.getWipeKey()))
                 .accountsKycGrantedByDefault(token.getKycStatus() == TokenKycStatusEnum.GRANTED)
                 .build();
@@ -147,26 +147,18 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
         }
     }
 
-    private Supplier<AccountID> getAutoRenewAccount(Long autoRenewAccountId, final Optional<Long> timestamp) {
+    private AccountID getAutoRenewAccount(Long autoRenewAccountId) {
         if (autoRenewAccountId == null) {
             return null;
         }
-        return Suppliers.memoize(() -> timestamp
-                .map(t -> entityRepository.findActiveByIdAndTimestamp(autoRenewAccountId, t))
-                .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(autoRenewAccountId))
-                .map(entity -> EntityIdUtils.toAccountId(entity.toEntityId()))
-                .orElse(null));
+        return EntityIdUtils.toAccountId(autoRenewAccountId);
     }
 
-    private Supplier<AccountID> getTreasury(EntityId treasuryId, final Optional<Long> timestamp) {
+    private AccountID getTreasury(EntityId treasuryId) {
         if (treasuryId == null) {
             return null;
         }
-        return Suppliers.memoize(() -> timestamp
-                .map(t -> entityRepository.findActiveByIdAndTimestamp(treasuryId.getId(), t))
-                .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(treasuryId.getId()))
-                .map(entity -> EntityIdUtils.toAccountId(entity.toEntityId()))
-                .orElse(null));
+        return EntityIdUtils.toAccountId(treasuryId);
     }
 
     private Supplier<List<CustomFee>> getCustomFees(Long tokenId, final Optional<Long> timestamp) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -28,11 +28,111 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 public class TokenTest extends AbstractStateTest {
+
+    /**
+     * List of all valid arguments for testing, built as a static list, so we can reuse it.
+     */
+    public static final List<Token> ARGUMENTS;
+
+    static {
+        final var tokenIdList = TokenIDTest.ARGUMENTS;
+        final var nameList = STRING_TESTS_LIST;
+        final var symbolList = STRING_TESTS_LIST;
+        final var decimalsList = INTEGER_TESTS_LIST;
+        final var totalSupplyList = LONG_TESTS_LIST;
+        final var treasuryAccountIdList = AccountIDTest.ARGUMENTS;
+        final var adminKeyList = KeyTest.ARGUMENTS;
+        final var kycKeyList = KeyTest.ARGUMENTS;
+        final var freezeKeyList = KeyTest.ARGUMENTS;
+        final var wipeKeyList = KeyTest.ARGUMENTS;
+        final var supplyKeyList = KeyTest.ARGUMENTS;
+        final var feeScheduleKeyList = KeyTest.ARGUMENTS;
+        final var pauseKeyList = KeyTest.ARGUMENTS;
+        final var lastUsedSerialNumberList = LONG_TESTS_LIST;
+        final var deletedList = BOOLEAN_TESTS_LIST;
+        final var tokenTypeList = Arrays.asList(TokenType.values());
+        final var supplyTypeList = Arrays.asList(TokenSupplyType.values());
+        final var autoRenewAccountIdList = AccountIDTest.ARGUMENTS;
+        final var autoRenewSecondsList = LONG_TESTS_LIST;
+        final var expirationSecondList = LONG_TESTS_LIST;
+        final var memoList = STRING_TESTS_LIST;
+        final var maxSupplyList = LONG_TESTS_LIST;
+        final var pausedList = BOOLEAN_TESTS_LIST;
+        final var accountsFrozenByDefaultList = BOOLEAN_TESTS_LIST;
+        final var accountsKycGrantedByDefaultList = BOOLEAN_TESTS_LIST;
+        final var customFeesList = generateListArguments(CUSTOM_FEE_ARGUMENTS);
+        final var metadataList = BYTES_TESTS_LIST;
+        final var metadataKeyList = KeyTest.ARGUMENTS;
+
+        // work out the longest of all the lists of args as that is how many test cases we need
+        final int maxValues = IntStream.of(
+                        tokenIdList.size(),
+                        nameList.size(),
+                        symbolList.size(),
+                        decimalsList.size(),
+                        totalSupplyList.size(),
+                        treasuryAccountIdList.size(),
+                        adminKeyList.size(),
+                        kycKeyList.size(),
+                        freezeKeyList.size(),
+                        wipeKeyList.size(),
+                        supplyKeyList.size(),
+                        feeScheduleKeyList.size(),
+                        pauseKeyList.size(),
+                        lastUsedSerialNumberList.size(),
+                        deletedList.size(),
+                        tokenTypeList.size(),
+                        supplyTypeList.size(),
+                        autoRenewAccountIdList.size(),
+                        autoRenewSecondsList.size(),
+                        expirationSecondList.size(),
+                        memoList.size(),
+                        maxSupplyList.size(),
+                        pausedList.size(),
+                        accountsFrozenByDefaultList.size(),
+                        accountsKycGrantedByDefaultList.size(),
+                        customFeesList.size(),
+                        metadataList.size(),
+                        metadataKeyList.size())
+                .max()
+                .getAsInt();
+        // create new stream of model objects using lists above as constructor params
+        ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
+                .mapToObj(i -> new Token(
+                        tokenIdList.get(Math.min(i, tokenIdList.size() - 1)),
+                        nameList.get(Math.min(i, nameList.size() - 1)),
+                        symbolList.get(Math.min(i, symbolList.size() - 1)),
+                        decimalsList.get(Math.min(i, decimalsList.size() - 1)),
+                        totalSupplyList.get(Math.min(i, totalSupplyList.size() - 1)),
+                        treasuryAccountIdList.get(Math.min(i, treasuryAccountIdList.size() - 1)),
+                        adminKeyList.get(Math.min(i, adminKeyList.size() - 1)),
+                        kycKeyList.get(Math.min(i, kycKeyList.size() - 1)),
+                        freezeKeyList.get(Math.min(i, freezeKeyList.size() - 1)),
+                        wipeKeyList.get(Math.min(i, wipeKeyList.size() - 1)),
+                        supplyKeyList.get(Math.min(i, supplyKeyList.size() - 1)),
+                        feeScheduleKeyList.get(Math.min(i, feeScheduleKeyList.size() - 1)),
+                        pauseKeyList.get(Math.min(i, pauseKeyList.size() - 1)),
+                        lastUsedSerialNumberList.get(Math.min(i, lastUsedSerialNumberList.size() - 1)),
+                        deletedList.get(Math.min(i, deletedList.size() - 1)),
+                        tokenTypeList.get(Math.min(i, tokenTypeList.size() - 1)),
+                        supplyTypeList.get(Math.min(i, supplyTypeList.size() - 1)),
+                        autoRenewAccountIdList.get(Math.min(i, autoRenewAccountIdList.size() - 1)),
+                        autoRenewSecondsList.get(Math.min(i, autoRenewSecondsList.size() - 1)),
+                        expirationSecondList.get(Math.min(i, expirationSecondList.size() - 1)),
+                        memoList.get(Math.min(i, memoList.size() - 1)),
+                        maxSupplyList.get(Math.min(i, maxSupplyList.size() - 1)),
+                        pausedList.get(Math.min(i, pausedList.size() - 1)),
+                        accountsFrozenByDefaultList.get(Math.min(i, accountsFrozenByDefaultList.size() - 1)),
+                        accountsKycGrantedByDefaultList.get(Math.min(i, accountsKycGrantedByDefaultList.size() - 1)),
+                        customFeesList.get(Math.min(i, customFeesList.size() - 1)),
+                        metadataList.get(Math.min(i, metadataList.size() - 1)),
+                        metadataKeyList.get(Math.min(i, metadataKeyList.size() - 1))))
+                .toList();
+    }
 
     @SuppressWarnings("EqualsWithItself")
     @Test
@@ -63,32 +163,32 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
-    void testHashCodeWithCustomSuppliers() {
+    void testHashCodeWithCustomTreasuryAndAutoRenew() {
         final var item1 = ARGUMENTS.get(1);
-        final var itemCustomSuppliers = item1.copyBuilder()
+        final var itemCustomTreasuryAndAutoRenew = item1.copyBuilder()
                 .totalSupply(1)
-                .treasuryAccountId(() -> new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 1L)))
-                .autoRenewAccountId(() -> new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 2L)))
+                .treasuryAccountId(new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 1L)))
+                .autoRenewAccountId(new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 2L)))
                 .build();
 
-        assertThat(item1.hashCode()).isNotEqualTo(itemCustomSuppliers.hashCode());
+        assertThat(item1.hashCode()).isNotEqualTo(itemCustomTreasuryAndAutoRenew.hashCode());
     }
 
     @Test
-    void testEqualsWithNullSuppliers() {
+    void testEqualsWithNullTreasuryAndAutoRenew() {
         final var item1 = ARGUMENTS.get(1);
-        final var itemNullSuppliers1 = item1.copyBuilder()
+        final var itemNullTreasuryAndAutoRenew1 = item1.copyBuilder()
                 .totalSupply(null)
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .autoRenewAccountId((Supplier<AccountID>) null)
+                .treasuryAccountId(null)
+                .autoRenewAccountId(null)
                 .build();
-        final var itemNullSuppliers2 = item1.copyBuilder()
+        final var itemNullTreasuryAndAutoRenew2 = item1.copyBuilder()
                 .totalSupply(null)
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .autoRenewAccountId((Supplier<AccountID>) null)
+                .treasuryAccountId(null)
+                .autoRenewAccountId(null)
                 .build();
 
-        assertEquals(itemNullSuppliers1, itemNullSuppliers2);
+        assertEquals(itemNullTreasuryAndAutoRenew1, itemNullTreasuryAndAutoRenew2);
     }
 
     @Test
@@ -178,31 +278,21 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
-    void testEqualsWithNullTreasuryAccountIdSupplierValue() {
+    void testEqualsWithNullTreasuryAccountId() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryAccountIdSupplierValue =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
-        assertNotEquals(itemNullTreasuryAccountIdSupplierValue, item1);
-        assertNotEquals(item1, itemNullTreasuryAccountIdSupplierValue);
-    }
-
-    @Test
-    void testEqualsWithNullTreasuryAccountIdSupplier() {
-        final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryAccountIdSupplier = item1.copyBuilder()
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .build();
-        assertNotEquals(itemNullTreasuryAccountIdSupplier, item1);
-        assertNotEquals(item1, itemNullTreasuryAccountIdSupplier);
+        final var itemNullTreasuryAccountId =
+                item1.copyBuilder().treasuryAccountId(null).build();
+        assertNotEquals(itemNullTreasuryAccountId, item1);
+        assertNotEquals(item1, itemNullTreasuryAccountId);
     }
 
     @Test
     void testEqualsWithNullTreasuryAccountIdBoth() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullTreasuryAccountId =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+                item1.copyBuilder().treasuryAccountId(null).build();
         final var itemNullTreasuryAccountId2 =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+                item1.copyBuilder().treasuryAccountId(null).build();
         assertEquals(itemNullTreasuryAccountId, itemNullTreasuryAccountId2);
     }
 
@@ -401,20 +491,10 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
-    void testEqualsWithNullAutoRenewAccountIdSupplierValue() {
+    void testEqualsWithNullAutoRenewAccountId() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullAutoRenewAccountId =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
-        assertNotEquals(itemNullAutoRenewAccountId, item1);
-        assertNotEquals(item1, itemNullAutoRenewAccountId);
-    }
-
-    @Test
-    void testEqualsWithNullAutoRenewAccountIdSupplier() {
-        final var item1 = ARGUMENTS.get(0);
-        final var itemNullAutoRenewAccountId = item1.copyBuilder()
-                .autoRenewAccountId((Supplier<AccountID>) null)
-                .build();
+                item1.copyBuilder().autoRenewAccountId(null).build();
         assertNotEquals(itemNullAutoRenewAccountId, item1);
         assertNotEquals(item1, itemNullAutoRenewAccountId);
     }
@@ -423,9 +503,9 @@ public class TokenTest extends AbstractStateTest {
     void testEqualsWithNullAutoRenewAccountIdBoth() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullAutoRenewAccountId =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+                item1.copyBuilder().autoRenewAccountId(null).build();
         final var itemNullAutoRenewAccountId2 =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+                item1.copyBuilder().autoRenewAccountId(null).build();
         assertEquals(itemNullAutoRenewAccountId, itemNullAutoRenewAccountId2);
     }
 
@@ -578,70 +658,46 @@ public class TokenTest extends AbstractStateTest {
     @Test
     void testHasTreasuryAccountId() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullTreasuryIdSupplierValue =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        final var itemNullTreasuryId =
+                item1.copyBuilder().treasuryAccountId(null).build();
 
         assertThat(item1.hasTreasuryAccountId()).isTrue();
-        assertThat(itemNullTreasuryIdSupplier.hasTreasuryAccountId()).isFalse();
-        assertThat(itemNullTreasuryIdSupplierValue.hasTreasuryAccountId()).isFalse();
+        assertThat(itemNullTreasuryId.hasTreasuryAccountId()).isFalse();
     }
 
     @Test
     void testIfTreasuryAccountId() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullTreasuryIdSupplierValue =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        final var itemNullTreasuryId =
+                item1.copyBuilder().treasuryAccountId(null).build();
 
         List<AccountID> accountIDS = new ArrayList<>();
         Consumer<AccountID> accountIDConsumerIDConsumer = accountIDS::add;
 
         item1.ifTreasuryAccountId(accountIDConsumerIDConsumer);
-        itemNullTreasuryIdSupplier.ifTreasuryAccountId(accountIDConsumerIDConsumer);
-        itemNullTreasuryIdSupplierValue.ifTreasuryAccountId(accountIDConsumerIDConsumer);
-        assertThat(accountIDS)
-                .isNotEmpty()
-                .hasSize(1)
-                .contains(item1.treasuryAccountIdSupplier().get());
+        itemNullTreasuryId.ifTreasuryAccountId(accountIDConsumerIDConsumer);
+        assertThat(accountIDS).isNotEmpty().hasSize(1).contains(item1.treasuryAccountId());
     }
 
     @Test
     void testTreasuryAccountIdOrElse() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullTreasuryIdSupplierValue =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        final var itemNullTreasuryId =
+                item1.copyBuilder().treasuryAccountId(null).build();
 
-        assertThat(item1.treasuryAccountIdOrElse(AccountID.DEFAULT))
-                .isEqualTo(item1.treasuryAccountIdSupplier().get());
-        assertThat(itemNullTreasuryIdSupplier.treasuryAccountIdOrElse(AccountID.DEFAULT))
-                .isEqualTo(AccountID.DEFAULT);
-        assertThat(itemNullTreasuryIdSupplierValue.treasuryAccountIdOrElse(AccountID.DEFAULT))
+        assertThat(item1.treasuryAccountIdOrElse(AccountID.DEFAULT)).isEqualTo(item1.treasuryAccountId());
+        assertThat(itemNullTreasuryId.treasuryAccountIdOrElse(AccountID.DEFAULT))
                 .isEqualTo(AccountID.DEFAULT);
     }
 
     @Test
     void testTreasuryAccountIdOrThrow() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
-                .treasuryAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullTreasuryIdSupplierValue =
-                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        final var itemNullTreasuryId =
+                item1.copyBuilder().treasuryAccountId(null).build();
 
-        assertThat(item1.treasuryAccountIdOrThrow())
-                .isEqualTo(item1.treasuryAccountIdSupplier().get());
-        assertThatThrownBy(itemNullTreasuryIdSupplier::treasuryAccountIdOrThrow)
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(itemNullTreasuryIdSupplierValue::treasuryAccountIdOrThrow)
-                .isInstanceOf(NullPointerException.class);
+        assertThat(item1.treasuryAccountIdOrThrow()).isEqualTo(item1.treasuryAccountId());
+        assertThatThrownBy(itemNullTreasuryId::treasuryAccountIdOrThrow).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -903,70 +959,45 @@ public class TokenTest extends AbstractStateTest {
     @Test
     void testHasAutoRenewAccountId() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
-                .autoRenewAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullAutoRenewIdSupplierValue =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        final var itemNullAutoRenewId =
+                item1.copyBuilder().autoRenewAccountId(null).build();
 
         assertThat(item1.hasAutoRenewAccountId()).isTrue();
-        assertThat(itemNullAutoRenewIdSupplier.hasAutoRenewAccountId()).isFalse();
-        assertThat(itemNullAutoRenewIdSupplierValue.hasAutoRenewAccountId()).isFalse();
+        assertThat(itemNullAutoRenewId.hasAutoRenewAccountId()).isFalse();
     }
 
     @Test
     void testIfAutoRenewAccountId() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
-                .autoRenewAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullAutoRenewIdSupplierValue =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        final var itemNullAutoRenewId =
+                item1.copyBuilder().autoRenewAccountId(null).build();
 
         List<AccountID> accountIDS = new ArrayList<>();
         Consumer<AccountID> accountIDConsumer = accountIDS::add;
 
         item1.ifAutoRenewAccountId(accountIDConsumer);
-        itemNullAutoRenewIdSupplier.ifAutoRenewAccountId(accountIDConsumer);
-        itemNullAutoRenewIdSupplierValue.ifAutoRenewAccountId(accountIDConsumer);
-        assertThat(accountIDS)
-                .isNotEmpty()
-                .hasSize(1)
-                .contains(item1.autoRenewAccountIdSupplier().get());
+        itemNullAutoRenewId.ifAutoRenewAccountId(accountIDConsumer);
+        assertThat(accountIDS).isNotEmpty().hasSize(1).contains(item1.autoRenewAccountId());
     }
 
     @Test
     void testAutoRenewAccountIdOrElse() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
-                .autoRenewAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullAutoRenewIdSupplierValue =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        final var itemNullAutoRenewId =
+                item1.copyBuilder().autoRenewAccountId(null).build();
 
-        assertThat(item1.autoRenewAccountIdOrElse(AccountID.DEFAULT))
-                .isEqualTo(item1.autoRenewAccountIdSupplier().get());
-        assertThat(itemNullAutoRenewIdSupplier.autoRenewAccountIdOrElse(AccountID.DEFAULT))
-                .isEqualTo(AccountID.DEFAULT);
-        assertThat(itemNullAutoRenewIdSupplierValue.autoRenewAccountIdOrElse(AccountID.DEFAULT))
+        assertThat(itemNullAutoRenewId.autoRenewAccountIdOrElse(AccountID.DEFAULT))
                 .isEqualTo(AccountID.DEFAULT);
     }
 
     @Test
     void testAutoRenewAccountIdOrThrow() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
-                .autoRenewAccountId((Supplier<AccountID>) null)
-                .build();
-        final var itemNullAutoRenewIdSupplierValue =
-                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        final var itemNullAutoRenewId =
+                item1.copyBuilder().autoRenewAccountId(null).build();
 
-        assertThat(item1.autoRenewAccountIdOrThrow())
-                .isEqualTo(item1.autoRenewAccountIdSupplier().get());
-        assertThatThrownBy(itemNullAutoRenewIdSupplier::autoRenewAccountIdOrThrow)
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(itemNullAutoRenewIdSupplierValue::autoRenewAccountIdOrThrow)
-                .isInstanceOf(NullPointerException.class);
+        assertThat(item1.autoRenewAccountIdOrThrow()).isEqualTo(item1.autoRenewAccountId());
+        assertThatThrownBy(itemNullAutoRenewId::autoRenewAccountIdOrThrow).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -1079,106 +1110,5 @@ public class TokenTest extends AbstractStateTest {
         assertThat(token.feeScheduleKey()).isNotNull();
         assertThat(token.pauseKey()).isNotNull();
         assertThat(token.metadataKey()).isNotNull();
-    }
-
-    /**
-     * List of all valid arguments for testing, built as a static list, so we can reuse it.
-     */
-    public static final List<Token> ARGUMENTS;
-
-    static {
-        final var tokenIdList = TokenIDTest.ARGUMENTS;
-        final var nameList = STRING_TESTS_LIST;
-        final var symbolList = STRING_TESTS_LIST;
-        final var decimalsList = INTEGER_TESTS_LIST;
-        final var totalSupplyList = LONG_TESTS_LIST;
-        final var treasuryAccountIdList = AccountIDTest.ARGUMENTS;
-        final var adminKeyList = KeyTest.ARGUMENTS;
-        final var kycKeyList = KeyTest.ARGUMENTS;
-        final var freezeKeyList = KeyTest.ARGUMENTS;
-        final var wipeKeyList = KeyTest.ARGUMENTS;
-        final var supplyKeyList = KeyTest.ARGUMENTS;
-        final var feeScheduleKeyList = KeyTest.ARGUMENTS;
-        final var pauseKeyList = KeyTest.ARGUMENTS;
-        final var lastUsedSerialNumberList = LONG_TESTS_LIST;
-        final var deletedList = BOOLEAN_TESTS_LIST;
-        final var tokenTypeList = Arrays.asList(TokenType.values());
-        final var supplyTypeList = Arrays.asList(TokenSupplyType.values());
-        final var autoRenewAccountIdList = AccountIDTest.ARGUMENTS;
-        final var autoRenewSecondsList = LONG_TESTS_LIST;
-        final var expirationSecondList = LONG_TESTS_LIST;
-        final var memoList = STRING_TESTS_LIST;
-        final var maxSupplyList = LONG_TESTS_LIST;
-        final var pausedList = BOOLEAN_TESTS_LIST;
-        final var accountsFrozenByDefaultList = BOOLEAN_TESTS_LIST;
-        final var accountsKycGrantedByDefaultList = BOOLEAN_TESTS_LIST;
-        final var customFeesList = generateListArguments(CUSTOM_FEE_ARGUMENTS);
-        final var metadataList = BYTES_TESTS_LIST;
-        final var metadataKeyList = KeyTest.ARGUMENTS;
-
-        // work out the longest of all the lists of args as that is how many test cases we need
-        final int maxValues = IntStream.of(
-                        tokenIdList.size(),
-                        nameList.size(),
-                        symbolList.size(),
-                        decimalsList.size(),
-                        totalSupplyList.size(),
-                        treasuryAccountIdList.size(),
-                        adminKeyList.size(),
-                        kycKeyList.size(),
-                        freezeKeyList.size(),
-                        wipeKeyList.size(),
-                        supplyKeyList.size(),
-                        feeScheduleKeyList.size(),
-                        pauseKeyList.size(),
-                        lastUsedSerialNumberList.size(),
-                        deletedList.size(),
-                        tokenTypeList.size(),
-                        supplyTypeList.size(),
-                        autoRenewAccountIdList.size(),
-                        autoRenewSecondsList.size(),
-                        expirationSecondList.size(),
-                        memoList.size(),
-                        maxSupplyList.size(),
-                        pausedList.size(),
-                        accountsFrozenByDefaultList.size(),
-                        accountsKycGrantedByDefaultList.size(),
-                        customFeesList.size(),
-                        metadataList.size(),
-                        metadataKeyList.size())
-                .max()
-                .getAsInt();
-        // create new stream of model objects using lists above as constructor params
-        ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
-                .mapToObj(i -> new Token(
-                        tokenIdList.get(Math.min(i, tokenIdList.size() - 1)),
-                        nameList.get(Math.min(i, nameList.size() - 1)),
-                        symbolList.get(Math.min(i, symbolList.size() - 1)),
-                        decimalsList.get(Math.min(i, decimalsList.size() - 1)),
-                        totalSupplyList.get(Math.min(i, totalSupplyList.size() - 1)),
-                        treasuryAccountIdList.get(Math.min(i, treasuryAccountIdList.size() - 1)),
-                        adminKeyList.get(Math.min(i, adminKeyList.size() - 1)),
-                        kycKeyList.get(Math.min(i, kycKeyList.size() - 1)),
-                        freezeKeyList.get(Math.min(i, freezeKeyList.size() - 1)),
-                        wipeKeyList.get(Math.min(i, wipeKeyList.size() - 1)),
-                        supplyKeyList.get(Math.min(i, supplyKeyList.size() - 1)),
-                        feeScheduleKeyList.get(Math.min(i, feeScheduleKeyList.size() - 1)),
-                        pauseKeyList.get(Math.min(i, pauseKeyList.size() - 1)),
-                        lastUsedSerialNumberList.get(Math.min(i, lastUsedSerialNumberList.size() - 1)),
-                        deletedList.get(Math.min(i, deletedList.size() - 1)),
-                        tokenTypeList.get(Math.min(i, tokenTypeList.size() - 1)),
-                        supplyTypeList.get(Math.min(i, supplyTypeList.size() - 1)),
-                        autoRenewAccountIdList.get(Math.min(i, autoRenewAccountIdList.size() - 1)),
-                        autoRenewSecondsList.get(Math.min(i, autoRenewSecondsList.size() - 1)),
-                        expirationSecondList.get(Math.min(i, expirationSecondList.size() - 1)),
-                        memoList.get(Math.min(i, memoList.size() - 1)),
-                        maxSupplyList.get(Math.min(i, maxSupplyList.size() - 1)),
-                        pausedList.get(Math.min(i, pausedList.size() - 1)),
-                        accountsFrozenByDefaultList.get(Math.min(i, accountsFrozenByDefaultList.size() - 1)),
-                        accountsKycGrantedByDefaultList.get(Math.min(i, accountsKycGrantedByDefaultList.size() - 1)),
-                        customFeesList.get(Math.min(i, customFeesList.size() - 1)),
-                        metadataList.get(Math.min(i, metadataList.size() - 1)),
-                        metadataKeyList.get(Math.min(i, metadataKeyList.size() - 1))))
-                .toList();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
@@ -163,6 +163,16 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
                 .persist();
     }
 
+    protected Entity tokenEntityPersistHistoricalCustomizable(
+            final Range<Long> timestampRange, final Consumer<Entity.EntityBuilder<?, ?>> customizer) {
+        return domainBuilder
+                .entity()
+                .customize(e -> {
+                    e.type(EntityType.TOKEN).timestampRange(timestampRange);
+                    customizer.accept(e);
+                })
+                .persist();
+    }
     /**
      * Method used to persist fungible TokenHistory object with no customization
      *

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -566,7 +566,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
 
-        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        final var autoRenewAccount = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistoricalCustomizable(
+                historicalRange, e -> e.autoRenewAccountId(autoRenewAccount.getId()));
         final var treasury =
                 accountPersistWithBalanceHistorical(DEFAULT_TOKEN_SUPPLY, tokenEntity.toEntityId(), historicalRange);
         final var feeCollector = accountEntityPersistWithEvmAddressHistorical(historicalRange);
@@ -585,7 +587,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var result = contract.call_getInformationForFungibleToken(getAddressFromEntity(tokenEntity))
                 .send();
 
-        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury, autoRenewAccount);
 
         final var fixedFees = new ArrayList<FixedFee>();
         fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
@@ -614,7 +616,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var owner = accountEntityPersistHistorical(historicalRange);
         final var treasury = accountEntityPersistWithEvmAddressHistorical(historicalRange);
         final var feeCollector = accountEntityPersistWithEvmAddressHistorical(historicalRange);
-        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        final var autoRenewAccount = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistoricalCustomizable(
+                historicalRange, e -> e.autoRenewAccountId(autoRenewAccount.getId()));
         final var token = nonFungibleTokenCustomizable(t -> t.tokenId(tokenEntity.getId())
                 .treasuryAccountId(treasury.toEntityId())
                 .timestampRange(historicalRange)
@@ -639,7 +643,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         getAddressFromEntity(tokenEntity), DEFAULT_SERIAL_NUMBER)
                 .send();
 
-        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury, autoRenewAccount);
 
         final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
         fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
@@ -670,7 +674,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
 
-        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        final var autoRenewAccount = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistoricalCustomizable(
+                historicalRange, e -> e.autoRenewAccountId(autoRenewAccount.getId()));
         final var treasury =
                 accountPersistWithBalanceHistorical(DEFAULT_TOKEN_SUPPLY, tokenEntity.toEntityId(), historicalRange);
         final var feeCollector = accountEntityPersistWithEvmAddressHistorical(historicalRange);
@@ -689,7 +695,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var result = contract.call_getInformationForToken(getAddressFromEntity(tokenEntity))
                 .send();
 
-        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury, autoRenewAccount);
 
         final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
         fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
@@ -711,7 +717,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var historicalRange = setUpHistoricalContext(blockNumber);
         final var treasury = accountEntityPersistWithEvmAddressHistorical(historicalRange);
         final var feeCollector = accountEntityPersistWithEvmAddressHistorical(historicalRange);
-        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        final var autoRenewAccount = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistoricalCustomizable(
+                historicalRange, e -> e.autoRenewAccountId(autoRenewAccount.getId()));
         final var token = nonFungibleTokenCustomizable(t -> t.tokenId(tokenEntity.getId())
                 .treasuryAccountId(treasury.toEntityId())
                 .timestampRange(historicalRange)
@@ -734,7 +742,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var result = contract.call_getInformationForToken(getAddressFromEntity(tokenEntity))
                 .send();
 
-        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury, autoRenewAccount);
 
         final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
         fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
@@ -1065,12 +1073,12 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     private PrecompileTestContractHistorical.HederaToken createExpectedHederaToken(
-            final Entity tokenEntity, final Token token, final Entity treasury) {
+            final Entity tokenEntity, final Token token, final Entity treasury, final Entity autoRenewAccount) {
         final var expectedTokenKeys = getExpectedTokenKeys(tokenEntity, token);
 
         final var expectedExpiry = new PrecompileTestContractHistorical.Expiry(
                 BigInteger.valueOf(tokenEntity.getExpirationTimestamp()).divide(BigInteger.valueOf(1_000_000_000L)),
-                Address.ZERO.toHexString(),
+                getAddressFromEntity(autoRenewAccount),
                 BigInteger.valueOf(tokenEntity.getAutoRenewPeriod()));
         return new PrecompileTestContractHistorical.HederaToken(
                 token.getName(),

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVStateTest.java
@@ -253,7 +253,7 @@ class TokenReadableKVStateTest {
 
         Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
 
-        assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId);
+        assertThat(token.treasuryAccountId()).isEqualTo(expectedTreasuryAccountId);
     }
 
     @Test
@@ -264,9 +264,8 @@ class TokenReadableKVStateTest {
         when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
         final var expectedTreasuryAccountId = toAccountId(entityId);
 
-        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
-                .satisfies(token ->
-                        assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId));
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        assertThat(token.treasuryAccountId()).isEqualTo(expectedTreasuryAccountId);
     }
 
     @Test
@@ -278,9 +277,8 @@ class TokenReadableKVStateTest {
         when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
 
         final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
-        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
-                .satisfies(token ->
-                        assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        assertThat(token.autoRenewAccountId()).isEqualTo(autoRenewAccountId);
     }
 
     @Test
@@ -293,9 +291,8 @@ class TokenReadableKVStateTest {
         when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
 
         final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
-        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
-                .satisfies(token ->
-                        assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        assertThat(token.autoRenewAccountId()).isEqualTo(autoRenewAccountId);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVStateTest.java
@@ -6,10 +6,8 @@ import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -248,51 +246,27 @@ class TokenReadableKVStateTest {
     @Test
     void getPartialTreasuryAccount() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        setupToken(Optional.empty());
-
-        Entity treasuryEntity = mock(Entity.class);
-        EntityId treasuryEntityId = mock(EntityId.class);
-        when(treasuryEntityId.getShard()).thenReturn(11L);
-        when(treasuryEntityId.getRealm()).thenReturn(12L);
-        when(treasuryEntityId.getNum()).thenReturn(13L);
-
-        when(treasuryEntity.toEntityId()).thenReturn(treasuryEntityId);
+        final var entityId = EntityId.of(11L, 12L, 13L);
+        setupToken(Optional.empty(), entityId);
         when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
-        when(entityRepository.findByIdAndDeletedIsFalse(
-                        databaseToken.getTreasuryAccountId().getId()))
-                .thenReturn(Optional.of(treasuryEntity));
-
-        final var expectedTreasuryAccountId = toAccountId(11L, 12L, 13L);
+        final var expectedTreasuryAccountId = toAccountId(entityId);
 
         Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
 
         assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId);
-        verify(entityRepository)
-                .findByIdAndDeletedIsFalse(databaseToken.getTreasuryAccountId().getId());
     }
 
     @Test
     void getPartialTreasuryAccountHistorical() {
         when(contractCallContext.getTimestamp()).thenReturn(timestamp);
-        setupToken(timestamp);
-
-        Entity treasuryEntity = mock(Entity.class);
-        EntityId treasuryEntityId = mock(EntityId.class);
-        when(treasuryEntityId.getShard()).thenReturn(0L);
-        when(treasuryEntityId.getRealm()).thenReturn(0L);
-        when(treasuryEntityId.getNum()).thenReturn(10L);
-        when(treasuryEntity.toEntityId()).thenReturn(treasuryEntityId);
-
+        final var entityId = EntityId.of(11L, 12L, 13L);
+        setupToken(timestamp, entityId);
         when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
-        when(entityRepository.findActiveByIdAndTimestamp(treasuryEntity.getId(), timestamp.get()))
-                .thenReturn(Optional.of(treasuryEntity));
+        final var expectedTreasuryAccountId = toAccountId(entityId);
 
-        final var expectedTreasuryAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId));
-
-        verify(entityRepository).findActiveByIdAndTimestamp(treasuryEntity.getId(), timestamp.get());
     }
 
     @Test
@@ -300,26 +274,13 @@ class TokenReadableKVStateTest {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
         setupToken(Optional.empty());
         databaseToken.setTreasuryAccountId(null);
-
-        Entity autorenewEntity = mock(Entity.class);
         entity.setAutoRenewAccountId(10L);
-        EntityId autorenewEntityId = mock(EntityId.class);
-        when(autorenewEntityId.getShard()).thenReturn(0L);
-        when(autorenewEntityId.getRealm()).thenReturn(0L);
-        when(autorenewEntityId.getNum()).thenReturn(10L);
-        when(autorenewEntity.toEntityId()).thenReturn(autorenewEntityId);
         when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
-        when(entityRepository.findByIdAndDeletedIsFalse(entity.getAutoRenewAccountId()))
-                .thenReturn(Optional.of(autorenewEntity));
-
-        verify(entityRepository, never()).findByIdAndDeletedIsFalse(anyLong());
 
         final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
-
-        verify(entityRepository).findByIdAndDeletedIsFalse(entity.getAutoRenewAccountId());
     }
 
     @Test
@@ -328,26 +289,13 @@ class TokenReadableKVStateTest {
         setupToken(timestamp);
         databaseToken.setTreasuryAccountId(null);
 
-        Entity autorenewEntity = mock(Entity.class);
-        EntityId autorenewEntityId = mock(EntityId.class);
-        when(autorenewEntityId.getShard()).thenReturn(0L);
-        when(autorenewEntityId.getRealm()).thenReturn(0L);
-        when(autorenewEntityId.getNum()).thenReturn(10L);
-        when(autorenewEntity.toEntityId()).thenReturn(autorenewEntityId);
-
         entity.setAutoRenewAccountId(10L);
         when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
-        when(entityRepository.findActiveByIdAndTimestamp(entity.getAutoRenewAccountId(), timestamp.get()))
-                .thenReturn(Optional.of(autorenewEntity));
-
-        verify(entityRepository, never()).findActiveByIdAndTimestamp(anyLong(), anyLong());
 
         final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
-
-        verify(entityRepository).findActiveByIdAndTimestamp(entity.getAutoRenewAccountId(), timestamp.get());
     }
 
     @Test
@@ -841,10 +789,15 @@ class TokenReadableKVStateTest {
     }
 
     private void setupToken(Optional<Long> timestamp) {
+        setupToken(timestamp, mock(EntityId.class));
+    }
+
+    private void setupToken(Optional<Long> timestamp, EntityId treasuryAccountId) {
         databaseToken =
                 domainBuilder.token().customize(t -> t.tokenId(entity.getId())).get();
-        final var treasuryId = mock(EntityId.class);
-        databaseToken.setTreasuryAccountId(treasuryId);
+
+        databaseToken.setTreasuryAccountId(treasuryAccountId);
+
         if (timestamp.isPresent()) {
             when(tokenRepository.findByTokenIdAndTimestamp(entity.getId(), timestamp.get()))
                     .thenReturn(Optional.ofNullable(databaseToken));


### PR DESCRIPTION
**Description**:

This PR removes db queries to retrieve treasury and autoRenew info and just encodes long ID to AccountID and returns it.

Changes:
`TokenReadableKVState` - remove db queries and just encode with `EntityIdUtils.toAccountId()`
Test adaptions to the change

**Related issue(s)**:

Fixes #10807

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
