### PR TITLE
Fix hbar leak from ethereum feature tests

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(75); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(70); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(100); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(75); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,7 +75,7 @@ public final class AcceptanceTestProperties {
     @NotNull
     @DecimalMax("1000000")
     @DecimalMin("1.0")
-    private BigDecimal operatorBalance = BigDecimal.valueOf(70); // Amount in USD
+    private BigDecimal operatorBalance = BigDecimal.valueOf(100); // Amount in USD
 
     @NotBlank
     private String operatorId;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -18,8 +18,8 @@ import org.springframework.validation.annotation.Validated;
 public class FeatureProperties {
 
     @Min(1)
-    @Max(5_000_000)
-    private long maxContractFunctionGas = 3_000_000;
+    @Max(10_000_000)
+    private long maxContractFunctionGas = 6_000_000;
 
     private boolean sidecars = false;
 }

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -19,7 +19,7 @@ public class FeatureProperties {
 
     @Min(1)
     @Max(10_000_000)
-    private long maxContractFunctionGas = 6_000_000;
+    private long maxContractFunctionGas = 5_250_000;
 
     private boolean sidecars = false;
 }

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -59,7 +59,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
                 .getPublicKey()
                 .toAccountId(commonProperties.getShard(), commonProperties.getRealm());
 
-        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(30L), null);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(8L), null);
 
         assertThat(networkTransactionResponse.getTransactionId()).isNotNull();
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
@@ -78,7 +78,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(30L).toTinybars());
+                .isEqualTo(Hbar.from(8L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -59,7 +59,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
                 .getPublicKey()
                 .toAccountId(commonProperties.getShard(), commonProperties.getRealm());
 
-        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(5L), null);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(30L), null);
 
         assertThat(networkTransactionResponse.getTransactionId()).isNotNull();
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
@@ -78,7 +78,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(5L).toTinybars());
+                .isEqualTo(Hbar.from(30L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.test.e2e.acceptance.client.AccountClient;
+import org.hiero.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum;
 import org.hiero.mirror.test.e2e.acceptance.client.ContractClient;
 import org.hiero.mirror.test.e2e.acceptance.client.EthereumClient;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
@@ -49,20 +50,21 @@ public class EthereumFeature extends AbstractEstimateFeature {
     protected AccountId ethereumSignerAccount;
     protected PrivateKey ethereumSignerPrivateKey;
     private String account;
+    private static final Long HBAR_AMOUNT_IN_TINYBARS = 800_000_000L;
 
     private byte[] childContractBytecodeFromParent;
 
     @Given("I successfully created a signer account with an EVM address alias")
     public void createAccountWithEvmAddressAlias() {
-        ethereumSignerPrivateKey = PrivateKey.generateECDSA();
-        ethereumSignerAccount = ethereumSignerPrivateKey
-                .getPublicKey()
-                .toAccountId(commonProperties.getShard(), commonProperties.getRealm());
+        // Create new signer account with EVM address and ECDSA key
+        var signerAccount = accountClient.createNewAccount(HBAR_AMOUNT_IN_TINYBARS, AccountNameEnum.BOB);
+        ethereumSignerAccount = signerAccount.getAccountId();
+        ethereumSignerPrivateKey = signerAccount.getPrivateKey();
 
-        networkTransactionResponse = accountClient.sendCryptoTransfer(ethereumSignerAccount, Hbar.from(8L), null);
-
-        assertThat(networkTransactionResponse.getTransactionId()).isNotNull();
-        assertThat(networkTransactionResponse.getReceipt()).isNotNull();
+        var accountInfo = mirrorClient.getAccountDetailsByAccountId(ethereumSignerAccount);
+        account = accountInfo.getAccount();
+        assertThat(accountInfo.getBalance().getBalance())
+                .isEqualTo(Hbar.fromTinybars(HBAR_AMOUNT_IN_TINYBARS).toTinybars());
     }
 
     @Then("validate the signer account and its balance")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -80,7 +80,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
         assertThat(accountInfo.getAccount()).isNotNull();
         assertThat(accountInfo.getBalance().getBalance())
-                .isEqualTo(Hbar.from(8L).toTinybars());
+                .isEqualTo(Hbar.from(5L).toTinybars());
 
         assertThat(accountInfo.getTransactions()).hasSize(1);
         assertThat(transactions).hasSize(2);

--- a/test/src/test/resources/features/contract/ethereum.feature
+++ b/test/src/test/resources/features/contract/ethereum.feature
@@ -5,7 +5,6 @@ Feature: Ethereum transactions Coverage Feature
 
 
   Given I successfully created a signer account with an EVM address alias
-  Then validate the signer account and its balance
 
   Given I successfully create contract by Legacy ethereum transaction
   Then the mirror node REST API should return status <httpStatusCode> for the eth contract creation transaction


### PR DESCRIPTION
**Description**:
In ethereum.feature tests we generate a signer account that is hollow and at the end we don't delete it. That means that the hbars that are left in that account are gone.
Because the account is hollow, in order to delete it we have to finalize it first. That's why in that PR a hollow account creation is removed and a real account with ECDSA key and alias is created. That way we are able to delete the account at the end of execution

Fixes #11139 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
