### PR TITLE
Set an implicit ContractID key on contracts with no key

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+blank_issues_enabled: false

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/ContractNullKeyMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/ContractNullKeyMigration.java
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hederahashgraph.api.proto.java.Key;
+import jakarta.inject.Named;
+import java.io.IOException;
+import java.util.Map;
+import org.flywaydb.core.api.MigrationVersion;
+import org.hiero.mirror.importer.ImporterProperties;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+@Named
+final class ContractNullKeyMigration extends ConfigurableJavaMigration {
+
+    private final NamedParameterJdbcOperations jdbcOperations;
+    private final boolean v2;
+
+    @Lazy
+    public ContractNullKeyMigration(
+            Environment environment,
+            NamedParameterJdbcOperations jdbcOperations,
+            ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
+        this.jdbcOperations = jdbcOperations;
+        this.v2 = environment.acceptsProfiles(Profiles.of("v2"));
+    }
+
+    @Override
+    public MigrationVersion getVersion() {
+        return v2 ? MigrationVersion.fromVersion("2.12.0") : MigrationVersion.fromVersion("1.107.0");
+    }
+
+    @Override
+    public String getDescription() {
+        return "Populates a default ContractID key for contracts with a missing key";
+    }
+
+    @Override
+    protected void doMigrate() throws IOException {
+        update(false);
+        update(true);
+    }
+
+    private void update(boolean history) {
+        String suffix = history ? "_history" : "";
+        var query = String.format(
+                "select id from entity%s where key is null and type = 'CONTRACT' and created_timestamp is not null",
+                suffix);
+        var update = String.format("update entity%s set key = :key where id = :id", suffix);
+
+        jdbcOperations.query(query, rs -> {
+            var id = EntityId.of(rs.getLong(1));
+            byte[] key =
+                    Key.newBuilder().setContractID(id.toContractID()).build().toByteArray();
+            jdbcOperations.update(update, Map.of("key", key, "id", id.getId()));
+        });
+    }
+}

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -14,6 +14,7 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hederahashgraph.api.proto.java.Key;
 import jakarta.inject.Named;
 import lombok.CustomLog;
 import org.hiero.mirror.importer.domain.EntityIdService;
@@ -83,6 +84,11 @@ class ContractCreateTransactionHandler extends AbstractEntityCrudTransactionHand
 
         if (transactionBody.hasAdminKey()) {
             entity.setKey(transactionBody.getAdminKey().toByteArray());
+        } else {
+            // Consensus nodes fall back to an implicit `ContractID(shard, realm, num)` key if one is not provided
+            var contractId = entity.toEntityId().toContractID();
+            var key = Key.newBuilder().setContractID(contractId).build().toByteArray();
+            entity.setKey(key);
         }
 
         if (transactionBody.hasProxyAccountID()) {

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/ContractNullKeyMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/ContractNullKeyMigrationTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hederahashgraph.api.proto.java.Key;
+import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.importer.ImporterIntegrationTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.jdbc.core.JdbcOperations;
+
+@RequiredArgsConstructor
+@Tag("migration")
+class ContractNullKeyMigrationTest extends ImporterIntegrationTest {
+
+    private final JdbcOperations jdbcOperations;
+    private final ContractNullKeyMigration migration;
+
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void migrateSuccessful(boolean history) throws Exception {
+        // Given
+        var key = domainBuilder.key();
+        insertEntity(history, 100L, 1L, null, EntityType.CONTRACT);
+        insertEntity(history, 101L, 2L, null, EntityType.CONTRACT);
+        insertEntity(history, 102L, 3L, null, EntityType.ACCOUNT);
+        insertEntity(history, null, 4L, null, EntityType.CONTRACT);
+        insertEntity(history, 104L, 5L, key, EntityType.CONTRACT);
+
+        // When
+        migration.doMigrate();
+
+        // Then
+        assertThat(findKey(history, 1L)).isEqualTo(asContractIdKey(1L));
+        assertThat(findKey(history, 2L)).isEqualTo(asContractIdKey(2L));
+        assertThat(findKey(history, 3L)).isEqualTo(null);
+        assertThat(findKey(history, 4L)).isEqualTo(null);
+        assertThat(findKey(history, 5L)).isEqualTo(key);
+    }
+
+    private byte[] asContractIdKey(long id) {
+        var entityId = EntityId.of(id);
+        return Key.newBuilder().setContractID(entityId.toContractID()).build().toByteArray();
+    }
+
+    private byte[] findKey(boolean history, long id) {
+        var suffix = history ? "_history" : "";
+        var query = String.format("select key from entity%s where id = ?", suffix);
+        return jdbcOperations.queryForObject(query, byte[].class, id);
+    }
+
+    private void insertEntity(boolean history, Long createdTimestamp, long id, byte[] key, EntityType type) {
+        var suffix = history ? "_history" : "";
+        var sql = String.format(
+                "insert into entity%s (created_timestamp, id, key, num, realm, shard, timestamp_range, type) "
+                        + "values (?,?,?,?,0,0,'[1,)',?::entity_type)",
+                suffix);
+        jdbcOperations.update(sql, createdTimestamp, id, key, id, type.toString());
+    }
+}


### PR DESCRIPTION
**Description**:

* Disallow blank issues when reporting an issue
* Migrate existing contracts without a key to a `ContractID` key
* Set an implicit `ContractID` key on contracts with no key during create

**Related issue(s)**:

Fixes #10988

**Notes for reviewer**:

Only 9730 contracts impacted on mainnet.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
