### PR TITLE
Upgrade mapstructure to v2.2.1

### DIFF
--- a/rosetta/app/config/config.go
+++ b/rosetta/app/config/config.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"

--- a/rosetta/go.mod
+++ b/rosetta/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0
 	github.com/cucumber/godog v0.15.0
 	github.com/go-playground/validator/v10 v10.26.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/hellofresh/health-go/v4 v4.7.0
 	github.com/hiero-ledger/hiero-sdk-go/v2 v2.61.0
 	github.com/jackc/pgtype v1.14.4
 	github.com/lib/pq v1.10.9
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onrik/gorm-logrus v0.5.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/pkg/errors v0.9.1
@@ -55,7 +55,6 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -77,6 +76,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/user v0.3.0 // indirect
 	github.com/moby/term v0.5.0 // indirect

--- a/rosetta/test/bdd-client/config.go
+++ b/rosetta/test/bdd-client/config.go
@@ -6,9 +6,9 @@ import (
 	"bytes"
 	"reflect"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/test/bdd-client/client"
 	"github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -72,8 +72,7 @@ func loadConfig() (*config, error) {
 	log.Infof("Loaded external configuration file %s", v.ConfigFileUsed())
 
 	config := &config{}
-	var decodeHook = interface{}(addDecodeHooks).(viper.DecoderConfigOption)
-	if err := v.UnmarshalKey(configPrefix, config, decodeHook); err != nil {
+	if err := v.UnmarshalKey(configPrefix, config, addDecodeHooks); err != nil {
 		log.Errorf("Failed to unmarshal config %v", err)
 		return nil, err
 	}


### PR DESCRIPTION
**Description**:

This PR upgrade `mapstructure` to v2.2.1 to fix a runtime type cast issue in rosetta bdd-client.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

`viper` upgraded to the forked `mapstructure` v2 module since v1.20.0, and we use legacy `mapstructure` v1 as a direct dependency. However when dependabot upgraded `viper` v1.20.0, it detected the incompatibility however applied a wrong patch. This PR corrects it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
