### PR TITLE
Fixing failing topic acceptance test (0.130)

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -36,7 +36,7 @@ import org.springframework.retry.support.RetryTemplate;
 @Named
 public class AccountClient extends AbstractNetworkClient {
 
-    private static final long DEFAULT_INITIAL_BALANCE = 50_000_000L; // 0.5 ℏ
+    private static final long DEFAULT_INITIAL_BALANCE = 75_000_000L; // 0.75 ℏ
 
     private final Map<AccountNameEnum, ExpandedAccountId> accountMap = new ConcurrentHashMap<>();
     private final Collection<ExpandedAccountId> accountIds = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
**Description**:
This PR changes the DEFAULT_INITIAL_BALANCE from 50_000_000 to 75_000_000 so that payer account in TopicFeature acceptance tests can have enough balance.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
