### PR TITLE
Fix flaky rest tests

### DIFF
--- a/rest/__tests__/globalSetup.js
+++ b/rest/__tests__/globalSetup.js
@@ -44,8 +44,6 @@ const initializeFlyway = () => {
   }
 };
 
-export default async function (globalConfig, projectConfig) {
-  initializeFlyway();
-}
+export default initializeFlyway;
 
 export {FLYWAY_DATA_PATH, FLYWAY_EXE_PATH, FLYWAY_VERSION};

--- a/rest/__tests__/globalSetup.js
+++ b/rest/__tests__/globalSetup.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {execSync} from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const FLYWAY_DATA_PATH = path.join('.', 'build', 'flyway');
+const FLYWAY_EXE_PATH = path.join('.', 'node_modules', 'node-flywaydb', 'bin', 'flyway');
+const FLYWAY_VERSION = '11.8.2';
+
+const initializeFlyway = () => {
+  const flywayConfigPath = path.join(FLYWAY_DATA_PATH, `config_global.json`);
+  const flywayConfig = {
+    flywayArgs: {
+      url: 'jdbc:postgresql://127.0.0.1:-1/invalid',
+    },
+    version: FLYWAY_VERSION,
+    downloads: {
+      storageDirectory: FLYWAY_DATA_PATH,
+    },
+  };
+
+  fs.mkdirSync(FLYWAY_DATA_PATH, {recursive: true});
+  fs.writeFileSync(flywayConfigPath, JSON.stringify(flywayConfig));
+
+  let retries = 10;
+  while (retries-- > 0) {
+    try {
+      execSync(`node ${FLYWAY_EXE_PATH} -c ${flywayConfigPath} info`, {stdio: 'pipe'});
+      break;
+    } catch (e) {
+      const errMessage = e.stderr.toString();
+      if (errMessage.includes('-1 not valid')) {
+        console.log(e.stdout.toString());
+        break;
+      } else {
+        console.log(errMessage);
+      }
+    }
+  }
+
+  if (retries < 0) {
+    throw new Error('Failed to initialize flyway');
+  }
+};
+
+export default async function (globalConfig, projectConfig) {
+  initializeFlyway();
+}
+
+export {FLYWAY_DATA_PATH, FLYWAY_EXE_PATH, FLYWAY_VERSION};

--- a/rest/jest.config.js
+++ b/rest/jest.config.js
@@ -11,6 +11,7 @@ const config = {
     '<rootDir>/node_modules/',
     '<rootDir>/__tests__/',
   ],
+  globalSetup: './__tests__/globalSetup.js',
   globalTeardown: './__tests__/globalTeardown.js',
   maxWorkers,
   reporters: [['github-actions', {silent: false}], 'jest-junit', ['summary', {summaryThreshold: 0}]],


### PR DESCRIPTION
**Description**:

This PR fixes the flaky rest tests

- Move flyway initialization to globalSetup and do it only once
- Fail the whole test suite early if retries are exhausted
- Bump flyway jar to v11.8.2

**Related issue(s)**:

Fixes #10992 

**Notes for reviewer**:

We have separate storage directories for jest worker processes and for a fresh clone, each worker, when running the first integration test, will do `flyway migrate` and trigger the gzipped flyway jar downloading.

Sometimes, downloading the artifact just fails, then the database is left in a state without any of the tables we need, so we see a lot of `relation xxx doesn't exist` errors in integration tests.

The downside of the change is now we try to initialize flyway for all tests, even though the test doesn't need database / flyway.

Jest doesn't provide the list of test files to run in its global setup context, nor a function to get that list.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
