### PR TITLE
Upgrade mainnet-na to v0.128.2

### DIFF
--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.128.0'
+      version: '0.128.2'
   driftDetection:
     mode: enabled
     ignore:

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.128.0'
+      version: '0.128.2'
   dependsOn:
     - name: mirror
       namespace: common
@@ -61,7 +61,6 @@ spec:
           enabled: false
     rest:
       env:
-        HEDERA_MIRROR_REST_CACHE_RESPONSE_ENABLED: "false"
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
       monitor:
@@ -110,5 +109,5 @@ spec:
     web3:
       env:
         HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
-        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "0"
+        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "0.01"
         HEDERA_MIRROR_WEB3_EVM_NETWORK: MAINNET


### PR DESCRIPTION
**Description**:

* Upgrade mainnet-na to v0.128.2
* Remove rest cache workaround
* Increase modularized web3 traffic to 1%

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
