### PR TITLE
Fix failing acceptance test in testnet

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -2135,7 +2135,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @RequiredArgsConstructor
     enum ContractMethodsModularizedServices implements ContractMethodInterface {
         TRANSFER_NFT("transferNFTExternal", 41571),
-        ASSOCIATE_TOKENS("associateTokensExternal", 1436847),
+        ASSOCIATE_TOKENS("associateTokensExternal", 1336847),
         CRYPTO_TRANSFER_NFT("cryptoTransferExternal", 47372),
         GET_TOKEN_EXPIRY_INFO("getTokenExpiryInfoExternal", 28607),
         IS_TOKEN("isTokenExternal", 27977),

--- a/web3/src/test/resources/config/application.yml
+++ b/web3/src/test/resources/config/application.yml
@@ -13,8 +13,6 @@ hiero:
           150: 0.46.0
           200: 0.50.0
         network: OTHER
-        modularizedServices: true
-        modularizedTrafficPercent: 1.0
       opcode:
         tracer:
           enabled: true

--- a/web3/src/test/resources/config/application.yml
+++ b/web3/src/test/resources/config/application.yml
@@ -13,6 +13,8 @@ hiero:
           150: 0.46.0
           200: 0.50.0
         network: OTHER
+        modularizedServices: true
+        modularizedTrafficPercent: 1.0
       opcode:
         tracer:
           enabled: true


### PR DESCRIPTION
There was a failing acceptance test on TESTNET in estimatePrecompile.feature -` I call estimateGas with associateTokens function for fungible tokens`, due to the gas calculation result. 
This PR changes the actual gas that we pass as a Gas limit for the call

**Related issue(s)**:

Fixes #11327 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
