### PR TITLE
Fix migrated environment variable to config property mapping

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/config/HieroPropertiesMigrator.java
+++ b/common/src/main/java/org/hiero/mirror/common/config/HieroPropertiesMigrator.java
@@ -12,6 +12,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 
 /**
@@ -22,6 +23,14 @@ import org.springframework.core.env.SystemEnvironmentPropertySource;
  */
 @CustomLog
 public class HieroPropertiesMigrator implements ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
+
+    private static final String DEFAULT_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX = "-hiero";
+
+    // For a SystemEnvironmentPropertySource, only when its name is "systemEnvironment" or ends with
+    // "-systemEnvironment", spring will use `SystemEnvironmentPropertyMapper` to map the environment variables
+    // and bind the properties to configuration property beans
+    private static final String SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX =
+            "-hiero-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
 
     @Override
     public int getOrder() {
@@ -53,7 +62,10 @@ public class HieroPropertiesMigrator implements ApplicationListener<ApplicationE
         }
 
         if (!properties.isEmpty()) {
-            var sourceName = propertySource.getName() + "-hiero";
+            var sourceName = propertySource.getName()
+                    + (environment
+                            ? SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX
+                            : DEFAULT_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX);
             var migratedPropertySource = environment
                     ? new SystemEnvironmentPropertySource(sourceName, properties)
                     : new MapPropertySource(sourceName, properties);

--- a/common/src/main/java/org/hiero/mirror/common/config/HieroPropertiesMigrator.java
+++ b/common/src/main/java/org/hiero/mirror/common/config/HieroPropertiesMigrator.java
@@ -24,7 +24,7 @@ import org.springframework.core.env.SystemEnvironmentPropertySource;
 @CustomLog
 public class HieroPropertiesMigrator implements ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
 
-    private static final String DEFAULT_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX = "-hiero";
+    private static final String DEFAULT_PROPERTY_SOURCE_NAME_SUFFIX = "-hiero";
 
     // For a SystemEnvironmentPropertySource, only when its name is "systemEnvironment" or ends with
     // "-systemEnvironment", spring will use `SystemEnvironmentPropertyMapper` to map the environment variables
@@ -65,7 +65,7 @@ public class HieroPropertiesMigrator implements ApplicationListener<ApplicationE
             var sourceName = propertySource.getName()
                     + (environment
                             ? SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX
-                            : DEFAULT_ENVIRONMENT_PROPERTY_SOURCE_NAME_SUFFIX);
+                            : DEFAULT_PROPERTY_SOURCE_NAME_SUFFIX);
             var migratedPropertySource = environment
                     ? new SystemEnvironmentPropertySource(sourceName, properties)
                     : new MapPropertySource(sourceName, properties);


### PR DESCRIPTION
**Description**:

This PR fixes migrated environment variable to config property mapping

- Set property source name per spring's requirement

**Related issue(s)**:

Fixes #11169

**Notes for reviewer**:
The acceptance tests failed because though `HEDERA_MIRROR_WEB3_` env vars are migrated to `HIERO_MIRROR_WEB3_` env vars, spring wouldn't use the values in the migrated property source to bind the property to the configuration property beans, so the web3 module runs in mono mode though the acceptance tests expect it in mod mode.

Tested the fix with a custom web3 image in integration.

Wanted to write an integration test however there's no way to set an environment variable.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
