### PR TITLE
Fix protobuf package and release notes generation

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -3,11 +3,12 @@
 changelog:
   contributors:
     exclude:
-      names: ["dependabot[bot]", "hedera-github-bot"]
+      names: ["hedera-github-bot"]
     title: "Contributors"
   issues:
     exclude:
       labels: ["wontfix", "question", "duplicate", "invalid"]
+  milestoneReference: title
   repository: hiero-ledger/hiero-mirror-node
   sections:
     - title: "Enhancements"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -24,8 +24,6 @@ jobs:
   release:
     name: Release
     runs-on: hiero-mirror-node-linux-medium
-    env:
-      RELEASE_NOTES_FILENAME: release_notes
     outputs:
       create_pr: ${{ env.CREATE_PR }}
       next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
@@ -114,12 +112,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release Notes
-        if: ${{ steps.milestone.outputs.milestone_id != '' }}
-        uses: step-security/release-notes-generator-action@d7cdbb310d4aab8d98f273f4ae20fdd7cb055799 # v3.1.6
-        env:
-          FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MILESTONE_NUMBER: ${{ steps.milestone.outputs.milestone_id }}
+        if: ${{ steps.version_parser.outputs.prerelease == '' }}
+        uses: spring-io/github-changelog-generator@86958813a62af8fb223b3fd3b5152035504bcb83 # v0.0.12
+        with:
+          config-file: .github/release-notes.yml
+          milestone: ${{ steps.version_parser.outputs.release }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and Tag
         uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
@@ -134,7 +132,7 @@ jobs:
       - name: Create Github Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
-          bodyFile: ${{ env.RELEASE_NOTES_FILENAME }}.md
+          bodyFile: changelog.md
           commit: ${{ env.RELEASE_BRANCH }}
           draft: ${{ steps.version_parser.outputs.prerelease == '' }}
           name: ${{ env.RELEASE_TAG }}

--- a/protobuf/src/main/proto/com/hedera/mirror/api/proto/consensus_service.proto
+++ b/protobuf/src/main/proto/com/hedera/mirror/api/proto/consensus_service.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package org.hiero.mirror.api.proto;
+package com.hedera.mirror.api.proto;
 
 option java_multiple_files = true; // Required for the reactor-grpc generator to work correctly
 option java_package = "com.hedera.mirror.api.proto";

--- a/protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
+++ b/protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package org.hiero.mirror.api.proto;
+package com.hedera.mirror.api.proto;
 
 option java_multiple_files = true; // Required for the reactor-grpc generator to work correctly
 option java_package = "com.hedera.mirror.api.proto";


### PR DESCRIPTION
**Description**:

* Change milestone lookup from by number to title. This helps idempotency as it works regardless of closing milestone or not.
* Remove `dependabot[bot]` release notes exclusion since `[bot]` is excluded by default now
* Revert protobuf package move since generator doesn't respect `option java_package`
* Switch to Spring maintained `github-changelog-generator`

**Related issue(s)**:

Fixes #11069

**Notes for reviewer**:

Successful changelog run: https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/14736661403/job/41364365121

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
