### PR TITLE
Add schedule KV state and tests

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ScheduleRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ScheduleRepository.java
@@ -1,7 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package com.hedera.mirror.web3.repository;
 
 import com.hedera.mirror.common.domain.schedule.Schedule;
 import org.springframework.data.repository.CrudRepository;
 
-public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
-}
+public interface ScheduleRepository extends CrudRepository<Schedule, Long> {}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ScheduleRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.hedera.mirror.web3.repository;
+
+import com.hedera.mirror.common.domain.schedule.Schedule;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TransactionSignatureRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TransactionSignatureRepository.java
@@ -1,0 +1,12 @@
+package com.hedera.mirror.web3.repository;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.transaction.TransactionSignature;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionSignatureRepository extends CrudRepository<TransactionSignature, TransactionSignature.Id> {
+    List<TransactionSignature> findByEntityId(EntityId entityId);
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TransactionSignatureRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TransactionSignatureRepository.java
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package com.hedera.mirror.web3.repository;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -9,4 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TransactionSignatureRepository extends CrudRepository<TransactionSignature, TransactionSignature.Id> {
     List<TransactionSignature> findByEntityId(EntityId entityId);
+
+    List<TransactionSignature> findByEntityIdAndConsensusTimestampLessThanEqual(
+            EntityId entityId, long consensusTimestamp);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ScheduleReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ScheduleReadableKVState.java
@@ -1,14 +1,17 @@
 package com.hedera.mirror.web3.state.keyvalue;
 
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.repository.ScheduleRepository;
+import com.hedera.mirror.web3.repository.TransactionSignatureRepository;
 import com.hedera.mirror.web3.state.CommonEntityAccessor;
 import com.hedera.node.app.service.schedule.impl.schemas.V0490ScheduleSchema;
 import com.hedera.pbj.runtime.ParseException;
@@ -16,6 +19,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.utils.EntityIdUtils;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Named;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Named
 public class ScheduleReadableKVState extends AbstractReadableKVState<ScheduleID, Schedule> {
@@ -24,10 +29,14 @@ public class ScheduleReadableKVState extends AbstractReadableKVState<ScheduleID,
 
     private final CommonEntityAccessor commonEntityAccessor;
 
-    protected ScheduleReadableKVState(ScheduleRepository scheduleRepository, CommonEntityAccessor commonEntityAccessor) {
+    private final TransactionSignatureRepository transactionSignatureRepository;
+
+    protected ScheduleReadableKVState(ScheduleRepository scheduleRepository, CommonEntityAccessor commonEntityAccessor,
+            TransactionSignatureRepository transactionSignatureRepository) {
         super(V0490ScheduleSchema.SCHEDULES_BY_ID_KEY);
         this.scheduleRepository = scheduleRepository;
         this.commonEntityAccessor = commonEntityAccessor;
+        this.transactionSignatureRepository = transactionSignatureRepository;
     }
 
     @Override
@@ -58,16 +67,53 @@ public class ScheduleReadableKVState extends AbstractReadableKVState<ScheduleID,
                 .scheduleId(scheduleID)
                 .payerAccountId(EntityIdUtils.toAccountId(schedule.getPayerAccountId()))
                 .schedulerAccountId(EntityIdUtils.toAccountId(schedule.getCreatorAccountId()))
-                // up to this point it should be correct
                 .deleted(entity.getDeleted())
                 .memo(entity.getMemo())
-               // .adminKey(entity.getKey())
-
                 .scheduledTransaction(SchedulableTransactionBody.PROTOBUF.parse(Bytes.wrap(schedule.getTransactionBody())))
                 .originalCreateTransaction(TransactionBody.newBuilder().transactionID(TransactionID.newBuilder()
                                 .accountID(EntityIdUtils.toAccountId(schedule.getCreatorAccountId()))))
-                //.signatories(entity.getKey())
-                .signatories()
+                .signatories(getSignatories(schedule.getScheduleId()))
                 .build();
     }
+
+    private List<Key> getSignatories(final Long scheduleId) {
+        // Here we should also start taking into a account the timestamp and make historical query
+        final var signatures = transactionSignatureRepository.findByEntityId(EntityId.of(scheduleId));
+
+        return signatures.stream()
+                .map(signature -> {
+                    Key.KeyOneOfType keyType = fromProtoOrdinal(signature.getType());
+
+                    return switch (keyType) {
+                        // Might need to add logic for KEY_LIST and THRESHOLD_KEY check
+                        // private static void accumulateNewSignatories( in AbstractScheduleHandler
+                        case ED25519 -> Key.newBuilder()
+                                .ed25519(Bytes.wrap(signature.getPublicKeyPrefix()))
+                                .build();
+
+                        case ECDSA_SECP256K1 -> Key.newBuilder()
+                                .ecdsaSecp256k1(Bytes.wrap(signature.getPublicKeyPrefix()))
+                                .build();
+                        default -> throw new IllegalArgumentException("Unsupported key type in getSignatories: " + keyType);
+                    };
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Converts a proto ordinal to the corresponding Key.KeyOneOfType enum value.
+     *
+     * @param protoOrdinal the proto ordinal to convert
+     * @return the corresponding Key.KeyOneOfType enum value
+     * @throws IllegalArgumentException if the proto ordinal does not correspond to any Key.KeyOneOfType
+     */
+    private Key.KeyOneOfType fromProtoOrdinal(int protoOrdinal) {
+        for (Key.KeyOneOfType kind : Key.KeyOneOfType.values()) {
+            if (kind.protoOrdinal() == protoOrdinal) {
+                return kind;
+            }
+        }
+        throw new IllegalArgumentException("Unknown protoOrdinal: " + protoOrdinal);
+    }
+
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ScheduleReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/ScheduleReadableKVState.java
@@ -1,0 +1,73 @@
+package com.hedera.mirror.web3.state.keyvalue;
+
+import com.hedera.hapi.node.base.ScheduleID;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
+import com.hedera.hapi.node.state.schedule.Schedule;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.ScheduleRepository;
+import com.hedera.mirror.web3.state.CommonEntityAccessor;
+import com.hedera.node.app.service.schedule.impl.schemas.V0490ScheduleSchema;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.utils.EntityIdUtils;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
+
+@Named
+public class ScheduleReadableKVState extends AbstractReadableKVState<ScheduleID, Schedule> {
+
+    private final ScheduleRepository scheduleRepository;
+
+    private final CommonEntityAccessor commonEntityAccessor;
+
+    protected ScheduleReadableKVState(ScheduleRepository scheduleRepository, CommonEntityAccessor commonEntityAccessor) {
+        super(V0490ScheduleSchema.SCHEDULES_BY_ID_KEY);
+        this.scheduleRepository = scheduleRepository;
+        this.commonEntityAccessor = commonEntityAccessor;
+    }
+
+    @Override
+    protected Schedule readFromDataSource(@Nonnull ScheduleID key) {
+        final var scheduleId = EntityIdUtils.toEntityId(key);
+
+        final var timestamp = ContractCallContext.get().getTimestamp();
+        final var entity = commonEntityAccessor.get(scheduleId, timestamp).orElse(null);
+
+        if (entity == null || entity.getType() != EntityType.SCHEDULE) {
+            return null;
+        }
+
+        return scheduleRepository.findById(scheduleId.getId())
+                .map(schedule -> {
+                    try {
+                        return mapToSchedule(schedule, key, entity);
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElse(null);
+    }
+
+    private Schedule mapToSchedule(final com.hedera.mirror.common.domain.schedule.Schedule schedule, final ScheduleID scheduleID,
+            final Entity entity) throws ParseException {
+        return Schedule.newBuilder()
+                .scheduleId(scheduleID)
+                .payerAccountId(EntityIdUtils.toAccountId(schedule.getPayerAccountId()))
+                .schedulerAccountId(EntityIdUtils.toAccountId(schedule.getCreatorAccountId()))
+                // up to this point it should be correct
+                .deleted(entity.getDeleted())
+                .memo(entity.getMemo())
+               // .adminKey(entity.getKey())
+
+                .scheduledTransaction(SchedulableTransactionBody.PROTOBUF.parse(Bytes.wrap(schedule.getTransactionBody())))
+                .originalCreateTransaction(TransactionBody.newBuilder().transactionID(TransactionID.newBuilder()
+                                .accountID(EntityIdUtils.toAccountId(schedule.getCreatorAccountId()))))
+                //.signatories(entity.getKey())
+                .signatories()
+                .build();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -112,6 +112,10 @@ public final class EntityIdUtils {
         return EntityId.of(accountID.shardNum(), accountID.realmNum(), accountID.accountNum());
     }
 
+    public static EntityId toEntityId(final com.hedera.hapi.node.base.ScheduleID scheduleID) {
+        return EntityId.of(scheduleID.shardNum(), scheduleID.realmNum(), scheduleID.scheduleNum());
+    }
+
     public static EntityId toEntityId(final com.hedera.hapi.node.base.TokenID tokenID) {
         return EntityId.of(tokenID.shardNum(), tokenID.realmNum(), tokenID.tokenNum());
     }
@@ -184,6 +188,16 @@ public final class EntityIdUtils {
                 .shardNum(entityId.getShard())
                 .realmNum(entityId.getRealm())
                 .tokenNum(entityId.getNum())
+                .build();
+    }
+
+    public static com.hedera.hapi.node.base.ScheduleID toScheduleId(final Long scheduleId) {
+        final var decodedEntityId = EntityId.of(scheduleId);
+
+        return com.hedera.hapi.node.base.ScheduleID.newBuilder()
+                .shardNum(decodedEntityId.getShard())
+                .realmNum(decodedEntityId.getRealm())
+                .scheduleNum(decodedEntityId.getNum())
                 .build();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TransactionSignatureRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TransactionSignatureRepositoryTest.java
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.hedera.mirror.web3.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.mirror.web3.Web3IntegrationTest;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+class TransactionSignatureRepositoryTest extends Web3IntegrationTest {
+
+    private final TransactionSignatureRepository transactionSignatureRepository;
+
+    @Test
+    void findByEntityIdSuccessful() {
+        final var transactionSignature = domainBuilder.transactionSignature().persist();
+        assertThat(transactionSignatureRepository.findByEntityId(transactionSignature.getEntityId()))
+                .contains(transactionSignature);
+    }
+
+    @Test
+    void findByEntityIdNotSuccessful() {
+        final var transactionSignature = domainBuilder.transactionSignature().persist();
+        final var wrongEntity = domainBuilder.entity().persist();
+        assertThat(transactionSignatureRepository.findByEntityId(wrongEntity.toEntityId()))
+                .doesNotContain(transactionSignature);
+    }
+
+    @Test
+    void findByEntityIdWithTimestampSuccessful() {
+        final long timestamp = Instant.now().getEpochSecond();
+        final var transactionSignature = domainBuilder
+                .transactionSignature()
+                .customize(e -> e.consensusTimestamp(timestamp))
+                .persist();
+        assertThat(transactionSignatureRepository.findByEntityIdAndConsensusTimestampLessThanEqual(
+                        transactionSignature.getEntityId(), timestamp))
+                .contains(transactionSignature);
+    }
+
+    @Test
+    void findByEntityIdWithTimestampNotSuccessful() {
+        final long timestamp = Instant.now().getEpochSecond();
+        final var transactionSignature = domainBuilder
+                .transactionSignature()
+                .customize(e -> e.consensusTimestamp(timestamp))
+                .persist();
+        assertThat(transactionSignatureRepository.findByEntityIdAndConsensusTimestampLessThanEqual(
+                        transactionSignature.getEntityId(), timestamp - 1))
+                .doesNotContain(transactionSignature);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -129,6 +129,55 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .build();
     }
 
+    /**
+     * @param messageHash - message to be signed
+     * @param privateKey - private key used to sign the message
+     */
+    // Sign message with ECDSA private key
+    protected static byte[] signMessageECDSA(final byte[] messageHash, byte[] privateKey) {
+        final LibSecp256k1.secp256k1_ecdsa_recoverable_signature signature =
+                new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
+        LibSecp256k1.secp256k1_ecdsa_sign_recoverable(CONTEXT, signature, messageHash, privateKey, null, null);
+
+        final ByteBuffer compactSig = ByteBuffer.allocate(64);
+        final IntByReference recId = new IntByReference(0);
+        LibSecp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact(
+                LibSecp256k1.CONTEXT, compactSig, recId, signature);
+        compactSig.flip();
+        final byte[] sig = compactSig.array();
+
+        final byte[] result = new byte[65];
+        System.arraycopy(sig, 0, result, 0, 64);
+        result[64] = (byte) (recId.getValue() + 27);
+        return result;
+    }
+
+    /**
+     * Signs message with ED25519 private key
+     *
+     * @param msg - message to be signed
+     * @param privateKey - private key used to sign the message
+     */
+    protected static byte[] signBytesED25519(final byte[] msg, final PrivateKey privateKey)
+            throws InvalidKeyException, SignatureException, NoSuchAlgorithmException {
+        Signature signature = Signature.getInstance(ED_25519);
+        signature.initSign(privateKey);
+        signature.update(msg);
+        return signature.sign();
+    }
+
+    /**
+     * Returns the evm address in proper format with Upper and Lower case for the letters
+     *
+     * @param address - address bytes to be converted into readable evm address
+     */
+    protected static com.esaulpaugh.headlong.abi.Address asHeadlongAddress(final byte[] address) {
+        final var addressBytes = Bytes.wrap(address);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return com.esaulpaugh.headlong.abi.Address.wrap(
+                com.esaulpaugh.headlong.abi.Address.toChecksumAddress(addressAsInteger));
+    }
+
     @BeforeEach
     protected void setup() {
         modularizedTrafficPercent = mirrorNodeEvmProperties.getModularizedTrafficPercent();
@@ -730,55 +779,6 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .customize(e -> e.createdTimestamp(genesisRecordFile.getConsensusStart())
                         .timestampRange(Range.atLeast(genesisRecordFile.getConsensusStart())))
                 .persist();
-    }
-
-    /**
-     * @param messageHash - message to be signed
-     * @param privateKey - private key used to sign the message
-     */
-    // Sign message with ECDSA private key
-    protected static byte[] signMessageECDSA(final byte[] messageHash, byte[] privateKey) {
-        final LibSecp256k1.secp256k1_ecdsa_recoverable_signature signature =
-                new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
-        LibSecp256k1.secp256k1_ecdsa_sign_recoverable(CONTEXT, signature, messageHash, privateKey, null, null);
-
-        final ByteBuffer compactSig = ByteBuffer.allocate(64);
-        final IntByReference recId = new IntByReference(0);
-        LibSecp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact(
-                LibSecp256k1.CONTEXT, compactSig, recId, signature);
-        compactSig.flip();
-        final byte[] sig = compactSig.array();
-
-        final byte[] result = new byte[65];
-        System.arraycopy(sig, 0, result, 0, 64);
-        result[64] = (byte) (recId.getValue() + 27);
-        return result;
-    }
-
-    /**
-     * Signs message with ED25519 private key
-     *
-     * @param msg - message to be signed
-     * @param privateKey - private key used to sign the message
-     */
-    protected static byte[] signBytesED25519(final byte[] msg, final PrivateKey privateKey)
-            throws InvalidKeyException, SignatureException, NoSuchAlgorithmException {
-        Signature signature = Signature.getInstance(ED_25519);
-        signature.initSign(privateKey);
-        signature.update(msg);
-        return signature.sign();
-    }
-
-    /**
-     * Returns the evm address in proper format with Upper and Lower case for the letters
-     *
-     * @param address - address bytes to be converted into readable evm address
-     */
-    protected static com.esaulpaugh.headlong.abi.Address asHeadlongAddress(final byte[] address) {
-        final var addressBytes = Bytes.wrap(address);
-        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
-        return com.esaulpaugh.headlong.abi.Address.wrap(
-                com.esaulpaugh.headlong.abi.Address.toChecksumAddress(addressAsInteger));
     }
 
     protected byte[] getProtobufKeyECDSA(BigInteger publicKey) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallContractSignScheduleTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallContractSignScheduleTest.java
@@ -1,13 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package com.hedera.mirror.web3.service;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.CONTEXT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.protobuf.ByteString;
+import com.hedera.hapi.node.base.AccountAmount;
 import com.hedera.hapi.node.base.Key.KeyOneOfType;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -17,51 +21,60 @@ import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.web3j.generated.HRC755Contract;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.sun.jna.ptr.IntByReference;
+import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.Key.KeyCase;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import lombok.RequiredArgsConstructor;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
-import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Keys;
+import org.web3j.utils.Numeric;
 
 @RequiredArgsConstructor
 class ContractCallContractSignScheduleTest extends AbstractContractCallServiceTest {
 
-    public static byte[] signMessage(final byte[] messageHash, byte[] privateKey) {
-        final LibSecp256k1.secp256k1_ecdsa_recoverable_signature signature =
-                new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
-        LibSecp256k1.secp256k1_ecdsa_sign_recoverable(CONTEXT, signature, messageHash, privateKey, null, null);
-
-        final ByteBuffer compactSig = ByteBuffer.allocate(64);
-        final IntByReference recId = new IntByReference(0);
-        LibSecp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact(
-                LibSecp256k1.CONTEXT, compactSig, recId, signature);
-        compactSig.flip();
-        final byte[] sig = compactSig.array();
-
-        final byte[] result = new byte[65];
-        System.arraycopy(sig, 0, result, 0, 64);
-        result[64] = (byte) (recId.getValue() + 27);
-        return result;
-    }
-
     @Test
-    void authorizeScheduleWithContract() {
+    void signScheduleWithEcdsaKey() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
-        final var payerAccount = accountEntityPersist();
-        final var scheduleEntity = domainBuilder.entity().customize(e -> e.type(EntityType.SCHEDULE)).persist();
-        final var scheduleTransactionBody = SchedulableTransactionBody.newBuilder().cryptoTransfer(
-                CryptoTransferTransactionBody.DEFAULT).build();
-        final var bytes = CommonPbjConverters.asBytes(SchedulableTransactionBody.PROTOBUF, scheduleTransactionBody);
-        final var schedule = domainBuilder.schedule().customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
-                .transactionBody(bytes).payerAccountId(payerAccount.toEntityId())
-                .creatorAccountId(payerAccount.toEntityId())
-        ).persist();
+        final var scheduleEntity = persistScheduleEntity();
+        final var messageHash = getMessageHash(scheduleEntity);
+
+        final var keyPair = Keys.createEcKeyPair();
+        final var signatureMapBytes = getSignatureMapBytesEcdsa(messageHash, keyPair);
+
+        final var ecdsaKey = Key.newBuilder()
+                .setECDSASecp256K1(convertToCompressedPublicKey(keyPair.getPublicKey()))
+                .build()
+                .toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ecdsaKey));
+
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
+
+        final var payerAccount = persistEd25519Account();
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
+
         // When
-        final var entityId = EntityId.of(schedule.getScheduleId());
-        final var functionCall = contract.send_authorizeScheduleCall((getAddressFromEntityId(entityId)));
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))), signatureMapBytes);
         // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(functionCall, contract);
@@ -72,65 +85,363 @@ class ContractCallContractSignScheduleTest extends AbstractContractCallServiceTe
     }
 
     @Test
-    void signScheduleWithContract()
-            throws Exception {
+    void signScheduleWithEcdsaKeyWhichAlreadySignedFails() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
-
-        final var payerAccount = accountEntityPersist();
-        final var scheduleEntity = domainBuilder.entity().customize(e -> e.type(EntityType.SCHEDULE)).persist();
-        final var scheduleTransactionBody = SchedulableTransactionBody.newBuilder().cryptoTransfer(
-                CryptoTransferTransactionBody.DEFAULT).build();
-        final var bytes = CommonPbjConverters.asBytes(SchedulableTransactionBody.PROTOBUF, scheduleTransactionBody);
-        final var schedule = domainBuilder.schedule().customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
-                .transactionBody(bytes).payerAccountId(payerAccount.toEntityId())
-                .creatorAccountId(payerAccount.toEntityId())
-        ).persist();
-
-        final var message = getMessageBytes(scheduleEntity);
-        final var messageHash = new Keccak.Digest256().digest(message.toByteArray());
+        final var scheduleEntity = persistScheduleEntity();
+        final var messageHash = getMessageHash(scheduleEntity);
 
         final var keyPair = Keys.createEcKeyPair();
-        var privateKey = keyPair.getPrivateKey().toByteArray();
-        var publicKey = keyPair.getPublicKey().toByteArray();
-        final var signedBytes = signMessage(messageHash, privateKey);
+        final var signatureMapBytes = getSignatureMapBytesEcdsa(messageHash, keyPair);
 
-        final var signaturePair = SignaturePair.newBuilder()
-                .ecdsaSecp256k1(Bytes.wrap(signedBytes))
-                .pubKeyPrefix(Bytes.wrap(publicKey))
-                .build();
+        final var ecdsaKey = Key.newBuilder()
+                .setECDSASecp256K1(convertToCompressedPublicKey(keyPair.getPublicKey()))
+                .build()
+                .toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ecdsaKey));
 
-        final var signatureMap = SignatureMap.newBuilder()
-                .sigPair(signaturePair)
-                .build();
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
 
-        final var signatureMapBytes =
-                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+        final var payerAccount = persistEd25519Account();
+        // Persist schedule
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
 
-        domainBuilder.transactionSignature()
-                .customize(ts -> ts.publicKeyPrefix(publicKey).signature(signedBytes).entityId(EntityId.of(schedule.getScheduleId()))
-                        .type(KeyOneOfType.ECDSA_SECP256K1.protoOrdinal())).persist();
+        // Persist signature
+        domainBuilder
+                .transactionSignature()
+                .customize(ts -> ts.publicKeyPrefix(convertToCompressedPublicKey(keyPair.getPublicKey())
+                                .toByteArray())
+                        .signature(signMessageECDSA(messageHash, Numeric.toBytesPadded(keyPair.getPrivateKey(), 32)))
+                        .entityId(EntityId.of(schedule.getScheduleId()))
+                        .type(KeyOneOfType.ECDSA_SECP256K1.protoOrdinal()))
+                .persist();
+
+        // Sign again with the same key
+        // When
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))), signatureMapBytes);
+        // Then
+
+        final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+        assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+    }
+
+    @Test
+    void signScheduleWithEcdsaKeyAndAlreadyExistingPayerEdSignature() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+        final var scheduleEntity = persistScheduleEntity();
+        final var messageHash = getMessageHash(scheduleEntity);
+
+        final var keyPair = Keys.createEcKeyPair();
+        final var signatureMapBytes = getSignatureMapBytesEcdsa(messageHash, keyPair);
+
+        final var ecdsaKey = Key.newBuilder()
+                .setECDSASecp256K1(convertToCompressedPublicKey(keyPair.getPublicKey()))
+                .build()
+                .toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ecdsaKey));
+
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
+
+        // Persist payer with custom ED key and get message signature
+        final var keyPairGenerator = KeyPairGenerator.getInstance(ED_25519);
+        final var keyPairEd = keyPairGenerator.generateKeyPair();
+        var publicKey = keyPairEd.getPublic();
+        var publicKeyCompressed = convertToCompressedPublicKey(publicKey);
+        var privateKey = keyPairEd.getPrivate();
+        final var signedBytes = signBytesED25519(getMessageBytes(scheduleEntity), privateKey);
+
+        final var ed25519Key =
+                Key.newBuilder().setEd25519(publicKeyCompressed).build().toByteArray();
+        final var payerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ed25519Key));
+
+        // Persist schedule
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
+
+        // Persist payer ed signature
+        domainBuilder
+                .transactionSignature()
+                .customize(ts -> ts.publicKeyPrefix(publicKeyCompressed.toByteArray())
+                        .signature(signedBytes)
+                        .entityId(EntityId.of(schedule.getScheduleId()))
+                        .type(KeyOneOfType.ED25519.protoOrdinal()))
+                .persist();
 
         // When
-        final var entityId = EntityId.of(schedule.getScheduleId());
-        final var functionCall = contract.send_signScheduleCall((getAddressFromEntityId(entityId)), signatureMapBytes);
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))), signatureMapBytes);
+
         // Then
         if (mirrorNodeEvmProperties.isModularizedServices()) {
-            final var result = contract.call_signScheduleCall(
-                    (getAddressFromEntityId(entityId)), signatureMapBytes).send();
-            assertThat(result).isNotNull();
-            //verifyEthCallAndEstimateGas(functionCall, contract);
+            verifyEthCallAndEstimateGas(functionCall, contract);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
         }
     }
 
-    private Bytes getMessageBytes(final Entity entity) {
+    @Test
+    void signScheduleWithEdKeyFailsWhenEcdsaExpected() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+        final var scheduleEntity = persistScheduleEntity();
+
+        // Persist expected ecdsa key signer
+        final var keyPair = Keys.createEcKeyPair();
+        final var ecdsaKey = Key.newBuilder()
+                .setECDSASecp256K1(convertToCompressedPublicKey(keyPair.getPublicKey()))
+                .build()
+                .toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ecdsaKey));
+
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
+
+        final var payerAccount = persistEd25519Account();
+
+        // Create unexpected ed25519 key signature
+        final var keyPairGenerator = KeyPairGenerator.getInstance(ED_25519);
+        final var keyPairEd = keyPairGenerator.generateKeyPair();
+        var publicKey = keyPairEd.getPublic();
+        var publicKeyCompressed = convertToCompressedPublicKey(publicKey);
+        var privateKey = keyPairEd.getPrivate();
+        final var signedBytes = signBytesED25519(getMessageBytes(scheduleEntity), privateKey);
+
+        final var signatureMap = SignatureMap.newBuilder()
+                .sigPair(SignaturePair.newBuilder()
+                        .ed25519(Bytes.wrap(signedBytes))
+                        .pubKeyPrefix(Bytes.wrap(publicKeyCompressed.toByteArray()))
+                        .build())
+                .build();
+
+        // Persist schedule
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
+
+        // When
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))),
+                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray());
+        // Then
+
+        final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+        assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+    }
+
+    @Test
+    void signScheduleWithEd25519Key() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+        final var scheduleEntity = persistScheduleEntity();
+
+        final var keyPairGenerator = KeyPairGenerator.getInstance(ED_25519);
+        final var keyPairEd = keyPairGenerator.generateKeyPair();
+        var publicKey = keyPairEd.getPublic();
+        var publicKeyCompressed = convertToCompressedPublicKey(publicKey);
+        var privateKey = keyPairEd.getPrivate();
+        final var signedBytes = signBytesED25519(getMessageBytes(scheduleEntity), privateKey);
+
+        final var signatureMap = SignatureMap.newBuilder()
+                .sigPair(SignaturePair.newBuilder()
+                        .ed25519(Bytes.wrap(signedBytes))
+                        .pubKeyPrefix(Bytes.wrap(publicKeyCompressed.toByteArray()))
+                        .build())
+                .build();
+
+        final var ed25519Key =
+                Key.newBuilder().setEd25519(publicKeyCompressed).build().toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ed25519Key));
+
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
+
+        final var payerAccount = persistEd25519Account();
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
+
+        // When
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))),
+                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray());
+        // Then
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void signScheduleWithЕcdsaKeyFailsWhenEd25519Expected() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+        final var scheduleEntity = persistScheduleEntity();
+
+        // Persist expected ed25519 signer
+        final var keyPairGenerator = KeyPairGenerator.getInstance(ED_25519);
+        final var keyPairEd = keyPairGenerator.generateKeyPair();
+        var publicKey = keyPairEd.getPublic();
+        var publicKeyCompressed = convertToCompressedPublicKey(publicKey);
+        final var ed25519Key =
+                Key.newBuilder().setEd25519(publicKeyCompressed).build().toByteArray();
+        final var signerAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .alias(null)
+                .evmAddress(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(ed25519Key));
+
+        final var receiverAccount = accountEntityPersist();
+        final var scheduleTransactionBodyBytes =
+                buildDefaultScheduleTransactionBodyForCryptoTransferBytes(signerAccount, receiverAccount);
+
+        // Create unexpected ecdsa key signature
+        final var keyPair = Keys.createEcKeyPair();
+        final var signatureMapBytes = getSignatureMapBytesEcdsa(getMessageHash(scheduleEntity), keyPair);
+
+        final var payerAccount = persistEd25519Account();
+        final var schedule = domainBuilder
+                .schedule()
+                .customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                        .transactionBody(scheduleTransactionBodyBytes)
+                        .payerAccountId(payerAccount.toEntityId())
+                        .creatorAccountId(payerAccount.toEntityId()))
+                .persist();
+
+        // When
+        final var functionCall = contract.send_signScheduleCall(
+                (getAddressFromEntityId(EntityId.of(schedule.getScheduleId()))), signatureMapBytes);
+        // Then
+        final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+        assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+    }
+
+    private Entity persistEd25519Account() {
+        return accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .evmAddress(null)
+                .alias(null)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .key(domainBuilder.key(KeyCase.ED25519)));
+    }
+
+    private Entity persistScheduleEntity() {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.SCHEDULE))
+                .persist();
+    }
+
+    private ByteString convertToCompressedPublicKey(final BigInteger publicKey) {
+        // Convert BigInteger public key to a full 65-byte uncompressed key
+        var fullPublicKey = Numeric.hexStringToByteArray(Numeric.toHexStringWithPrefixZeroPadded(publicKey, 130));
+
+        // Convert to compressed format (33 bytes)
+        var prefix = (byte) (fullPublicKey[64] % 2 == 0 ? 0x02 : 0x03); // 0x02 for even Y, 0x03 for odd Y
+        var compressedKey = new byte[33];
+        compressedKey[0] = prefix;
+        System.arraycopy(fullPublicKey, 1, compressedKey, 1, 32); // Copy only X coordinate
+        return ByteString.copyFrom(compressedKey);
+    }
+
+    private ByteString convertToCompressedPublicKey(final PublicKey publicKey) {
+        var publicKeyEncoded = publicKey.getEncoded();
+        SubjectPublicKeyInfo info = SubjectPublicKeyInfo.getInstance(publicKeyEncoded);
+        var raw = info.getPublicKeyData().getOctets();
+        return ByteString.copyFrom(raw);
+    }
+
+    private byte[] getMessageBytes(final Entity entity) {
         final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES * 3);
         buffer.putLong(entity.getShard());
         buffer.putLong(entity.getRealm());
         buffer.putLong(entity.getNum());
-        return Bytes.wrap(buffer.array());
+        return Bytes.wrap(buffer.array()).toByteArray();
+    }
+
+    private byte[] getMessageHash(Entity scheduleEntity) {
+        return new Keccak.Digest256().digest(getMessageBytes(scheduleEntity));
+    }
+
+    private byte[] getSignatureMapBytesEcdsa(final byte[] messageHash, final ECKeyPair keyPair) {
+        final var signedMessage = signMessageECDSA(messageHash, Numeric.toBytesPadded(keyPair.getPrivateKey(), 32));
+        var publicKeyBytestring = convertToCompressedPublicKey(keyPair.getPublicKey());
+        var compressedPublicKey = publicKeyBytestring.toByteArray();
+
+        final var signatureMap = SignatureMap.newBuilder()
+                .sigPair(SignaturePair.newBuilder()
+                        .ecdsaSecp256k1(Bytes.wrap(signedMessage))
+                        .pubKeyPrefix(Bytes.wrap(compressedPublicKey))
+                        .build())
+                .build();
+        return SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+    }
+
+    private byte[] buildDefaultScheduleTransactionBodyForCryptoTransferBytes(
+            final Entity sender, final Entity receiver) {
+        final long transferAmount = 100L;
+        final var scheduleBody = SchedulableTransactionBody.newBuilder()
+                .cryptoTransfer(CryptoTransferTransactionBody.newBuilder()
+                        .transfers(TransferList.newBuilder()
+                                .accountAmounts(
+                                        AccountAmount.newBuilder()
+                                                .accountID(EntityIdUtils.toAccountId(sender))
+                                                .amount(-transferAmount)
+                                                .build(),
+                                        AccountAmount.newBuilder()
+                                                .accountID(EntityIdUtils.toAccountId(receiver))
+                                                .amount(transferAmount)
+                                                .build())
+                                .build()))
+                .build();
+        return CommonPbjConverters.asBytes(SchedulableTransactionBody.PROTOBUF, scheduleBody);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallContractSignScheduleTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallContractSignScheduleTest.java
@@ -1,0 +1,129 @@
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.CONTEXT;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.web3j.generated.HRC755Contract;
+import com.hedera.node.app.hapi.utils.CommonPbjConverters;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.sun.jna.ptr.IntByReference;
+import java.nio.ByteBuffer;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Keys;
+
+@RequiredArgsConstructor
+class ContractCallContractSignScheduleTest extends AbstractContractCallServiceTest {
+
+    public static byte[] signMessage(final byte[] messageHash, byte[] privateKey) {
+        final LibSecp256k1.secp256k1_ecdsa_recoverable_signature signature =
+                new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
+        LibSecp256k1.secp256k1_ecdsa_sign_recoverable(CONTEXT, signature, messageHash, privateKey, null, null);
+
+        final ByteBuffer compactSig = ByteBuffer.allocate(64);
+        final IntByReference recId = new IntByReference(0);
+        LibSecp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact(
+                LibSecp256k1.CONTEXT, compactSig, recId, signature);
+        compactSig.flip();
+        final byte[] sig = compactSig.array();
+
+        final byte[] result = new byte[65];
+        System.arraycopy(sig, 0, result, 0, 64);
+        result[64] = (byte) (recId.getValue() + 27);
+        return result;
+    }
+
+    @Test
+    void authorizeScheduleWithContract() {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+        final var payerAccount = accountEntityPersist();
+        final var scheduleEntity = domainBuilder.entity().customize(e -> e.type(EntityType.SCHEDULE)).persist();
+        final var scheduleTransactionBody = SchedulableTransactionBody.newBuilder().cryptoTransfer(
+                CryptoTransferTransactionBody.DEFAULT).build();
+        final var bytes = CommonPbjConverters.asBytes(SchedulableTransactionBody.PROTOBUF, scheduleTransactionBody);
+        final var schedule = domainBuilder.schedule().customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                .transactionBody(bytes).payerAccountId(payerAccount.toEntityId())
+                .creatorAccountId(payerAccount.toEntityId())
+        ).persist();
+        // When
+        final var entityId = EntityId.of(schedule.getScheduleId());
+        final var functionCall = contract.send_authorizeScheduleCall((getAddressFromEntityId(entityId)));
+        // Then
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void signScheduleWithContract()
+            throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
+
+        final var payerAccount = accountEntityPersist();
+        final var scheduleEntity = domainBuilder.entity().customize(e -> e.type(EntityType.SCHEDULE)).persist();
+        final var scheduleTransactionBody = SchedulableTransactionBody.newBuilder().cryptoTransfer(
+                CryptoTransferTransactionBody.DEFAULT).build();
+        final var bytes = CommonPbjConverters.asBytes(SchedulableTransactionBody.PROTOBUF, scheduleTransactionBody);
+        final var schedule = domainBuilder.schedule().customize(e -> e.scheduleId(scheduleEntity.toEntityId().getId())
+                .transactionBody(bytes).payerAccountId(payerAccount.toEntityId())
+                .creatorAccountId(payerAccount.toEntityId())
+        ).persist();
+
+        final var message = getMessageBytes(scheduleEntity);
+        final var messageHash = new Keccak.Digest256().digest(message.toByteArray());
+
+        final var keyPair = Keys.createEcKeyPair();
+        var privateKey = keyPair.getPrivateKey().toByteArray();
+        var publicKey = keyPair.getPublicKey().toByteArray();
+        final var signedBytes = signMessage(messageHash, privateKey);
+
+        final var signatureMap = SignatureMap.newBuilder()
+                .sigPair(SignaturePair.newBuilder()
+                        .ecdsaSecp256k1(Bytes.wrap(signedBytes))
+                        .pubKeyPrefix(Bytes.wrap(publicKey))
+                        .build())
+                .build();
+
+        final var signatureMapBytes =
+                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+        // When
+        final var entityId = EntityId.of(schedule.getScheduleId());
+        final var functionCall = contract.send_signScheduleCall((getAddressFromEntityId(entityId)), signatureMapBytes);
+        // Then
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            final var result = contract.call_signScheduleCall(
+                    (getAddressFromEntityId(entityId)), signatureMapBytes).send();
+            assertThat(result).isNotNull();
+            //verifyEthCallAndEstimateGas(functionCall, contract);
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    private Bytes getMessageBytes(final Entity entity) {
+        final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES * 3);
+        buffer.putLong(entity.getShard());
+        buffer.putLong(entity.getRealm());
+        buffer.putLong(entity.getNum());
+        return Bytes.wrap(buffer.array());
+    }
+}

--- a/hedera-mirror-web3/src/test/resources/config/application.yml
+++ b/hedera-mirror-web3/src/test/resources/config/application.yml
@@ -4,8 +4,6 @@ hedera:
   mirror:
     web3:
       evm:
-        modularizedServices: true
-        modularizedTrafficPercent: 1.0
         properties:
           contracts.maxRefundPercentOfGasLimit: "100"
         evm_versions:

--- a/hedera-mirror-web3/src/test/resources/config/application.yml
+++ b/hedera-mirror-web3/src/test/resources/config/application.yml
@@ -4,6 +4,8 @@ hedera:
   mirror:
     web3:
       evm:
+        modularizedServices: true
+        modularizedTrafficPercent: 1.0
         properties:
           contracts.maxRefundPercentOfGasLimit: "100"
         evm_versions:

--- a/hedera-mirror-web3/src/test/solidity/HRC755Contract.sol
+++ b/hedera-mirror-web3/src/test/solidity/HRC755Contract.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+
+import "./HederaScheduleService.sol";
+import "./HederaResponseCodes.sol";
+pragma experimental ABIEncoderV2;
+
+contract HRC755Contract is HederaScheduleService {
+    function authorizeScheduleCall(address schedule) external returns (int64 responseCode)
+    {
+        (responseCode) = HederaScheduleService.authorizeSchedule(schedule);
+        require(responseCode == HederaResponseCodes.SUCCESS, "Authorize schedule failed");
+    }
+
+    function signScheduleCall(address schedule, bytes memory signatureMap) external returns (int64 responseCode) {
+        (responseCode) = HederaScheduleService.signSchedule(schedule, signatureMap);
+        require(responseCode == HederaResponseCodes.SUCCESS, "Authorize schedule failed");
+    }
+}

--- a/hedera-mirror-web3/src/test/solidity/HederaScheduleService.sol
+++ b/hedera-mirror-web3/src/test/solidity/HederaScheduleService.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaResponseCodes.sol";
+import "./IHederaScheduleService.sol";
+
+abstract contract HederaScheduleService {
+    address constant scheduleSystemContractAddress = address(0x16b);
+
+    /// Authorizes the calling contract as a signer to the schedule transaction.
+    /// @param schedule the address of the schedule transaction.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function authorizeSchedule(address schedule) internal returns (int64 responseCode) {
+        (bool success, bytes memory result) = scheduleSystemContractAddress.call(
+            abi.encodeWithSelector(IHederaScheduleService.authorizeSchedule.selector, schedule));
+        responseCode = success ? abi.decode(result, (int64)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    /// Allows for the signing of a schedule transaction given a protobuf encoded signature map
+    /// The message signed by the keys is defined to be the concatenation of the shard, realm, and schedule transaction ID.
+    /// @param schedule the address of the schedule transaction.
+    /// @param signatureMap the protobuf encoded signature map
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function signSchedule(address schedule, bytes memory signatureMap) internal returns (int64 responseCode) {
+        (bool success, bytes memory result) = scheduleSystemContractAddress.call(
+            abi.encodeWithSelector(IHederaScheduleService.signSchedule.selector, schedule, signatureMap));
+        responseCode = success ? abi.decode(result, (int64)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    /// Allows for the creation of a schedule transaction for given a system contract address, abi encoded call data and payer address
+    /// Currently supports the Hedera Token Service System Contract (0x167) with encoded call data for
+    /// createFungibleToken, createNonFungibleToken, createFungibleTokenWithCustomFees, createNonFungibleTokenWithCustomFees
+    /// and updateToken functions
+    /// @param systemContractAddress the address of the system contract from which to create the schedule transaction
+    /// @param callData the abi encoded call data for the system contract function
+    /// @param payer the address of the account that will pay for the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return scheduleAddress The address of the newly created schedule transaction.
+    function scheduleNative(address systemContractAddress, bytes memory callData, address payer) internal returns (int64 responseCode, address scheduleAddress) {
+        (bool success, bytes memory result) = scheduleSystemContractAddress.call(
+            abi.encodeWithSelector(IHederaScheduleService.scheduleNative.selector, systemContractAddress, callData, payer));
+        (responseCode, scheduleAddress) = success ? abi.decode(result, (int64, address)) : (int64(HederaResponseCodes.UNKNOWN), address(0));
+    }
+
+    /// Returns the token information for a scheduled fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return fungibleTokenInfo The token information for the scheduled fungible token create transaction
+    function getScheduledCreateFungibleTokenInfo(address scheduleAddress) internal returns (int64 responseCode, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo) {
+        (bool success, bytes memory result) = scheduleSystemContractAddress.call(
+            abi.encodeWithSelector(IHederaScheduleService.getScheduledCreateFungibleTokenInfo.selector, scheduleAddress));
+        IHederaTokenService.FungibleTokenInfo memory defaultTokenInfo;
+        (responseCode, fungibleTokenInfo) = success ? abi.decode(result, (int64, IHederaTokenService.FungibleTokenInfo)) : (int64(HederaResponseCodes.UNKNOWN), defaultTokenInfo);
+    }
+
+    /// Returns the token information for a scheduled non fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return nonFungibleTokenInfo The token information for the scheduled non fungible token create transaction
+    function getScheduledCreateNonFungibleTokenInfo(address scheduleAddress) internal returns (int64 responseCode, IHederaTokenService.NonFungibleTokenInfo memory nonFungibleTokenInfo) {
+        (bool success, bytes memory result) = scheduleSystemContractAddress.call(
+            abi.encodeWithSelector(IHederaScheduleService.getScheduledCreateNonFungibleTokenInfo.selector, scheduleAddress));
+        IHederaTokenService.NonFungibleTokenInfo memory defaultTokenInfo;
+        (responseCode, nonFungibleTokenInfo) = success ? abi.decode(result, (int64, IHederaTokenService.NonFungibleTokenInfo)) : (int64(HederaResponseCodes.UNKNOWN), defaultTokenInfo);
+    }
+}

--- a/hedera-mirror-web3/src/test/solidity/IHRC755.sol
+++ b/hedera-mirror-web3/src/test/solidity/IHRC755.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+interface IHRC755 {
+    /// Signs the targeted schedule transaction with the key of the calling EOA.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function signSchedule() external returns (int64 responseCode);
+}

--- a/hedera-mirror-web3/src/test/solidity/IHederaScheduleService.sol
+++ b/hedera-mirror-web3/src/test/solidity/IHederaScheduleService.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./IHederaTokenService.sol";
+interface IHederaScheduleService {
+
+    /// Authorizes the calling contract as a signer to the schedule transaction.
+    /// @param schedule the address of the schedule transaction.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function authorizeSchedule(address schedule) external returns (int64 responseCode);
+
+    /// Allows for the signing of a schedule transaction given a protobuf encoded signature map
+    /// The message signed by the keys is defined to be the concatenation of the shard, realm, and schedule transaction ID.
+    /// @param schedule the address of the schedule transaction.
+    /// @param signatureMap the protobuf encoded signature map
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function signSchedule(address schedule, bytes memory signatureMap) external returns (int64 responseCode);
+
+    /// Allows for the creation of a schedule transaction for given a system contract address, abi encoded call data and payer address
+    /// Currently supports the Hedera Token Service System Contract (0x167) with encoded call data for
+    /// createFungibleToken, createNonFungibleToken, createFungibleTokenWithCustomFees, createNonFungibleTokenWithCustomFees
+    /// and updateToken functions
+    /// @param systemContractAddress the address of the system contract from which to create the schedule transaction
+    /// @param callData the abi encoded call data for the system contract function
+    /// @param payer the address of the account that will pay for the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return scheduleAddress The address of the newly created schedule transaction.
+    function scheduleNative(address systemContractAddress, bytes memory callData, address payer) external returns (int64 responseCode, address scheduleAddress);
+
+    /// Returns the token information for a scheduled fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return fungibleTokenInfo The token information for the scheduled fungible token create transaction
+    function getScheduledCreateFungibleTokenInfo(address scheduleAddress) external returns (int64 responseCode, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo);
+
+    /// Returns the token information for a scheduled non fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return nonFungibleTokenInfo The token information for the scheduled non fungible token create transaction
+    function getScheduledCreateNonFungibleTokenInfo(address scheduleAddress) external returns (int64 responseCode, IHederaTokenService.NonFungibleTokenInfo memory nonFungibleTokenInfo);
+}


### PR DESCRIPTION
**Description**:
This PR adds `ScheduleReadableKVState`.
Adds repositories for `Schedule` and `TransactionSignature` entities.
Adds integrations tests for Schedule sign operations.
Copies schedule solidity contracts from consensus node repo.

`ScheduleRepository` 
`TransactionSignatureRepository` - also support for historical queries by consensus timestamp.
`TransactionSignatureRepositoryTest` - adds test for TransactionSignatureRepository methods.
`ScheduleReadableKVState` - gets schedule info.
`ContractCallContractSignScheduleTest` - adds integration tests for various scenarios for schedule sign
 .sol files are copied from consensus node

**Related issue(s)**:

Fixes #10927 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
