### PR TITLE
Optimize rest API resource management

### DIFF
--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -270,7 +270,7 @@ readinessProbe:
 resources:
   limits:
     cpu: 1100m
-    memory: 350Mi
+    memory: 600Mi
   requests:
     cpu: 700m
     memory: 64Mi

--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -16,12 +16,13 @@ RUN npm config set update-notifier false && \
     chown -R node:node .
 COPY --chown=node:node . ./
 
-# Install OS updates
+# Install OS updates, install wget, and use jemalloc
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y wget && \
+    apt-get install -y libjemalloc2 wget && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    echo /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 >> /etc/ld.so.preload
 USER node
 
 # Run

--- a/rest/monitoring/config/default.serverlist.json
+++ b/rest/monitoring/config/default.serverlist.json
@@ -58,7 +58,7 @@
     "limit": 2
   },
   "stateproof": {
-    "enabled": false,
+    "enabled": true,
     "intervalMultiplier": 10
   },
   "transaction": {

--- a/rest/monitoring/config/default.serverlist.json
+++ b/rest/monitoring/config/default.serverlist.json
@@ -58,7 +58,7 @@
     "limit": 2
   },
   "stateproof": {
-    "enabled": true,
+    "enabled": false,
     "intervalMultiplier": 10
   },
   "transaction": {

--- a/rest/s3client.js
+++ b/rest/s3client.js
@@ -2,6 +2,7 @@
 
 import {GetObjectCommand, S3} from '@aws-sdk/client-s3';
 import {NodeHttpHandler} from '@smithy/node-http-handler';
+import https from 'https';
 
 import config from './config';
 import {cloudProviders, defaultCloudProviderEndpoints} from './constants';
@@ -53,6 +54,9 @@ const buildS3ConfigFromStreamsConfig = () => {
   const endpoint = hasEndpointOverride ? endpointOverride : defaultCloudProviderEndpoints[cloudProvider];
   const forcePathStyle = hasEndpointOverride || isGCP;
   const requestHandler = new NodeHttpHandler({
+    httpsAgent: new https.Agent({
+      keepAlive: true,
+    }),
     connectionTimeout: httpOptions.connectTimeout,
     requestTimeout: httpOptions.timeout,
   });

--- a/tools/traffic-replay/README.md
+++ b/tools/traffic-replay/README.md
@@ -42,5 +42,14 @@ There are two simple steps. And step 2 can be repeated to replay the traffic wit
    ```bash
    $ gor --input-file demo-2024-10-05-gor.log --output-http http://localhost:8080
    ```
-   By default, goreplay doesn't show progress at all, if needed, add `--verbose 3` to show logs for each replayed
-   request.
+
+   Use `--stats --output-http-stats` to show the statistics every 5 seconds. The interval can be changed with
+   `--output-http-stats-ms`.
+   
+   Additional frequently used options:
+   
+   - `--input-file-loop` to loop the input(s) indefinitely
+   - Increase or decrease rate: add a percentage limiter after the replay filename, e.g., `"traffic.log|10%"` or
+     `"traffic.log|200%`
+
+   Please refer to the [Wiki](https://github.com/buger/goreplay/wiki) for more information.

--- a/tools/traffic-replay/README.md
+++ b/tools/traffic-replay/README.md
@@ -50,6 +50,6 @@ There are two simple steps. And step 2 can be repeated to replay the traffic wit
    
    - `--input-file-loop` to loop the input(s) indefinitely
    - Increase or decrease rate: add a percentage limiter after the replay filename, e.g., `"traffic.log|10%"` or
-     `"traffic.log|200%`
+     `"traffic.log|200%"`
 
    Please refer to the [Wiki](https://github.com/buger/goreplay/wiki) for more information.

--- a/tools/traffic-replay/README.md
+++ b/tools/traffic-replay/README.md
@@ -39,15 +39,16 @@ There are two simple steps. And step 2 can be repeated to replay the traffic wit
    Please refer to internal documentation for the available cluster filters.
 
 2. Replay the traffic using goreplay. Example usage:
+
    ```bash
    $ gor --input-file demo-2024-10-05-gor.log --output-http http://localhost:8080
    ```
 
    Use `--stats --output-http-stats` to show the statistics every 5 seconds. The interval can be changed with
    `--output-http-stats-ms`.
-   
+
    Additional frequently used options:
-   
+
    - `--input-file-loop` to loop the input(s) indefinitely
    - Increase or decrease rate: add a percentage limiter after the replay filename, e.g., `"traffic.log|10%"` or
      `"traffic.log|200%"`


### PR DESCRIPTION
**Description**:

This PR optimizes rest API resource management

- Use a lazily created singleton s3client in stateproof handler
- Use jemalloc in image for less memory fragmentation
- Simplify retrieving data from s3 `GetObjectOutput`
- Turn on http keep alive
- Increase rest pod memory limits to 600Mi
- Update traffic-replay README

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
