### PR TITLE
Fix cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,10 +3,6 @@
 name: Cleanup
 
 on:
-  push:
-    branches:
-      - fix-cleanup-workflow
-
   schedule:
     - cron: "0 0 * * *" # Daily at midnight
 
@@ -44,6 +40,8 @@ jobs:
         with:
           egress-policy: audit
 
+      # Instead of checking out the code which is completely unnecessary, create the workspace folder,
+      # and ./git.info/exclude, required by google-github-auth
       - name: Create Workspace
         run: mkdir -p "${{ github.workspace }}/.git/info" && touch "${{ github.workspace }}/.git/info/exclude"
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -45,7 +45,7 @@ jobs:
           egress-policy: audit
 
       - name: Create Workspace
-        run: mkdir -p "${{ github.workspace }}"
+        run: mkdir -p "${{ github.workspace }}/dummy"
 
       - name: Authenticate to Google Cloud
         uses: step-security/google-github-auth@40f6deebd366f16c782d7a0ad0844e3b96a032a6 # v2.1.10

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -45,7 +45,7 @@ jobs:
           egress-policy: audit
 
       - name: Create Workspace
-        run: mkdir -p "${{ github.workspace }}/dummy"
+        run: mkdir -p "${{ github.workspace }}/.git/info" && touch "${{ github.workspace }}/.git/info/exclude"
 
       - name: Authenticate to Google Cloud
         uses: step-security/google-github-auth@40f6deebd366f16c782d7a0ad0844e3b96a032a6 # v2.1.10

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,6 +3,10 @@
 name: Cleanup
 
 on:
+  push:
+    branches:
+      - fix-cleanup-workflow
+
   schedule:
     - cron: "0 0 * * *" # Daily at midnight
 
@@ -39,6 +43,9 @@ jobs:
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
+      - name: Create Workspace
+        run: mkdir -p "${{ github.workspace }}"
 
       - name: Authenticate to Google Cloud
         uses: step-security/google-github-auth@40f6deebd366f16c782d7a0ad0844e3b96a032a6 # v2.1.10


### PR DESCRIPTION
**Description**

This PR fixes the cleanup workflow.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

After switching to workload identity provider auth for google-github-auth action, a non-empty workspace directory with `.git/info/exclude` are required because the action will update `.git/info/exclude` to exclude the temporary credentials file created in the workspace folder.

Instead of using `@actions/checkout` action, the fix plays tricks by creating the required folder and file.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
