### PR TITLE
Add user connection limit to pgbouncer

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -337,6 +337,12 @@ stackgres:
           pool_mode: session
         mirror_importer:
           pool_mode: session
+        mirror_rest:
+          max_user_client_connections: 1000
+          max_user_connections: 250
+        mirror_web3:
+          max_user_client_connections: 1000
+          max_user_connections: 250
     resources:
       cpu: 100m
       memory: 1Gi


### PR DESCRIPTION
**Description**:

This PR adds user connection limit for `mirror_rest` and `mirror_web3` to pgbouncer.

**Related issue(s)**:

Fixes #11080

**Notes for reviewer**:

The limit for `mirror_rest` should be far than enough per current prod traffic, though the max server connection during performance test is way higher than 250.

The default values for both config properties are 0, so for staging, we can override to remove the limit. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
