### PR TITLE
Fix secret-passwords template (0.132)

### DIFF
--- a/charts/hedera-mirror/templates/secret-passwords.yaml
+++ b/charts/hedera-mirror/templates/secret-passwords.yaml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+{{- define "existingPassword" -}}
+{{- $key := print "MIRROR_" .key -}}
+{{- coalesce (print "HEDERA_" $key | get .passwords) (print "HIERO_" $key | get .passwords) | default "" | b64dec -}}
+{{- end -}}
+
 {{- $name := "mirror-passwords" -}}  # postgresl-ha doesn't support templated names
 {{- $dbHost := include "hedera-mirror.db" . }}
 {{- $dbHostPrimary := printf "%s-coord-primary" (include "hedera-mirror.stackgres" .) }}
@@ -7,22 +12,22 @@
 {{- $dbSchema := .Values.db.schema }}
 {{- $secret := lookup "v1" "Secret" (include "hedera-mirror.namespace" .) $name | default dict -}}
 {{- $passwords := $secret.data | default dict -}}
-{{- $graphqlPassword := coalesce .Values.graphql.db.password ($passwords.HIERO_MIRROR_GRAPHQL_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $graphqlPassword := coalesce .Values.graphql.db.password (include "existingPassword" (dict "passwords" $passwords "key" "GRAPHQL_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $graphqlUsername := .Values.graphql.db.username -}}
-{{- $grpcPassword := coalesce .Values.grpc.db.password ($passwords.HIERO_MIRROR_GRPC_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $grpcPassword := coalesce .Values.grpc.db.password (include "existingPassword" (dict "passwords" $passwords "key" "GRPC_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $grpcUsername := .Values.grpc.db.username -}}
-{{- $importerPassword := coalesce .Values.importer.db.password ($passwords.HIERO_MIRROR_IMPORTER_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $importerPassword := coalesce .Values.importer.db.password (include "existingPassword" (dict "passwords" $passwords "key" "IMPORTER_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $importerUsername := .Values.importer.db.username -}}
-{{- $ownerPassword := coalesce .Values.db.owner.password ($passwords.HIERO_MIRROR_IMPORTER_DB_OWNERPASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $ownerPassword := coalesce .Values.db.owner.password (include "existingPassword" (dict "passwords" $passwords "key" "IMPORTER_DB_OWNERPASSWORD")) (randAlphaNum 40) -}}
 {{- $ownerUsername := .Values.db.owner.username -}}
-{{- $restPassword := coalesce .Values.rest.db.password ($passwords.HIERO_MIRROR_IMPORTER_DB_RESTPASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $restPassword := coalesce .Values.rest.db.password (include "existingPassword" (dict "passwords" $passwords "key" "IMPORTER_DB_RESTPASSWORD")) (randAlphaNum 40) -}}
 {{- $restUsername := .Values.rest.db.username -}}
-{{- $restJavaPassword := coalesce .Values.restjava.db.password ($passwords.HIERO_MIRROR_RESTJAVA_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $restJavaPassword := coalesce .Values.restjava.db.password (include "existingPassword" (dict "passwords" $passwords "key" "RESTJAVA_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $restJavaUsername := .Values.restjava.db.username -}}
-{{- $rosettaPassword := coalesce .Values.rosetta.db.password ($passwords.HIERO_MIRROR_ROSETTA_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $rosettaPassword := coalesce .Values.rosetta.db.password (include "existingPassword" (dict "passwords" $passwords "key" "ROSETTA_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $rosettaUsername := .Values.rosetta.db.username -}}
 {{- $tempSchema := .Values.db.tempSchema }}
-{{- $web3Password := coalesce .Values.web3.db.password ($passwords.HIERO_MIRROR_WEB3_DB_PASSWORD | default "" | b64dec) (randAlphaNum 40) -}}
+{{- $web3Password := coalesce .Values.web3.db.password (include "existingPassword" (dict "passwords" $passwords "key" "WEB3_DB_PASSWORD")) (randAlphaNum 40) -}}
 {{- $web3Username := .Values.web3.db.username }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
**Description**:

This PR cherry-picks the fix to `release/0.132`:

- Also coalesce from HEDERA_ prefix password env vars in the secrets template

**Related issue(s)**:

Fixes #11389 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
