### PR TITLE
Deploy v0.129.1 to mainnet-na

### DIFF
--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.128.2'
+      version: '0.129.1'
   driftDetection:
     mode: enabled
     ignore:
@@ -26,7 +26,6 @@ spec:
   timeout: 10m
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
   valuesFrom:
     - kind: Secret
       name: mirror

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.128.2'
+      version: '0.129.1'
   dependsOn:
     - name: mirror
       namespace: common
@@ -109,5 +109,5 @@ spec:
     web3:
       env:
         HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
-        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "0.01"
+        HEDERA_MIRROR_WEB3_EVM_MODULARIZEDTRAFFICPERCENT: "0.25"
         HEDERA_MIRROR_WEB3_EVM_NETWORK: MAINNET

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -90,6 +90,11 @@ spec:
             pods:
               persistentVolume:
                 size: 550Gi
+        pgbouncer:
+          users:
+            mirror_web3:
+              max_user_client_connections: 800
+              max_user_connections: 250
         resources:
           cpu: 15750m
           memory: 82Gi


### PR DESCRIPTION
**Description**:

* Deploy v0.129.1 to mainnet-na
* Disable CRD replacement for common
* Increase modularized traffic to 25%
* Limit mirror_web3 connections

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
