### PR TITLE
Fix `NullPointerException` on `FractionalFee.getMaximumAmount()` (0.129)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/TokenReadableKVState.java
@@ -201,7 +201,7 @@ public class TokenReadableKVState extends AbstractReadableKVState<TokenID, Token
             final var fractionalFee = new FractionalFee(
                     new Fraction(f.getNumerator(), f.getDenominator()),
                     f.getMinimumAmount(),
-                    f.getMaximumAmount(),
+                    f.getMaximumAmount() == null ? 0 : f.getMaximumAmount(),
                     f.isNetOfTransfers());
             var constructed = new CustomFee(
                     new OneOf<>(FeeOneOfType.FRACTIONAL_FEE, fractionalFee), collector, f.isAllCollectorsAreExempt());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -10,6 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.token.FallbackFee;
+import com.hedera.mirror.common.domain.token.FixedFee;
+import com.hedera.mirror.common.domain.token.FractionalFee;
+import com.hedera.mirror.common.domain.token.RoyaltyFee;
 import com.hedera.mirror.web3.utils.BytecodeUtils;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
@@ -17,6 +22,7 @@ import com.hedera.mirror.web3.web3j.generated.ERCTestContract;
 import com.hedera.mirror.web3.web3j.generated.RedirectTestContract;
 import jakarta.annotation.Resource;
 import java.math.BigInteger;
+import java.util.List;
 import lombok.SneakyThrows;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -180,6 +186,50 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
         final var token = fungibleTokenPersistWithTreasuryAccount(treasury);
         final var tokenId = token.getTokenId();
         tokenAccountPersist(tokenId, recipient.getId());
+
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var contractAddress = Address.fromHexString(contract.getContractAddress());
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+
+        tokenAccountPersist(tokenId, contractEntityId.getId());
+        final var tokenAddress = toAddress(tokenId).toHexString();
+        final var recipientAddress = toAddress(recipient).toHexString();
+        // When
+        final var functionCall =
+                contract.send_transfer(tokenAddress, recipientAddress, BigInteger.valueOf(DEFAULT_AMOUNT_GRANTED));
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void transferWithFees() {
+        // Given
+        final var recipient = accountEntityPersist().toEntityId();
+        final var treasury = accountEntityPersist().toEntityId();
+
+        final var token = fungibleTokenPersistWithTreasuryAccount(treasury);
+        final var tokenId = token.getTokenId();
+        tokenAccountPersist(tokenId, recipient.getId());
+        final var tokenEntityId = EntityId.of(tokenId);
+        final var fractionalFee =
+                FractionalFee.builder().collectorAccountId(recipient).build();
+        final var fixedFee = FixedFee.builder()
+                .denominatingTokenId(tokenEntityId)
+                .collectorAccountId(recipient)
+                .build();
+        final var fallbackFee =
+                FallbackFee.builder().denominatingTokenId(tokenEntityId).build();
+        final var royaltyFee = RoyaltyFee.builder()
+                .fallbackFee(fallbackFee)
+                .collectorAccountId(recipient)
+                .build();
+        domainBuilder
+                .customFee()
+                .customize(f -> f.entityId(tokenId)
+                        .fixedFees(List.of(fixedFee))
+                        .fractionalFees(List.of(fractionalFee))
+                        .royaltyFees(List.of(royaltyFee)))
+                .persist();
 
         final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
         final var contractAddress = Address.fromHexString(contract.getContractAddress());


### PR DESCRIPTION
This PR changes TokenReadableKVState to handle case when null is passed for maximumAmount in FractionalFee. Added an integration test to simulate this scenario as well.

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
