### PR TITLE
Bump org.owasp:dependency-check-gradle from 12.1.1 to 12.1.3

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jooq:jooq-codegen-gradle:$jooqVersion")
     implementation("org.jooq:jooq-meta:$jooqVersion")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.13.0")
-    implementation("org.owasp:dependency-check-gradle:12.1.1")
+    implementation("org.owasp:dependency-check-gradle:12.1.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:6.2.0.5505")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.0")
     implementation("org.testcontainers:postgresql:1.21.1")


### PR DESCRIPTION
**Description**:

Bump org.owasp:dependency-check-gradle from 12.1.1 to 12.1.3

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
