### PR TITLE
Fix acceptance tests that were failing with INSUFFICIENT_GAS

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(75); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(70); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(100); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(75); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(70); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(100); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -18,8 +18,8 @@ import org.springframework.validation.annotation.Validated;
 public class FeatureProperties {
 
     @Min(1)
-    @Max(5_000_000)
-    private long maxContractFunctionGas = 3_000_000;
+    @Max(10_000_000)
+    private long maxContractFunctionGas = 6_000_000;
 
     private boolean sidecars = false;
 }

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -19,7 +19,7 @@ public class FeatureProperties {
 
     @Min(1)
     @Max(10_000_000)
-    private long maxContractFunctionGas = 6_000_000;
+    private long maxContractFunctionGas = 5_250_000;
 
     private boolean sidecars = false;
 }

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -59,7 +59,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
                 .getPublicKey()
                 .toAccountId(commonProperties.getShard(), commonProperties.getRealm());
 
-        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(30L), null);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(8L), null);
 
         assertThat(networkTransactionResponse.getTransactionId()).isNotNull();
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
@@ -78,7 +78,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(30L).toTinybars());
+                .isEqualTo(Hbar.from(8L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.test.e2e.acceptance.steps;
 
-import static com.hedera.mirror.rest.model.TransactionTypes.CRYPTOCREATEACCOUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PARENT_CONTRACT;
 import static org.hiero.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CREATE_CHILD;
@@ -22,7 +21,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Comparator;
 import java.util.Objects;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -63,36 +61,6 @@ public class EthereumFeature extends AbstractEstimateFeature {
         account = accountInfo.getAccount();
         assertThat(accountInfo.getBalance().getBalance())
                 .isEqualTo(Hbar.fromTinybars(HBAR_AMOUNT_IN_TINYBARS).toTinybars());
-    }
-
-    @Then("validate the signer account and its balance")
-    public void verifyAccountCreated() {
-        var accountInfo = mirrorClient.getAccountDetailsUsingAlias(ethereumSignerAccount);
-        account = accountInfo.getAccount();
-        var transactions = mirrorClient
-                .getTransactions(networkTransactionResponse.getTransactionIdStringNoCheckSum())
-                .getTransactions()
-                .stream()
-                .sorted(Comparator.comparing(TransactionDetail::getConsensusTimestamp))
-                .toList();
-
-        assertThat(accountInfo.getAccount()).isNotNull();
-        assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(5L).toTinybars());
-
-        assertThat(accountInfo.getTransactions()).hasSize(1);
-        assertThat(transactions).hasSize(2);
-
-        var createAccountTransaction = transactions.get(0);
-        var transferTransaction = transactions.get(1);
-
-        assertThat(transferTransaction)
-                .usingRecursiveComparison()
-                .ignoringFields("assessedCustomFees")
-                .isEqualTo(accountInfo.getTransactions().get(0));
-
-        assertThat(createAccountTransaction.getName()).isEqualTo(CRYPTOCREATEACCOUNT);
-        assertThat(createAccountTransaction.getConsensusTimestamp()).isEqualTo(accountInfo.getCreatedTimestamp());
     }
 
     @Given("I successfully create contract by Legacy ethereum transaction")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -59,7 +59,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
                 .getPublicKey()
                 .toAccountId(commonProperties.getShard(), commonProperties.getRealm());
 
-        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(5L), null);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(30L), null);
 
         assertThat(networkTransactionResponse.getTransactionId()).isNotNull();
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
@@ -78,7 +78,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(5L).toTinybars());
+                .isEqualTo(Hbar.from(30L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -78,7 +78,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(8L).toTinybars());
+                .isEqualTo(Hbar.from(5L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/resources/features/contract/ethereum.feature
+++ b/test/src/test/resources/features/contract/ethereum.feature
@@ -3,9 +3,7 @@ Feature: Ethereum transactions Coverage Feature
 
   Scenario Outline: Validate Ethereum Contract create and call
 
-
   Given I successfully created a signer account with an EVM address alias
-  Then validate the signer account and its balance
 
   Given I successfully create contract by Legacy ethereum transaction
   Then the mirror node REST API should return status <httpStatusCode> for the eth contract creation transaction


### PR DESCRIPTION
With the latest version of services 0.62 and above, there were some changes in gas prices for contract deploy and contract create and those changes were causing some failures in our acceptance tests. 
- Update the gas that is passed for contract create from 3_000_000 to 5_250_000
- update the operator USD balance from 70 to 75
- update the transferred amount of hbars from operator to ethereum signer account from 5 to 30

**Related issue(s)**:

Fixes #11121

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
