### PR TITLE
Cherry-pick dependency bumps to 0.132

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ extra.apply {
     set("jooq.version", "3.20.4") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
     set("nodeJsVersion", "22.14.0")
+    set("postgresql.version", "42.7.7") // Temporary until next Spring Boot version
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
     set("vertxVersion", "4.5.14")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ extra.apply {
     set("postgresql.version", "42.7.7") // Temporary until next Spring Boot version
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
+    set("spring-framework.version", "6.2.8") // Temporary until next Spring Boot version
+    set("tomcat.version", "10.1.42") // Temporary until next Spring Boot version
     set("vertxVersion", "4.5.14")
     set("tuweniVersion", "2.3.1")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("org.jooq:jooq-codegen-gradle:$jooqVersion")
     implementation("org.jooq:jooq-meta:$jooqVersion")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.13.0")
-    implementation("org.owasp:dependency-check-gradle:12.1.1")
+    implementation("org.owasp:dependency-check-gradle:12.1.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:6.2.0.5505")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.0")
     implementation("org.testcontainers:postgresql:1.21.1")

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -49,7 +49,9 @@ dependencies {
     testImplementation("org.apache.commons:commons-math3")
     testImplementation("org.awaitility:awaitility")
     testImplementation("org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api") // Used by s3proxy
-    testImplementation("org.gaul:s3proxy")
+    testImplementation("org.gaul:s3proxy") {
+        exclude(group = "org.apache.commons", module = "commons-fileupload2-javax")
+    }
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")


### PR DESCRIPTION
**Description**:

Cherry-pick multiple vulnerable dependency bumps to release/0.132:

* [Bump org.owasp:dependency-check-gradle from 12.1.1 to 12.1.3](https://github.com/hiero-ledger/hiero-mirror-node/commit/36b6c9fa00a2250d7b581c650ab8781f17eaf568)
* [Bump org.postgresql:postgresql from 42.7.5 to 42.7.7](https://github.com/hiero-ledger/hiero-mirror-node/commit/46f390de1887d7e953f72bca9a19c62efa53091b)
* [Bump spring-framework to 6.2.8 and tomcat to 10.1.42](https://github.com/hiero-ledger/hiero-mirror-node/commit/d942cc7354f1ca8d787337e8f306f9ed302c862c)
* Exclude unused vulnerable dependency `org.apache.commons:commons-fileupload2-javax`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
