### PR TITLE
Fix async java migration checksum tracking (0.131)

### DIFF
--- a/docs/checklist/release.md
+++ b/docs/checklist/release.md
@@ -11,6 +11,7 @@ This checklist verifies a release is rolled out successfully.
 - [ ] No pre-release or snapshot dependencies present in build files
 - [ ] Verify HAPI protobuf dependency doesn't contain any unsupported fields or messages
 - [ ] Automated Kubernetes deployment to integration successful
+- [ ] No abnormal exceptions in importer logs in integration since the first SNAPSHOT
 - [ ] Tag release
 
 ## Release Candidates
@@ -36,6 +37,7 @@ Deployed automatically on every tag.
 - [ ] Deployed
 - [ ] Helm Controller logs show successful reconciliation check
 - [ ] Helm release status is healthy
+- [ ] No abnormal exceptions in importer logs
 - [ ] REST API performance tests
 - [ ] REST Java API performance tests
 - [ ] Web3 API performance tests

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/AsyncJavaMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/AsyncJavaMigration.java
@@ -22,6 +22,11 @@ import reactor.core.scheduler.Schedulers;
 
 abstract class AsyncJavaMigration<T> extends RepeatableMigration {
 
+    private static final String ASYNC_JAVA_MIGRATION_HISTORY_FIXED =
+            """
+            select exists(select * from flyway_schema_history where version in ('1.109.0', '2.14.0'))
+            """;
+
     private static final String CHECK_FLYWAY_SCHEMA_HISTORY_EXISTENCE_SQL =
             """
             select exists(select * from information_schema.tables
@@ -31,14 +36,22 @@ abstract class AsyncJavaMigration<T> extends RepeatableMigration {
     private static final String SELECT_LAST_CHECKSUM_SQL =
             """
             select checksum from flyway_schema_history
-            where script = :className order by installed_rank desc limit 1
+            where description = :description
+            order by installed_rank desc limit 1
+            """;
+
+    private static final String SELECT_LAST_CHECKSUM_SQL_PRE_FIX =
+            """
+            select checksum from flyway_schema_history
+            where description = :description and script like 'com.hedera.%'
+            order by installed_rank desc limit 1
             """;
 
     private static final String UPDATE_CHECKSUM_SQL =
             """
             with last as (
               select installed_rank from flyway_schema_history
-              where script = :className order by installed_rank desc limit 1
+              where description = :description order by installed_rank desc limit 1
             )
             update flyway_schema_history f
             set checksum = :checksum,
@@ -75,14 +88,33 @@ abstract class AsyncJavaMigration<T> extends RepeatableMigration {
             return -1;
         }
 
-        Integer lastChecksum = queryForObjectOrNull(SELECT_LAST_CHECKSUM_SQL, getSqlParamSource(), Integer.class);
+        var params = getSqlParamSource();
+        var lastChecksum = queryForObjectOrNull(SELECT_LAST_CHECKSUM_SQL, params, Integer.class);
         if (lastChecksum == null) {
             return -1;
-        } else if (lastChecksum < 0) {
+        }
+
+        if (!isAsyncJavaMigrationHistoryFixed()) {
+            var lastChecksumPreRenaming = queryForObjectOrNull(SELECT_LAST_CHECKSUM_SQL_PRE_FIX, params, Integer.class);
+            if ((lastChecksumPreRenaming == null || lastChecksumPreRenaming < 0) && lastChecksum < 0) {
+                // when
+                // - the asynchronous migration did not complete before being renamed to org.hiero prefix, or did not
+                //   run at all
+                // - and the runs after renaming didn't complete either
+                // subtract the checksum by 1 as the return value so the migration continues
+                return lastChecksum - 1;
+            }
+
+            // migration history isn't fixed, return the same checksum so flyway will skip it
+            return lastChecksum;
+        }
+
+        if (lastChecksum < 0) {
             return lastChecksum - 1;
         } else if (lastChecksum != getSuccessChecksum()) {
             return -1;
         }
+
         return lastChecksum;
     }
 
@@ -165,13 +197,20 @@ abstract class AsyncJavaMigration<T> extends RepeatableMigration {
     protected abstract Optional<T> migratePartial(T last);
 
     private MapSqlParameterSource getSqlParamSource() {
-        return new MapSqlParameterSource().addValue("className", getClass().getName());
+        return new MapSqlParameterSource().addValue("description", getDescription());
     }
 
     private boolean hasFlywaySchemaHistoryTable() {
         var exists = namedParameterJdbcTemplate.queryForObject(
                 CHECK_FLYWAY_SCHEMA_HISTORY_EXISTENCE_SQL, Map.of("schema", schema), Boolean.class);
         return BooleanUtils.isTrue(exists);
+    }
+
+    private boolean isAsyncJavaMigrationHistoryFixed() {
+        var fixed = namedParameterJdbcTemplate
+                .getJdbcTemplate()
+                .queryForObject(ASYNC_JAVA_MIGRATION_HISTORY_FIXED, Boolean.class);
+        return BooleanUtils.isTrue(fixed);
     }
 
     private void onSuccess() {

--- a/importer/src/main/resources/db/migration/v1/V1.109.0__fix_async_java_migration_history.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.109.0__fix_async_java_migration_history.sql
@@ -1,0 +1,28 @@
+-- due to hiero migration, java migrations FQCN changed from com.hedera. prefix to org.hiero. prefix and caused
+-- issue in async java migration checksum query. As part of the fix, incorrect rows need to be removed
+with affected as (
+  select description
+  from flyway_schema_history
+  where type = 'JDBC' and version is null
+  group by description
+  having count(distinct script) = 2
+), incorrect as (
+  select description
+  from affected as a
+  where (
+    select checksum
+    from flyway_schema_history
+    where description = a.description and script like 'com.hedera.%'
+    order by installed_rank desc
+    limit 1
+  ) > 0 and (
+    select checksum
+    from flyway_schema_history
+    where description = a.description and script like 'org.hiero.%'
+    order by installed_rank desc
+    limit 1
+  ) < 0
+)
+delete from flyway_schema_history as f
+using incorrect as i
+where f.description = i.description and script like 'org.hiero.%';

--- a/importer/src/main/resources/db/migration/v2/V2.14.0__fix_async_java_migration_history.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.14.0__fix_async_java_migration_history.sql
@@ -1,0 +1,28 @@
+-- due to hiero migration, java migrations FQCN changed from com.hedera. prefix to org.hiero. prefix and caused
+-- issue in async java migration checksum query. As part of the fix, incorrect rows need to be removed
+with affected as (
+  select description
+  from flyway_schema_history
+  where type = 'JDBC' and version is null
+  group by description
+  having count(distinct script) = 2
+), incorrect as (
+  select description
+  from affected as a
+  where (
+    select checksum
+    from flyway_schema_history
+    where description = a.description and script like 'com.hedera.%'
+    order by installed_rank desc
+    limit 1
+  ) > 0 and (
+    select checksum
+    from flyway_schema_history
+    where description = a.description and script like 'org.hiero.%'
+    order by installed_rank desc
+    limit 1
+  ) < 0
+)
+delete from flyway_schema_history as f
+using incorrect as i
+where f.description = i.description and script like 'org.hiero.%';

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationBaseTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationBaseTest.java
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Resource;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.Value;
+import org.hiero.mirror.importer.ImporterIntegrationTest;
+import org.hiero.mirror.importer.db.DBProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.support.TransactionOperations;
+
+class AsyncJavaMigrationBaseTest extends ImporterIntegrationTest {
+
+    protected static final int ELAPSED = 20;
+    protected static final String SCRIPT = AsyncJavaMigrationBaseTest.TestAsyncJavaMigration.class.getName();
+    protected static final String SCRIPT_HEDERA = SCRIPT.replace("org.hiero.", "com.hedera.");
+    protected static final String TEST_MIGRATION_DESCRIPTION = "Async java migration for testing";
+
+    private static final DataClassRowMapper<MigrationHistory> MAPPER = new DataClassRowMapper<>(MigrationHistory.class);
+
+    @Resource
+    protected DBProperties dbProperties;
+
+    @Resource
+    protected NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Resource
+    protected TransactionOperations transactionOperations;
+
+    private final String script = AsyncJavaMigrationBaseTest.TestAsyncJavaMigration.class.getName();
+
+    @AfterEach
+    @BeforeEach
+    void cleanup() {
+        ownerJdbcTemplate.update("delete from flyway_schema_history where description = ?", TEST_MIGRATION_DESCRIPTION);
+    }
+
+    protected void addMigrationHistory(AsyncJavaMigrationBaseTest.MigrationHistory migrationHistory) {
+        if (migrationHistory.checksum() == null) {
+            return;
+        }
+
+        var paramSource = new MapSqlParameterSource()
+                .addValue("installedRank", migrationHistory.installedRank())
+                .addValue("description", TEST_MIGRATION_DESCRIPTION)
+                .addValue("script", migrationHistory.script())
+                .addValue("checksum", migrationHistory.checksum());
+        var sql =
+                """
+                insert into flyway_schema_history (installed_rank, description, type, script, checksum,
+                installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
+                :checksum, 20, 100, true)
+                """;
+        namedParameterJdbcTemplate.update(sql, paramSource);
+    }
+
+    protected List<AsyncJavaMigrationBaseTest.MigrationHistory> getAllMigrationHistory() {
+        return namedParameterJdbcTemplate.query(
+                """
+                        select installed_rank, checksum, execution_time, script
+                        from flyway_schema_history
+                        where description = :description
+                        order by installed_rank asc""",
+                Map.of("description", TEST_MIGRATION_DESCRIPTION),
+                MAPPER);
+    }
+
+    protected record MigrationHistory(Integer checksum, int executionTime, int installedRank, String script) {}
+
+    @Value
+    protected class TestAsyncJavaMigration extends AsyncJavaMigration<Long> {
+
+        private final boolean error;
+        private final long sleep;
+
+        public TestAsyncJavaMigration(boolean error, MigrationProperties migrationProperties, long sleep) {
+            super(
+                    Map.of("testAsyncJavaMigration", migrationProperties),
+                    AsyncJavaMigrationBaseTest.this.namedParameterJdbcTemplate,
+                    dbProperties.getSchema());
+            this.error = error;
+            this.sleep = sleep;
+        }
+
+        @Override
+        public String getDescription() {
+            return TEST_MIGRATION_DESCRIPTION;
+        }
+
+        @Nonnull
+        @Override
+        protected Optional<Long> migratePartial(final Long last) {
+            if (sleep > 0) {
+                Uninterruptibles.sleepUninterruptibly(sleep, TimeUnit.SECONDS);
+            }
+
+            if (error) {
+                throw new RuntimeException();
+            }
+
+            return Optional.empty();
+        }
+
+        @Override
+        protected TransactionOperations getTransactionOperations() {
+            return transactionOperations;
+        }
+
+        @Override
+        protected Long getInitial() {
+            return Long.MAX_VALUE;
+        }
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationPreFixTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationPreFixTest.java
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Profiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(initializers = AsyncJavaMigrationPreFixTest.Initializer.class)
+@Tag("migration")
+class AsyncJavaMigrationPreFixTest extends AsyncJavaMigrationBaseTest {
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+            , , -1
+            , -1, -2
+            , 1, 1
+            1, , 1
+            1, -1, -1
+            1, 1, 1
+            -1, , -2
+            -1, -1, -2
+            -1, 1, 1
+            """)
+    void getChecksum(Integer preRenamingChecksum, Integer postRenamingChecksum, int expected) {
+        // given
+        addMigrationHistory(new MigrationHistory(preRenamingChecksum, ELAPSED, 1000, SCRIPT_HEDERA));
+        addMigrationHistory(new MigrationHistory(postRenamingChecksum, ELAPSED, 1100, SCRIPT));
+        var migration = new TestAsyncJavaMigration(false, new MigrationProperties(), 1);
+
+        // when, then
+        assertThat(migration.getChecksum()).isEqualTo(expected);
+    }
+
+    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            var environment = configurableApplicationContext.getEnvironment();
+            String version = environment.acceptsProfiles(Profiles.of("v2")) ? "2.13.0" : "1.108.0";
+            TestPropertyValues.of("spring.flyway.target=" + version).applyTo(environment);
+        }
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/AsyncJavaMigrationTest.java
@@ -6,48 +6,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-import jakarta.annotation.Nonnull;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
-import org.hiero.mirror.importer.EnabledIfV1;
-import org.hiero.mirror.importer.ImporterIntegrationTest;
-import org.hiero.mirror.importer.db.DBProperties;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.transaction.support.TransactionOperations;
 
-@EnabledIfV1
 @RequiredArgsConstructor
 @Tag("migration")
-class AsyncJavaMigrationTest extends ImporterIntegrationTest {
+class AsyncJavaMigrationTest extends AsyncJavaMigrationBaseTest {
 
-    private static final int ELAPSED = 20;
-    private static final String TEST_MIGRATION_DESCRIPTION = "Async java migration for testing";
-
-    private final DBProperties dbProperties;
-    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-    private final TransactionOperations transactionOperations;
-    private final String script = TestAsyncJavaMigration.class.getName();
     private final Collection<AsyncJavaMigration<?>> asyncMigrations;
-
-    @AfterEach
-    @BeforeEach
-    void cleanup() {
-        namedParameterJdbcTemplate.update(
-                "delete from flyway_schema_history where script = :script", Map.of("script", script));
-    }
 
     @Test
     void disabledInConfig() {
@@ -61,43 +33,43 @@ class AsyncJavaMigrationTest extends ImporterIntegrationTest {
     @ParameterizedTest
     @CsvSource(value = {", -1", "-1, -2", "1, 1", "2, -1"})
     void getChecksum(Integer existing, Integer expected) {
-        addMigrationHistory(new MigrationHistory(existing, ELAPSED, 1000));
+        addMigrationHistory(new MigrationHistory(existing, ELAPSED, 1000, SCRIPT));
         var migration = new TestAsyncJavaMigration(false, new MigrationProperties(), 1);
         assertThat(migration.getChecksum()).isEqualTo(expected);
     }
 
     @Test
     void migrate() throws Exception {
-        addMigrationHistory(new MigrationHistory(-1, ELAPSED, 1000));
-        addMigrationHistory(new MigrationHistory(-2, ELAPSED, 1001));
+        addMigrationHistory(new MigrationHistory(-1, ELAPSED, 1000, SCRIPT));
+        addMigrationHistory(new MigrationHistory(-2, ELAPSED, 1001, SCRIPT));
         var migration = new TestAsyncJavaMigration(false, new MigrationProperties(), 1);
         migrateSync(migration);
         assertThat(getAllMigrationHistory())
                 .hasSize(2)
-                .extracting(MigrationHistory::getChecksum)
+                .extracting(MigrationHistory::checksum)
                 .containsExactly(-1, 1);
     }
 
     @Test
     void migrateUpdatedExecutionTime() throws Exception {
-        addMigrationHistory(new MigrationHistory(-1, ELAPSED, 1000));
+        addMigrationHistory(new MigrationHistory(-1, ELAPSED, 1000, SCRIPT));
         var migration = new TestAsyncJavaMigration(false, new MigrationProperties(), 1);
         migrateSync(migration);
         assertThat(getAllMigrationHistory())
                 .hasSize(1)
-                .extracting(MigrationHistory::getExecutionTime)
+                .extracting(AsyncJavaMigrationBaseTest.MigrationHistory::executionTime)
                 .isNotEqualTo(ELAPSED);
     }
 
     @Test
     void migrateError() throws Exception {
-        addMigrationHistory(new MigrationHistory(-1, ELAPSED, 1000));
-        addMigrationHistory(new MigrationHistory(-2, ELAPSED, 1001));
+        addMigrationHistory(new AsyncJavaMigrationBaseTest.MigrationHistory(-1, ELAPSED, 1000, SCRIPT));
+        addMigrationHistory(new AsyncJavaMigrationBaseTest.MigrationHistory(-2, ELAPSED, 1001, SCRIPT));
         var migration = new TestAsyncJavaMigration(true, new MigrationProperties(), 0);
         migrateSync(migration);
         assertThat(getAllMigrationHistory())
                 .hasSize(2)
-                .extracting(MigrationHistory::getChecksum)
+                .extracting(AsyncJavaMigrationBaseTest.MigrationHistory::checksum)
                 .containsExactly(-1, -2);
     }
 
@@ -111,95 +83,11 @@ class AsyncJavaMigrationTest extends ImporterIntegrationTest {
         assertThat(getAllMigrationHistory()).isEmpty();
     }
 
-    private void addMigrationHistory(MigrationHistory migrationHistory) {
-        if (migrationHistory.getChecksum() == null) {
-            return;
-        }
-
-        var paramSource = new MapSqlParameterSource()
-                .addValue("installedRank", migrationHistory.getInstalledRank())
-                .addValue("description", TEST_MIGRATION_DESCRIPTION)
-                .addValue("script", script)
-                .addValue("checksum", migrationHistory.getChecksum());
-        var sql =
-                """
-                insert into flyway_schema_history (installed_rank, description, type, script, checksum,
-                installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
-                :checksum, 20, 100, true)
-                """;
-        namedParameterJdbcTemplate.update(sql, paramSource);
-    }
-
-    private List<MigrationHistory> getAllMigrationHistory() {
-        return namedParameterJdbcTemplate.query(
-                "select installed_rank, checksum, execution_time from flyway_schema_history where "
-                        + "script = :script order by installed_rank asc",
-                Map.of("script", script),
-                (rs, rowNum) -> {
-                    Integer checksum = rs.getInt("checksum");
-                    int executionTime = rs.getInt("execution_time");
-                    int installedRank = rs.getInt("installed_rank");
-                    return new MigrationHistory(checksum, executionTime, installedRank);
-                });
-    }
-
     private void migrateSync(AsyncJavaMigration<?> migration) throws Exception {
         migration.doMigrate();
 
         while (!migration.isComplete()) {
             Uninterruptibles.sleepUninterruptibly(100L, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    @Value
-    private static class MigrationHistory {
-        private Integer checksum;
-        private int executionTime;
-        private int installedRank;
-    }
-
-    @Value
-    private class TestAsyncJavaMigration extends AsyncJavaMigration<Long> {
-
-        private final boolean error;
-        private final long sleep;
-
-        public TestAsyncJavaMigration(boolean error, MigrationProperties migrationProperties, long sleep) {
-            super(
-                    Map.of("testAsyncJavaMigration", migrationProperties),
-                    AsyncJavaMigrationTest.this.namedParameterJdbcTemplate,
-                    dbProperties.getSchema());
-            this.error = error;
-            this.sleep = sleep;
-        }
-
-        @Override
-        public String getDescription() {
-            return TEST_MIGRATION_DESCRIPTION;
-        }
-
-        @Nonnull
-        @Override
-        protected Optional<Long> migratePartial(final Long last) {
-            if (sleep > 0) {
-                Uninterruptibles.sleepUninterruptibly(sleep, TimeUnit.SECONDS);
-            }
-
-            if (error) {
-                throw new RuntimeException();
-            }
-
-            return Optional.empty();
-        }
-
-        @Override
-        protected TransactionOperations getTransactionOperations() {
-            return transactionOperations;
-        }
-
-        @Override
-        protected Long getInitial() {
-            return Long.MAX_VALUE;
         }
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/FixAsyncJavaMigrationHistoryMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/FixAsyncJavaMigrationHistoryMigrationTest.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hiero.mirror.importer.DisableRepeatableSqlMigration;
+import org.hiero.mirror.importer.TestUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Profiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(initializers = FixAsyncJavaMigrationHistoryMigrationTest.Initializer.class)
+@DisablePartitionMaintenance
+@DisableRepeatableSqlMigration
+@Tag("migration")
+class FixAsyncJavaMigrationHistoryMigrationTest extends AsyncJavaMigrationBaseTest {
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+            '', ''
+            '', '-1,-2'
+            '', '-1,-2,1',
+            '-1,-2,1', ''
+            '-1,-2,1', '-1,-2,1'
+            '-1,-2', ''
+            '-1,-2', '-1,-2'
+            '-1,-2', '-1,-2,1'
+            """)
+    void noRowsRemoved(String preChecksums, String postChecksums) {
+        // given
+        var rank = new AtomicInteger(1000);
+        var expected = ListUtils.union(
+                addMigrationHistories(preChecksums, rank, SCRIPT_HEDERA),
+                addMigrationHistories(postChecksums, rank, SCRIPT));
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(getAllMigrationHistory())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("executionTime")
+                .containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    void removeIncorrectRows() {
+        // given
+        var rank = new AtomicInteger(1000);
+        var expected = addMigrationHistories("-1,-2,1", rank, SCRIPT_HEDERA);
+        addMigrationHistories("-1,-2", rank, SCRIPT);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(getAllMigrationHistory())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("executionTime")
+                .containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @SneakyThrows
+    private void runMigration() {
+        String migrationFilepath = isV1()
+                ? "v1/V1.109.0__fix_async_java_migration_history.sql"
+                : "v2/V2.14.0__fix_async_java_migration_history.sql";
+        var file = TestUtils.getResource("db/migration/" + migrationFilepath);
+        ownerJdbcTemplate.execute(FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    }
+
+    private List<MigrationHistory> addMigrationHistories(String checksums, AtomicInteger rank, String script) {
+        if (StringUtils.isEmpty(checksums)) {
+            return Collections.emptyList();
+        }
+
+        var histories = new ArrayList<MigrationHistory>();
+        for (var value : checksums.split(",")) {
+            int checksum = Integer.parseInt(value);
+            var migrationHistory = new MigrationHistory(checksum, ELAPSED, rank.getAndIncrement(), script);
+            addMigrationHistory(migrationHistory);
+            histories.add(migrationHistory);
+        }
+
+        return histories;
+    }
+
+    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            var environment = configurableApplicationContext.getEnvironment();
+            String version = environment.acceptsProfiles(Profiles.of("v2")) ? "2.13.0" : "1.108.0";
+            TestPropertyValues.of("spring.flyway.target=" + version).applyTo(environment);
+        }
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/TopicMessageLookupMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/TopicMessageLookupMigrationTest.java
@@ -34,12 +34,13 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 class TopicMessageLookupMigrationTest extends AbstractTopicMessageLookupIntegrationTest {
 
     private static final String PARTITION_SKIPPED_TEMPLATE = "Partition %s doesn't need migration";
-    private static final String RESET_CHECKSUM_SQL = "update flyway_schema_history set checksum = -1 where script = ?";
+    private static final String RESET_CHECKSUM_SQL =
+            "update flyway_schema_history set checksum = -1 where description = ?";
     private static final String SELECT_LAST_CHECKSUM_SQL =
             """
             select (
               select checksum from flyway_schema_history
-              where script = ?
+              where description = ?
               order by installed_rank desc
               limit 1
             )
@@ -50,7 +51,7 @@ class TopicMessageLookupMigrationTest extends AbstractTopicMessageLookupIntegrat
     @AfterEach
     @BeforeEach
     void resetChecksum() {
-        jdbcOperations.update(RESET_CHECKSUM_SQL, migration.getClass().getName());
+        jdbcOperations.update(RESET_CHECKSUM_SQL, migration.getDescription());
     }
 
     @Test
@@ -298,8 +299,7 @@ class TopicMessageLookupMigrationTest extends AbstractTopicMessageLookupIntegrat
     }
 
     private boolean isMigrationCompleted() {
-        var actual = jdbcOperations.queryForObject(
-                SELECT_LAST_CHECKSUM_SQL, Integer.class, migration.getClass().getName());
+        var actual = jdbcOperations.queryForObject(SELECT_LAST_CHECKSUM_SQL, Integer.class, migration.getDescription());
         return Objects.equals(actual, migration.getSuccessChecksum());
     }
 }


### PR DESCRIPTION
**Description**:

This PR cherry-picks the fix to `release/0.131`

- Change to query latest async java migration checksum using migration description
- Return correct checksum given different pre and post renaming state combinations
- Add versioned SQL migration to remove incorrect rows in flyway_schema_history
- Add new steps in release checklist

**Related issue(s)**:

Fixes #11356 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
