### PR TITLE
Add integration tests for Schedule token create with smart contract

### DIFF
--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -99,6 +99,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final BigInteger DEFAULT_FEE_MIN_VALUE = BigInteger.valueOf(1L);
     protected static final BigInteger DEFAULT_FEE_MAX_VALUE = BigInteger.valueOf(1000L);
     protected static final String ED_25519 = "Ed25519";
+    protected static final BigInteger DEFAULT_WEI_VALUE = BigInteger.ZERO;
 
     @Resource
     protected TestWeb3jService testWeb3jService;

--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -99,7 +99,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected static final BigInteger DEFAULT_FEE_MIN_VALUE = BigInteger.valueOf(1L);
     protected static final BigInteger DEFAULT_FEE_MAX_VALUE = BigInteger.valueOf(1000L);
     protected static final String ED_25519 = "Ed25519";
-    protected static final BigInteger DEFAULT_WEI_VALUE = BigInteger.ZERO;
+    protected static final BigInteger DEFAULT_TINYBAR_VALUE = BigInteger.ZERO;
 
     @Resource
     protected TestWeb3jService testWeb3jService;

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
@@ -194,8 +194,8 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
         }
 
         // When
-        final var functionCall = contract.send_nftNAmountAirdrops(nfts, senders, receivers, serials,
-                DEFAULT_TINYBAR_VALUE);
+        final var functionCall =
+                contract.send_nftNAmountAirdrops(nfts, senders, receivers, serials, DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -508,7 +508,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                         getAddressFromEntity(sender),
                         receiverContractAddress,
                         DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_TINYBAR_VALUE)
+                        DEFAULT_TINYBAR_VALUE)
                 : contract.send_nftAirdrop(
                         tokenAddress,
                         getAddressFromEntity(sender),

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
@@ -39,7 +39,6 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
 class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceTest {
 
-    private static final BigInteger DEFAULT_WEI_VALUE = BigInteger.ZERO;
     private static final BigInteger DEFAULT_DEPLOYED_CONTRACT_BALANCE = BigInteger.valueOf(100_000_000L);
     private static final BigInteger DEPLOYED_BALANCE_1_BILLION = BigInteger.valueOf(1_000_000_000L);
     private static final BigInteger DEPLOYED_BALANCE_10_BILLION = BigInteger.valueOf(10_000_000_000L);

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAirdropSystemContractTest.java
@@ -110,7 +110,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 toAddress(receiver).toHexString(),
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -134,7 +134,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 toAddress(receiver).toHexString(),
                 DEFAULT_SERIAL_NUMBER,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -163,7 +163,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
 
         // When
         final var functionCall = contract.send_tokenNAmountAirdrops(
-                tokens, senders, receivers, DEFAULT_TOKEN_AIRDROP_AMOUNT, DEFAULT_WEI_VALUE);
+                tokens, senders, receivers, DEFAULT_TOKEN_AIRDROP_AMOUNT, DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -194,7 +194,8 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
         }
 
         // When
-        final var functionCall = contract.send_nftNAmountAirdrops(nfts, senders, receivers, serials, DEFAULT_WEI_VALUE);
+        final var functionCall = contract.send_nftNAmountAirdrops(nfts, senders, receivers, serials,
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -249,7 +250,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 nftReceivers,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
                 serials,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -356,7 +357,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 receivers,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
                 serials,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -391,7 +392,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 receiverContractAddress,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -421,7 +422,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 receiverContractAddress,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -473,7 +474,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 receiverContractAddress,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -507,13 +508,13 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                         getAddressFromEntity(sender),
                         receiverContractAddress,
                         DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                        DEFAULT_WEI_VALUE)
+                DEFAULT_TINYBAR_VALUE)
                 : contract.send_nftAirdrop(
                         tokenAddress,
                         getAddressFromEntity(sender),
                         receiverContractAddress,
                         BigInteger.ONE,
-                        DEFAULT_WEI_VALUE);
+                        DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -552,7 +553,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 receivers,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -677,7 +678,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
 
         // When
         final var functionCall = contract.send_nftAirdropDistribute(
-                nftAddress, getAddressFromEntity(sender), receivers, DEFAULT_WEI_VALUE);
+                nftAddress, getAddressFromEntity(sender), receivers, DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCall(functionCall, contract);
@@ -784,7 +785,7 @@ class ContractCallAirdropSystemContractTest extends AbstractContractCallServiceT
                 getAddressFromEntity(sender),
                 receiverContractAddress,
                 DEFAULT_TOKEN_AIRDROP_AMOUNT,
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
 
         // Then
         verifyContractCallWithException(functionCall);

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallScheduleTokenCreateTests.java
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.service;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hiero.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TokenSupplyType;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
+import com.hedera.hapi.node.token.TokenCreateTransactionBody;
+import com.hedera.node.app.hapi.utils.CommonPbjConverters;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.math.BigInteger;
+import org.hiero.mirror.common.domain.entity.Entity;
+import org.hiero.mirror.common.domain.entity.EntityId;
+import org.hiero.mirror.common.domain.entity.EntityType;
+import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
+import org.hiero.mirror.web3.web3j.generated.GetScheduleInfo;
+import org.hiero.mirror.web3.web3j.generated.HIP756Contract;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * This test class validates the correct results for schedule create token transactions via smart contract calls.
+ */
+class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHistoricalTest {
+
+
+    @Test
+    void scheduleCreateFungibleTokenTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+
+        final var sendFunction = contract.send_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void scheduleCreateFungibleTokenWithDesignatedPayerTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+        final var designatedPayer = accountEntityPersist();
+
+        final var sendFunction = contract.send_scheduleCreateFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer), BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void scheduleCreateNonFungibleTokenTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+
+        final var sendFunction = contract.send_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void scheduleCreateNonFungibleTokenWithDesignatedPayerTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+        final var designatedPayer = accountEntityPersist();
+
+        final var sendFunction = contract.send_scheduleCreateNFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer), BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateNFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void scheduleUpdateTokenTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+        final var token = fungibleTokenPersistWithTreasuryAccount(treasury.toEntityId());
+
+        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAcc(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo");
+        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAcc(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo");
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+
+    @Test
+    void scheduleUpdateTokenDesignatedPayerTest() throws Exception {
+        final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
+        final var treasury = accountEntityPersist();
+        final var autoRenew = accountEntityPersist();
+        final var token = fungibleTokenPersistWithTreasuryAccount(treasury.toEntityId());
+        final var designatedPayer = accountEntityPersist();
+
+        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo", getAddressFromEntity(designatedPayer));
+        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo", getAddressFromEntity(designatedPayer));
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            verifyEthCallAndEstimateGas(sendFunction, contract);
+            final var callFunctionResult = callFunction.send();
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
+            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+        } else {
+            final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
+            assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
+        }
+    }
+}

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallGetScheduleInfoTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallGetScheduleInfoTest.java
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package org.hiero.mirror.web3.service;
+package org.hiero.mirror.web3.service.ScheduleTests;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -20,6 +20,7 @@ import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
+import org.hiero.mirror.web3.service.AbstractContractCallServiceHistoricalTest;
 import org.hiero.mirror.web3.web3j.generated.GetScheduleInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
@@ -1,30 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package org.hiero.mirror.web3.service;
+package org.hiero.mirror.web3.service.ScheduleTests;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hiero.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.hapi.node.base.AccountID;
-import com.hedera.hapi.node.base.Timestamp;
-import com.hedera.hapi.node.base.TokenSupplyType;
-import com.hedera.hapi.node.base.TokenType;
-import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
-import com.hedera.hapi.node.token.TokenCreateTransactionBody;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.math.BigInteger;
-import org.hiero.mirror.common.domain.entity.Entity;
-import org.hiero.mirror.common.domain.entity.EntityId;
-import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
-import org.hiero.mirror.web3.web3j.generated.GetScheduleInfo;
+import org.hiero.mirror.web3.service.AbstractContractCallServiceHistoricalTest;
 import org.hiero.mirror.web3.web3j.generated.HIP756Contract;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This test class validates the correct results for schedule create token transactions via smart contract calls.

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
@@ -19,21 +19,27 @@ import org.junit.jupiter.api.Test;
  */
 class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHistoricalTest {
 
-
     @Test
     void scheduleCreateFungibleTokenTest() throws Exception {
         final var contract = testWeb3jService.deploy(HIP756Contract::deploy);
         final var treasury = accountEntityPersist();
         final var autoRenew = accountEntityPersist();
 
-        final var sendFunction = contract.send_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
-        final var callFunction = contract.call_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
+        final var sendFunction = contract.send_scheduleCreateFT(
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+        final var callFunction =
+                contract.call_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -47,14 +53,24 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
         final var designatedPayer = accountEntityPersist();
 
-        final var sendFunction = contract.send_scheduleCreateFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer), BigInteger.valueOf(0));
-        final var callFunction = contract.call_scheduleCreateFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
+        final var sendFunction = contract.send_scheduleCreateFTWithDesignatedPayer(
+                getAddressFromEntity(autoRenew),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(designatedPayer),
+                BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateFTWithDesignatedPayer(
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -67,14 +83,21 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var treasury = accountEntityPersist();
         final var autoRenew = accountEntityPersist();
 
-        final var sendFunction = contract.send_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
-        final var callFunction = contract.call_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
+        final var sendFunction = contract.send_scheduleCreateNFT(
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+        final var callFunction =
+                contract.call_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -88,14 +111,24 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
         final var designatedPayer = accountEntityPersist();
 
-        final var sendFunction = contract.send_scheduleCreateNFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer), BigInteger.valueOf(0));
-        final var callFunction = contract.call_scheduleCreateNFTWithDesignatedPayer(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
+        final var sendFunction = contract.send_scheduleCreateNFTWithDesignatedPayer(
+                getAddressFromEntity(autoRenew),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(designatedPayer),
+                BigInteger.valueOf(0));
+        final var callFunction = contract.call_scheduleCreateNFTWithDesignatedPayer(
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -109,14 +142,31 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
         final var token = fungibleTokenPersistWithTreasuryAccount(treasury.toEntityId());
 
-        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAcc(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo");
-        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAcc(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo");
+        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAcc(
+                toAddress(token.getTokenId()).toHexString(),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(autoRenew),
+                token.getName(),
+                "FUNG",
+                "Memo");
+        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAcc(
+                toAddress(token.getTokenId()).toHexString(),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(autoRenew),
+                token.getName(),
+                "FUNG",
+                "Memo");
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -131,14 +181,33 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var token = fungibleTokenPersistWithTreasuryAccount(treasury.toEntityId());
         final var designatedPayer = accountEntityPersist();
 
-        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo", getAddressFromEntity(designatedPayer));
-        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(toAddress(token.getTokenId()).toHexString(), getAddressFromEntity(treasury), getAddressFromEntity(autoRenew), token.getName(), "FUNG", "Memo", getAddressFromEntity(designatedPayer));
+        final var sendFunction = contract.send_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(
+                toAddress(token.getTokenId()).toHexString(),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(autoRenew),
+                token.getName(),
+                "FUNG",
+                "Memo",
+                getAddressFromEntity(designatedPayer));
+        final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(
+                toAddress(token.getTokenId()).toHexString(),
+                getAddressFromEntity(treasury),
+                getAddressFromEntity(autoRenew),
+                token.getName(),
+                "FUNG",
+                "Memo",
+                getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the format and the status of the result
-            assertThat(callFunctionResult.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
+            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+            // format and the status of the result
+            assertThat(callFunctionResult.component1())
+                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+            assertThat(callFunctionResult.component2())
+                    .startsWith("0x")
+                    .hasSize(42)
+                    .matches("^0x[0-9a-fA-F]+$");
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
@@ -19,9 +19,6 @@ import org.junit.jupiter.api.Test;
  * This test class validates the correct results for schedule create token transactions via smart contract calls.
  */
 class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHistoricalTest {
-    private final String PREFIX = "0x";
-    private final String SCHEDULE_ADDRESS_REGEX = "^0x[0-9a-fA-F]+$";
-    private final int SCHEDULE_ADDRESS_LENGTH = 42;
 
     @Test
     void scheduleCreateFungibleTokenTest() throws Exception {
@@ -36,14 +33,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -67,14 +57,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -94,14 +77,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -125,14 +101,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -163,14 +132,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -204,17 +166,17 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
-            // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
-            // format and the status of the result
-            assertThat(callFunctionResult.component1())
-                    .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
-            assertThat(callFunctionResult.component2())
-                    .startsWith(PREFIX)
-                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
-                    .matches(SCHEDULE_ADDRESS_REGEX);
+            verifyCallFunctionResult(callFunctionResult);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
         }
+    }
+
+    protected void verifyCallFunctionResult(final org.web3j.tuples.generated.Tuple2<BigInteger, String> functionCall) {
+        // Because we perform eth_call, we cannot validate if the scheduleId is valid or not, we only check the
+        // format and the status of the result
+        assertThat(functionCall.component1()).isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
+        assertThat(functionCall.component2()).startsWith("0x").hasSize(42).matches("^0x[0-9a-fA-F]+$");
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.service.AbstractContractCallServiceHistoricalTest;
 import org.hiero.mirror.web3.web3j.generated.HIP756Contract;
@@ -18,6 +19,9 @@ import org.junit.jupiter.api.Test;
  * This test class validates the correct results for schedule create token transactions via smart contract calls.
  */
 class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHistoricalTest {
+    private final String PREFIX = "0x";
+    private final String SCHEDULE_ADDRESS_REGEX = "^0x[0-9a-fA-F]+$";
+    private final int SCHEDULE_ADDRESS_LENGTH = 42;
 
     @Test
     void scheduleCreateFungibleTokenTest() throws Exception {
@@ -26,7 +30,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
 
         final var sendFunction = contract.send_scheduleCreateFT(
-                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_WEI_VALUE);
         final var callFunction =
                 contract.call_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -37,9 +41,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -57,7 +61,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(autoRenew),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(designatedPayer),
-                BigInteger.valueOf(0));
+                DEFAULT_WEI_VALUE);
         final var callFunction = contract.call_scheduleCreateFTWithDesignatedPayer(
                 getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -68,9 +72,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -84,7 +88,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
 
         final var sendFunction = contract.send_scheduleCreateNFT(
-                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), BigInteger.valueOf(0));
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_WEI_VALUE);
         final var callFunction =
                 contract.call_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -95,9 +99,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -115,7 +119,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(autoRenew),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(designatedPayer),
-                BigInteger.valueOf(0));
+                DEFAULT_WEI_VALUE);
         final var callFunction = contract.call_scheduleCreateNFTWithDesignatedPayer(
                 getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -126,9 +130,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -147,15 +151,15 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(autoRenew),
                 token.getName(),
-                "FUNG",
-                "Memo");
+                token.getSymbol(),
+                new String(token.getMetadata(), StandardCharsets.UTF_8));
         final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAcc(
                 toAddress(token.getTokenId()).toHexString(),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(autoRenew),
                 token.getName(),
-                "FUNG",
-                "Memo");
+                token.getName(),
+                new String(token.getMetadata(), StandardCharsets.UTF_8));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
             final var callFunctionResult = callFunction.send();
@@ -164,9 +168,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());
@@ -186,16 +190,16 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(autoRenew),
                 token.getName(),
-                "FUNG",
-                "Memo",
+                token.getName(),
+                new String(token.getMetadata(), StandardCharsets.UTF_8),
                 getAddressFromEntity(designatedPayer));
         final var callFunction = contract.call_scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(
                 toAddress(token.getTokenId()).toHexString(),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(autoRenew),
                 token.getName(),
-                "FUNG",
-                "Memo",
+                token.getName(),
+                new String(token.getMetadata(), StandardCharsets.UTF_8),
                 getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
             verifyEthCallAndEstimateGas(sendFunction, contract);
@@ -205,9 +209,9 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
             assertThat(callFunctionResult.component1())
                     .isEqualTo(BigInteger.valueOf(ResponseCodeEnum.SUCCESS.getNumber()));
             assertThat(callFunctionResult.component2())
-                    .startsWith("0x")
-                    .hasSize(42)
-                    .matches("^0x[0-9a-fA-F]+$");
+                    .startsWith(PREFIX)
+                    .hasSize(SCHEDULE_ADDRESS_LENGTH)
+                    .matches(SCHEDULE_ADDRESS_REGEX);
         } else {
             final var exception = assertThrows(MirrorEvmTransactionException.class, sendFunction::send);
             assertThat(exception.getMessage()).isEqualTo(CONTRACT_REVERT_EXECUTED.protoName());

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallScheduleTokenCreateTests.java
@@ -27,7 +27,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
 
         final var sendFunction = contract.send_scheduleCreateFT(
-                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_WEI_VALUE);
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_TINYBAR_VALUE);
         final var callFunction =
                 contract.call_scheduleCreateFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -51,7 +51,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(autoRenew),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(designatedPayer),
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
         final var callFunction = contract.call_scheduleCreateFTWithDesignatedPayer(
                 getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -71,7 +71,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
         final var autoRenew = accountEntityPersist();
 
         final var sendFunction = contract.send_scheduleCreateNFT(
-                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_WEI_VALUE);
+                getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), DEFAULT_TINYBAR_VALUE);
         final var callFunction =
                 contract.call_scheduleCreateNFT(getAddressFromEntity(autoRenew), getAddressFromEntity(treasury));
         if (mirrorNodeEvmProperties.isModularizedServices()) {
@@ -95,7 +95,7 @@ class ContractCallScheduleTokenCreateTests extends AbstractContractCallServiceHi
                 getAddressFromEntity(autoRenew),
                 getAddressFromEntity(treasury),
                 getAddressFromEntity(designatedPayer),
-                DEFAULT_WEI_VALUE);
+                DEFAULT_TINYBAR_VALUE);
         final var callFunction = contract.call_scheduleCreateNFTWithDesignatedPayer(
                 getAddressFromEntity(autoRenew), getAddressFromEntity(treasury), getAddressFromEntity(designatedPayer));
         if (mirrorNodeEvmProperties.isModularizedServices()) {

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallSignScheduleTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallSignScheduleTest.java
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package org.hiero.mirror.web3.service;
+package org.hiero.mirror.web3.service.ScheduleTests;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -30,6 +30,7 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.domain.schedule.Schedule;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
+import org.hiero.mirror.web3.service.AbstractContractCallServiceTest;
 import org.hiero.mirror.web3.web3j.generated.HRC755Contract;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;

--- a/web3/src/test/solidity/HIP756Contract.sol
+++ b/web3/src/test/solidity/HIP756Contract.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+
+import "./HederaScheduleService.sol";
+import "./HederaTokenService.sol";
+import "./HederaResponseCodes.sol";
+import "./KeyHelper.sol";
+pragma experimental ABIEncoderV2;
+
+contract HIP756Contract is HederaScheduleService, KeyHelper {
+
+    function scheduleCreateFT(address autoRenew, address treasury) external payable returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.treasury = treasury;
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenew;
+        token.expiry = expiry;
+
+        token.name = "test";
+        token.symbol = "TTT";
+
+        bytes memory tokenCreateBytes = abi.encodeWithSelector(IHederaTokenService.createFungibleToken.selector, token, 1000, 10);
+        (responseCode, scheduleAddress) = scheduleNative( address(0x167), tokenCreateBytes, address(this));
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert("Failed to associate");
+        }
+    }
+
+    function scheduleCreateFTWithDesignatedPayer(address autoRenew, address treasury, address payer) external payable returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.treasury = treasury;
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenew;
+        token.expiry = expiry;
+
+        token.name = "test with designated payer";
+        token.symbol = "TTTP";
+
+        bytes memory tokenCreateBytes = abi.encodeWithSelector(IHederaTokenService.createFungibleToken.selector, token, 1000, 10);
+        (responseCode, scheduleAddress) = scheduleNative( address(0x167), tokenCreateBytes, payer);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert("Failed to associate");
+        }
+    }
+
+    function scheduleCreateNFT(address autoRenew, address treasury) external payable returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.name = "nft";
+        token.symbol = "nft";
+        token.treasury = address(treasury);
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenew;
+        token.expiry = expiry;
+        token.tokenKeys = new IHederaTokenService.TokenKey[](1);
+        IHederaTokenService.TokenKey memory tokenSupplyKey = KeyHelper.getSingleKey(4, 2, address(this));
+        token.tokenKeys[0] = tokenSupplyKey;
+        bytes memory tokenCreateBytes = abi.encodeWithSelector(IHederaTokenService.createNonFungibleToken.selector, token);
+        (responseCode, scheduleAddress) = scheduleNative(address(0x167), tokenCreateBytes, address(this));
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+    }
+
+    function scheduleCreateNFTWithDesignatedPayer(
+        address autoRenew,
+        address treasury,
+        address payer) external payable returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.name = "nft with designated payer";
+        token.symbol = "nftp";
+        token.treasury = address(treasury);
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenew;
+        token.expiry = expiry;
+        token.tokenKeys = new IHederaTokenService.TokenKey[](1);
+        IHederaTokenService.TokenKey memory tokenSupplyKey = KeyHelper.getSingleKey(4, 2, address(this));
+        token.tokenKeys[0] = tokenSupplyKey;
+        bytes memory tokenCreateBytes = abi.encodeWithSelector(IHederaTokenService.createNonFungibleToken.selector, token);
+        (responseCode, scheduleAddress) = scheduleNative(address(0x167), tokenCreateBytes, payer);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+    }
+
+    function scheduleUpdateTreasuryAndAutoRenewAcc(
+        address tokenAddress,
+        address treasuryAddress,
+        address autoRenewAddress,
+        string memory name,
+        string memory symbol,
+        string memory memo) external returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.name = name;
+        token.symbol = symbol;
+        token.treasury = treasuryAddress;
+        token.memo = memo;
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenewAddress;
+        token.expiry = expiry;
+
+        bytes memory tokenUpdateBytes = abi.encodeWithSelector(IHederaTokenService.updateTokenInfo.selector, tokenAddress, token);
+        (responseCode, scheduleAddress) = scheduleNative(address(0x167), tokenUpdateBytes, address(this));
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ("Update of tokenInfo.treasury failed!");
+        }
+    }
+
+    function scheduleUpdateTreasuryAndAutoRenewAccWithDesignatedPayer(address tokenAddress, address treasuryAddress, address autoRenewAddress, string memory name, string memory symbol, string memory memo, address designatedPayer) external returns (int64 responseCode, address scheduleAddress) {
+        IHederaTokenService.HederaToken memory token;
+        token.name = name;
+        token.symbol = symbol;
+        token.treasury = treasuryAddress;
+        token.memo = memo;
+        IHederaTokenService.Expiry memory expiry;
+        expiry.autoRenewAccount = autoRenewAddress;
+        token.expiry = expiry;
+
+        bytes memory tokenUpdateBytes = abi.encodeWithSelector(IHederaTokenService.updateTokenInfo.selector, tokenAddress, token);
+        (responseCode, scheduleAddress) = scheduleNative(address(0x167), tokenUpdateBytes, designatedPayer);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ("Update of tokenInfo.treasury failed!");
+        }
+    }
+}

--- a/web3/src/test/solidity/HederaTokenService.sol
+++ b/web3/src/test/solidity/HederaTokenService.sol
@@ -10,6 +10,14 @@ abstract contract HederaTokenService {
     // 90 days in seconds
     int32 constant defaultAutoRenewPeriod = 7776000;
 
+    uint constant ADMIN_KEY_TYPE = 1;
+    uint constant KYC_KEY_TYPE = 2;
+    uint constant FREEZE_KEY_TYPE = 4;
+    uint constant WIPE_KEY_TYPE = 8;
+    uint constant SUPPLY_KEY_TYPE = 16;
+    uint constant FEE_SCHEDULE_KEY_TYPE = 32;
+    uint constant PAUSE_KEY_TYPE = 64;
+
     modifier nonEmptyExpiry(IHederaTokenService.HederaToken memory token)
     {
         if (token.expiry.second == 0 && token.expiry.autoRenewPeriod == 0) {
@@ -743,6 +751,13 @@ abstract contract HederaTokenService {
     function rejectTokens(address rejectingAddress, address[] memory ftAddresses, IHederaTokenService.NftID[] memory nftIds) internal returns (int64 responseCode) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.rejectTokens.selector, rejectingAddress, ftAddresses, nftIds)
+        );
+        (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    function updateNFTsMetadata(address nftToken, int64[] memory serialNumbers, bytes memory metadata) external returns (int64 responseCode) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.updateNFTsMetadata.selector, nftToken, serialNumbers, metadata)
         );
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }

--- a/web3/src/test/solidity/IHederaTokenService.sol
+++ b/web3/src/test/solidity/IHederaTokenService.sol
@@ -868,4 +868,6 @@ interface IHederaTokenService {
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     function rejectTokens(address rejectingAddress, address[] memory ftAddresses, NftID[] memory nftIDs) external returns (int64 responseCode);
 
+
+    function updateNFTsMetadata(address nftToken, int64[] memory serialNumbers, bytes memory metadata) external returns (int64 responseCode);
 }

--- a/web3/src/test/solidity/KeyHelper.sol
+++ b/web3/src/test/solidity/KeyHelper.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+
+contract KeyHelper is HederaTokenService {
+
+    using Bits for uint;
+    address supplyContract;
+
+    function getDefaultKeys() internal view returns (IHederaTokenService.TokenKey[] memory keys) {
+        keys = new IHederaTokenService.TokenKey[](2);
+        keys[0] = getSingleKey(1, 1, "");
+        keys[1] = IHederaTokenService.TokenKey (getDuplexKeyType(4, 6), getKeyValueType(2, ""));
+    }
+
+    function getAllTypeKeys(uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.TokenKey[] memory keys) {
+        keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = IHederaTokenService.TokenKey (getAllKeyTypes(), getKeyValueType(keyValueType, key));
+    }
+
+    function getCustomSingleTypeKeys(uint8 keyType, uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.TokenKey[] memory keys) {
+        keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = IHederaTokenService.TokenKey (getKeyType(keyType), getKeyValueType(keyValueType, key));
+    }
+
+    function getCustomDuplexTypeKeys(uint8 firstType, uint8 secondType, uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.TokenKey[] memory keys) {
+        keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = IHederaTokenService.TokenKey (getDuplexKeyType(firstType, secondType), getKeyValueType(keyValueType, key));
+    }
+
+    function getSingleKey(uint8 keyType, uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.TokenKey memory tokenKey) {
+        tokenKey =  IHederaTokenService.TokenKey (getKeyType(keyType), getKeyValueType(keyValueType, key));
+    }
+
+    function getSingleKey(uint8 keyType, uint8 keyValueType, address key) internal view returns (IHederaTokenService.TokenKey memory tokenKey) {
+        tokenKey =  IHederaTokenService.TokenKey (getKeyType(keyType), getKeyValueType(keyValueType, key));
+    }
+
+    function getSingleKey(uint8 firstType, uint8 secondType, uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.TokenKey memory tokenKey) {
+        tokenKey =  IHederaTokenService.TokenKey (getDuplexKeyType(firstType, secondType), getKeyValueType(keyValueType, key));
+    }
+
+    function getDuplexKeyType(uint8 firstType, uint8 secondType) internal pure returns (uint keyType) {
+        keyType = keyType.setBit(firstType);
+        keyType = keyType.setBit(secondType);
+    }
+
+    function getAllKeyTypes() internal pure returns (uint keyType) {
+        keyType = keyType.setBit(0);
+        keyType = keyType.setBit(1);
+        keyType = keyType.setBit(2);
+        keyType = keyType.setBit(3);
+        keyType = keyType.setBit(4);
+        keyType = keyType.setBit(5);
+        keyType = keyType.setBit(6);
+    }
+
+    function getKeyType(uint8 keyType) internal pure returns (uint) {
+        if (keyType == 0) {
+            return HederaTokenService.ADMIN_KEY_TYPE;
+        } else if(keyType == 1) {
+            return HederaTokenService.KYC_KEY_TYPE;
+        } else if(keyType == 2) {
+            return HederaTokenService.FREEZE_KEY_TYPE;
+        } else if(keyType == 3) {
+            return HederaTokenService.WIPE_KEY_TYPE;
+        } else if(keyType == 4) {
+            return HederaTokenService.SUPPLY_KEY_TYPE;
+        } else if(keyType == 5) {
+            return HederaTokenService.FEE_SCHEDULE_KEY_TYPE;
+        } else if(keyType == 6) {
+            return HederaTokenService.PAUSE_KEY_TYPE;
+        }
+
+        return 0;
+    }
+
+    function getKeyValueType(uint8 keyValueType, bytes memory key) internal view returns (IHederaTokenService.KeyValue memory keyValue) {
+        if(keyValueType == 1) {
+            keyValue.inheritAccountKey = true;
+        } else if(keyValueType == 2) {
+            keyValue.contractId = supplyContract;
+        } else if(keyValueType == 3) {
+            keyValue.ed25519 = key;
+        } else if(keyValueType == 4) {
+            keyValue.ECDSA_secp256k1 = key;
+        } else if(keyValueType == 5) {
+            keyValue.delegatableContractId = supplyContract;
+        }
+    }
+
+    function getKeyValueType(uint8 keyValueType, address keyAddress) internal view returns (IHederaTokenService.KeyValue memory keyValue) {
+        if (keyValueType == 2) {
+            keyValue.contractId = keyAddress;
+        } else if(keyValueType == 5) {
+            keyValue.delegatableContractId = keyAddress;
+        }
+    }
+}
+
+library Bits {
+
+    uint constant internal ONE = uint(1);
+
+    // Sets the bit at the given 'index' in 'self' to '1'.
+    // Returns the modified value.
+    function setBit(uint self, uint8 index) internal pure returns (uint) {
+        return self | ONE << index;
+    }
+}


### PR DESCRIPTION
This PR adds additional tests related to modularized EVM for Schedule Create token via smart contract. The schedule tests are grouped in a common folder called ScheduleTests for better readability.

The solidity files for the contracts are directly copied from the consensus node repository. 

**Related issue(s)**:

Fixes #10929 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
