### PR TITLE
Fix `NullPointerException` on FractionalFee getMaximumAmount()

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
@@ -14,7 +14,7 @@ public class FractionalFee extends AbstractFee {
 
     private long denominator;
 
-    private Long maximumAmount;
+    private long maximumAmount;
 
     private long minimumAmount;
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
@@ -14,7 +14,7 @@ public class FractionalFee extends AbstractFee {
 
     private long denominator;
 
-    private long maximumAmount;
+    private Long maximumAmount;
 
     private long minimumAmount;
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -201,7 +201,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
             final var fractionalFee = new FractionalFee(
                     new Fraction(f.getNumerator(), f.getDenominator()),
                     f.getMinimumAmount(),
-                    f.getMaximumAmount(),
+                    f.getMaximumAmount() == null ? 0 : f.getMaximumAmount(),
                     f.isNetOfTransfers());
             var constructed = new CustomFee(
                     new OneOf<>(FeeOneOfType.FRACTIONAL_FEE, fractionalFee), collector, f.isAllCollectorsAreExempt());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.token.FractionalFee;
 import com.hedera.mirror.web3.utils.BytecodeUtils;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
@@ -17,6 +18,7 @@ import com.hedera.mirror.web3.web3j.generated.ERCTestContract;
 import com.hedera.mirror.web3.web3j.generated.RedirectTestContract;
 import jakarta.annotation.Resource;
 import java.math.BigInteger;
+import java.util.List;
 import lombok.SneakyThrows;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -180,6 +182,40 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
         final var token = fungibleTokenPersistWithTreasuryAccount(treasury);
         final var tokenId = token.getTokenId();
         tokenAccountPersist(tokenId, recipient.getId());
+
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var contractAddress = Address.fromHexString(contract.getContractAddress());
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+
+        tokenAccountPersist(tokenId, contractEntityId.getId());
+        final var tokenAddress = toAddress(tokenId).toHexString();
+        final var recipientAddress = toAddress(recipient).toHexString();
+        // When
+        final var functionCall =
+                contract.send_transfer(tokenAddress, recipientAddress, BigInteger.valueOf(DEFAULT_AMOUNT_GRANTED));
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void transferWithFractionalFee() {
+        // Given
+        final var recipient = accountEntityPersist().toEntityId();
+        final var treasury = accountEntityWithEvmAddressPersist().toEntityId();
+
+        final var token = fungibleTokenPersistWithTreasuryAccount(treasury);
+        final var tokenId = token.getTokenId();
+        tokenAccountPersist(tokenId, recipient.getId());
+
+        final var fractionalFee =
+                FractionalFee.builder().collectorAccountId(recipient).build();
+        domainBuilder
+                .customFee()
+                .customize(f -> f.entityId(token.getTokenId())
+                        .fixedFees(List.of())
+                        .fractionalFees(List.of(fractionalFee))
+                        .royaltyFees(List.of()))
+                .persist();
 
         final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
         final var contractAddress = Address.fromHexString(contract.getContractAddress());


### PR DESCRIPTION
**Description**:
This PR changes TokenReadableKVState to handle case when null is passed for maximumAmount in FractionalFee. Added an integration test to simulate this scenario as well.
**Related issue(s)**:

Fixes #11137 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
