### PR TITLE
Upgrade mainnet-staging and performance to v0.129.0-rc1

### DIFF
--- a/clusters/mainnet-staging-na/common/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.128.0-rc1'
+      version: '0.129.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube
@@ -29,7 +29,6 @@ spec:
   timeout: 10m
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
   valuesFrom:
     - kind: Secret
       name: mirror

--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -59,6 +59,7 @@ spec:
       env:
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
+        HEDERA_MIRROR_REST_CACHE_RESPONSE_ENABLED: "false"
       hpa:
         metrics:
           - type: Resource

--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.128.0-rc1'
+      version: '0.129.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
@@ -59,7 +59,6 @@ spec:
       env:
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
-        HEDERA_MIRROR_REST_CACHE_RESPONSE_ENABLED: "false"
       hpa:
         metrics:
           - type: Resource

--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.128.0'
+      version: '0.129.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube
@@ -29,7 +29,6 @@ spec:
   timeout: 10m
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
   valuesFrom:
     - kind: Secret
       name: mirror

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.128.0-rc1'
+      version: '0.129.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common


### PR DESCRIPTION
**Description**:

* Disable CRD replacement on upgrade to hopefully fix `trackTimestampsStaleness` reconciliation issue
* Upgrade mainnet-staging to v0.129.0-rc1
* Upgrade performance to v0.129.0-rc1

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
