### PR TITLE
Bump spring-framework to 6.2.8 and tomcat to 10.1.42

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ extra.apply {
     set("postgresql.version", "42.7.7") // Temporary until next Spring Boot version
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
+    set("spring-framework.version", "6.2.8") // Temporary until next Spring Boot version
+    set("tomcat.version", "10.1.42") // Temporary until next Spring Boot version
     set("tuweniVersion", "2.3.1")
 }
 

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -46,7 +46,9 @@ dependencies {
     testImplementation("org.apache.commons:commons-math3")
     testImplementation("org.awaitility:awaitility")
     testImplementation("org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api") // Used by s3proxy
-    testImplementation("org.gaul:s3proxy")
+    testImplementation("org.gaul:s3proxy") {
+        exclude(group = "org.apache.commons", module = "commons-fileupload2-javax")
+    }
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")


### PR DESCRIPTION
**Description**:

* Bump spring-framework from 6.2.7 to 6.2.8 temporarily until next Spring Boot
* Bump tomcat from 10.1.41 to 10.1.42 temporarily until next Spring Boot
* Exclude unused vulnerable dependency `org.apache.commons:commons-fileupload2-javax`

**Related issue(s)**:

**Notes for reviewer**:

Will cherry-pick to release/0.132

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
