### PR TITLE
Fix unexpected changelog.md

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -13,11 +13,16 @@ changelog:
   sections:
     - title: "Enhancements"
       labels: ["enhancement", "epic"]
+      type: PULL_REQUEST
     - title: "Bug Fixes"
       labels: ["bug"]
+      type: PULL_REQUEST
     - title: "Documentation"
       labels: ["documentation"]
+      type: PULL_REQUEST
     - title: "Dependency Upgrades"
       labels: ["dependencies"]
+      type: PULL_REQUEST
     - title: "Deployments"
       labels: ["deploy"]
+      type: PULL_REQUEST

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Create Release Notes
         if: ${{ steps.version_parser.outputs.prerelease == '' }}
-        uses: spring-io/github-changelog-generator@86958813a62af8fb223b3fd3b5152035504bcb83 # v0.0.12
+        uses: spring-io/github-changelog-generator@925ed0a45f3ede77449f704b628fbb77b4178a90 # v0.0.13-SNAPSHOT
         with:
           config-file: .github/release-notes.yml
           milestone: ${{ steps.version_parser.outputs.release }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Chart.lock
 /data/
 /db/
 *.log
+changelog.md
 
 ### VisualStudioCode ###
 .vscode/


### PR DESCRIPTION
**Description**:

* Ignore `changelog.md` generated by github-changelog-generator action during release
* Update `github-changelog-generator` to include only PRs in output after my upstream enhancement

**Related issue(s)**:

Fixes #111232

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
