### PR TITLE
Upgrade mainnet-na to v0.128.2

### DIFF
--- a/clusters/mainnet-eu/common/helmrelease.yaml
+++ b/clusters/mainnet-eu/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.128.0'
+      version: '0.128.2'
   driftDetection:
     mode: enabled
     ignore:

--- a/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.128.0'
+      version: '0.128.2'
   dependsOn:
     - name: mirror
       namespace: common
@@ -67,7 +67,6 @@ spec:
       ingress:
         enabled: true
       env:
-        HEDERA_MIRROR_REST_CACHE_RESPONSE_ENABLED: "false"
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
       monitor:
@@ -123,5 +122,5 @@ spec:
         enabled: true
       env:
         HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
-        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "0"
+        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "1"
         HEDERA_MIRROR_WEB3_EVM_NETWORK: MAINNET


### PR DESCRIPTION
**Description**:

* Upgrade mainnet-na to v0.128.2
* Remove rest cache workaround
* Increase modularized web3 traffic to 1%

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
