### PR TITLE
Add jumbo transaction tests

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -353,7 +353,6 @@ public class MirrorNodeEvmProperties implements EvmProperties {
         props.put("executor.maxSignedTxnSize", String.valueOf(maxDataSize.toBytes() + 1024));
         props.put("hedera.realm", String.valueOf(commonProperties.getRealm()));
         props.put("hedera.shard", String.valueOf(commonProperties.getShard()));
-        props.put("jumboTransactions.isEnabled", "false");
         props.put("ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());
         props.put("nodes.gossipFqdnRestricted", "false");
         props.put("tss.hintsEnabled", "false");

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
@@ -12,8 +12,11 @@ import org.junit.jupiter.api.Test;
 
 public class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
 
-    private static final int JUMBO_PAYLOAD = 64 * 128;
-    private static final int OVERSIZED_JUMBO_PAYLOAD = 128 * 1024;
+    private static final int KILOBYTE = 1024;
+
+    // Jumbo payload: any payload over 6 KiB and up to 128 KiB
+    private static final int JUMBO_PAYLOAD = 64 * KILOBYTE;
+    private static final int OVERSIZED_JUMBO_PAYLOAD = 128 * KILOBYTE;
 
     @Test
     void testJumboTransactionHappyPath() {

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
@@ -6,9 +6,11 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.hedera.node.config.data.JumboTransactionsConfig;
 import org.hiero.mirror.common.exception.MirrorNodeException;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.web3j.generated.JumboTransaction;
+import org.hiero.mirror.web3.web3j.generated.NestedCalls;
 import org.junit.jupiter.api.Test;
 
 class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
@@ -30,9 +32,23 @@ class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
     }
 
     @Test
+    void testJumboContractCreate() {
+        // Given
+        testWeb3jService.setUseContractCallDeploy(true);
+        // When
+        // 12 kb deploy
+        final var contract = testWeb3jService.deploy(NestedCalls::deploy);
+        // Then
+        assertThat(contract.getContractAddress()).isNotNull();
+    }
+
+    @Test
     void testJumboTransactionOverMaxSize() {
         // Given
-        final int maxDataSize = (int) mirrorNodeEvmProperties.getMaxDataSize().toBytes();
+        final int maxDataSize = mirrorNodeEvmProperties
+                .getVersionedConfiguration()
+                .getConfigData(JumboTransactionsConfig.class)
+                .ethereumMaxCallDataSize();
         final var jumboPayload = new byte[maxDataSize];
         final var contract = testWeb3jService.deploy(JumboTransaction::deploy);
         // When

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
@@ -11,13 +11,12 @@ import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.web3j.generated.JumboTransaction;
 import org.junit.jupiter.api.Test;
 
-public class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
+class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
 
     private static final int KILOBYTE = 1024;
 
     // Jumbo payload: any payload over 6 KiB and up to 128 KiB
     private static final int JUMBO_PAYLOAD = 64 * KILOBYTE;
-    private static final int OVERSIZED_JUMBO_PAYLOAD = 128 * KILOBYTE;
 
     @Test
     void testJumboTransactionHappyPath() {
@@ -33,7 +32,8 @@ public class ContractCallJumboTransactionTest extends AbstractContractCallServic
     @Test
     void testJumboTransactionOverMaxSize() {
         // Given
-        final var jumboPayload = new byte[OVERSIZED_JUMBO_PAYLOAD];
+        final int maxDataSize = (int) mirrorNodeEvmProperties.getMaxDataSize().toBytes();
+        final var jumboPayload = new byte[maxDataSize];
         final var contract = testWeb3jService.deploy(JumboTransaction::deploy);
         // When
         final var functionCall = contract.call_consumeLargeCalldata(jumboPayload);

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.service;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_OVERSIZE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hiero.mirror.common.exception.MirrorNodeException;
+import org.hiero.mirror.web3.web3j.generated.JumboTransaction;
+import org.junit.jupiter.api.Test;
+
+public class ContractCallJumboTransactionTest extends AbstractContractCallServiceTest {
+
+    private static final int JUMBO_PAYLOAD = 64 * 128;
+    private static final int OVERSIZED_JUMBO_PAYLOAD = 128 * 1024;
+
+    @Test
+    void testJumboTransactionHappyPath() {
+        // Given
+        final var jumboPayload = new byte[JUMBO_PAYLOAD];
+        final var contract = testWeb3jService.deploy(JumboTransaction::deploy);
+        // When
+        final var functionCall = contract.send_consumeLargeCalldata(jumboPayload);
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void testJumboTransactionOverMaxSize() {
+        // Given
+        if (!mirrorNodeEvmProperties.isModularizedServices()) {
+            return;
+        }
+        final var jumboPayload = new byte[OVERSIZED_JUMBO_PAYLOAD];
+        final var contract = testWeb3jService.deploy(JumboTransaction::deploy);
+        final var functionCall = contract.call_consumeLargeCalldata(jumboPayload);
+        // When
+        var exception = assertThrows(MirrorNodeException.class, functionCall::send);
+        // Тhen
+        assertThat(exception.getMessage()).isEqualTo(TRANSACTION_OVERSIZE.protoName());
+    }
+}

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallJumboTransactionTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hiero.mirror.common.exception.MirrorNodeException;
+import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.web3j.generated.JumboTransaction;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +33,16 @@ public class ContractCallJumboTransactionTest extends AbstractContractCallServic
     @Test
     void testJumboTransactionOverMaxSize() {
         // Given
-        if (!mirrorNodeEvmProperties.isModularizedServices()) {
-            return;
-        }
         final var jumboPayload = new byte[OVERSIZED_JUMBO_PAYLOAD];
         final var contract = testWeb3jService.deploy(JumboTransaction::deploy);
-        final var functionCall = contract.call_consumeLargeCalldata(jumboPayload);
         // When
-        var exception = assertThrows(MirrorNodeException.class, functionCall::send);
+        final var functionCall = contract.call_consumeLargeCalldata(jumboPayload);
         // Тhen
-        assertThat(exception.getMessage()).isEqualTo(TRANSACTION_OVERSIZE.protoName());
+        if (mirrorNodeEvmProperties.isModularizedServices()) {
+            var exception = assertThrows(MirrorNodeException.class, functionCall::send);
+            assertThat(exception.getMessage()).isEqualTo(TRANSACTION_OVERSIZE.protoName());
+        } else {
+            assertThrows(MirrorEvmTransactionException.class, functionCall::send);
+        }
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/web3j/TestWeb3jService.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/web3j/TestWeb3jService.java
@@ -145,6 +145,11 @@ public class TestWeb3jService implements Web3jService {
         return deployer.deploy(web3j, credentials, contractGasProvider, value).send();
     }
 
+    @SneakyThrows(Exception.class)
+    public <T extends Contract> T deployWithInput(DeployerWithInput<T> deployer, byte[] input) {
+        return deployer.deploy(web3j, credentials, contractGasProvider, input).send();
+    }
+
     @Override
     public <T extends Response> T send(Request request, Class<T> responseType) {
         final var method = request.getMethod();
@@ -415,6 +420,11 @@ public class TestWeb3jService implements Web3jService {
     public interface DeployerWithValue<T extends Contract> {
         RemoteCall<T> deploy(
                 Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider, BigInteger value);
+    }
+
+    public interface DeployerWithInput<T extends Contract> {
+        RemoteCall<T> deploy(
+                Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider, byte[] input);
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/web3/src/test/solidity/JumboTransaction.sol
+++ b/web3/src/test/solidity/JumboTransaction.sol
@@ -3,6 +3,13 @@ pragma solidity ^0.8.20;
 
 contract JumboTransaction {
 
+    bytes public payload;
+
+    constructor(bytes memory input) {
+        require(input.length > 6144, "Input too small");
+        payload = input;
+    }
+
     function consumeLargeCalldata(bytes calldata input) external pure returns (uint256) {
         require(input.length > 6144, "Input too small");
 

--- a/web3/src/test/solidity/JumboTransaction.sol
+++ b/web3/src/test/solidity/JumboTransaction.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract JumboTransaction {
+
+    function consumeLargeCalldata(bytes calldata input) external pure returns (uint256) {
+        require(input.length > 6144, "Input too small");
+
+        uint256 sum;
+        for (uint256 i = 0; i < input.length; i++) {
+            sum += uint8(input[i]);
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION
**Description**:
This PR adds integration tests for jumbo transactions.
There are upstream changes in 0.63 that enable us to remove `props.put("jumboTransactions.isEnabled", "false");`

Fixes #11354

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
