### PR TITLE
Generating table usage report in java modules

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     api("org.springframework.boot:spring-boot-starter-validation")
     api("org.web3j:core")
+    api("jakarta.servlet:jakarta.servlet-api")
     testImplementation("org.hyperledger.besu:evm")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")

--- a/common/src/test/java/org/hiero/mirror/common/GlobalTestSetup.java
+++ b/common/src/test/java/org/hiero/mirror/common/GlobalTestSetup.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.common;
 
+import org.hiero.mirror.common.util.MarkdownReportGenerator;
+import org.hiero.mirror.common.util.TestExecutionTracker;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
@@ -14,7 +16,9 @@ public class GlobalTestSetup implements LauncherSessionListener, TestExecutionLi
 
     @Override
     public void launcherSessionOpened(LauncherSession session) {
-        session.getLauncher().registerTestExecutionListeners(this);
+        final var laucher = session.getLauncher();
+        laucher.registerTestExecutionListeners(this);
+        laucher.registerTestExecutionListeners(new TestExecutionTracker());
     }
 
     @Override
@@ -41,5 +45,10 @@ public class GlobalTestSetup implements LauncherSessionListener, TestExecutionLi
         var commonProperties = CommonProperties.getInstance();
         commonProperties.setShard(originalCommonProperties.getShard());
         commonProperties.setRealm(originalCommonProperties.getRealm());
+    }
+
+    @Override
+    public void launcherSessionClosed(LauncherSession session) {
+        MarkdownReportGenerator.generateTableUsageReport();
     }
 }

--- a/common/src/test/java/org/hiero/mirror/common/GlobalTestSetup.java
+++ b/common/src/test/java/org/hiero/mirror/common/GlobalTestSetup.java
@@ -16,9 +16,7 @@ public class GlobalTestSetup implements LauncherSessionListener, TestExecutionLi
 
     @Override
     public void launcherSessionOpened(LauncherSession session) {
-        final var laucher = session.getLauncher();
-        laucher.registerTestExecutionListeners(this);
-        laucher.registerTestExecutionListeners(new TestExecutionTracker());
+        session.getLauncher().registerTestExecutionListeners(this, new TestExecutionTracker());
     }
 
     @Override

--- a/common/src/test/java/org/hiero/mirror/common/aspect/RepositoryUsageTrackerAspect.java
+++ b/common/src/test/java/org/hiero/mirror/common/aspect/RepositoryUsageTrackerAspect.java
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.aspect;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.hiero.mirror.common.filter.ApiTrackingFilter;
+import org.hiero.mirror.common.util.TestExecutionTracker;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
+
+@Aspect
+@AllArgsConstructor
+public class RepositoryUsageTrackerAspect {
+
+    private static final String CRUD_REPOSITORY = "CrudRepository";
+    private static final String UNKNOWN_TABLE = "UNKNOWN_TABLE";
+
+    private final EntityManager entityManager;
+
+    @Getter
+    private static final Map<String, Map<String, Set<String>>> apiTableQueries = new ConcurrentHashMap<>();
+
+    @Around("execution(* org.hiero.mirror..repository.*.*(..))")
+    public Object trackRepositoryCall(final ProceedingJoinPoint joinPoint) throws Throwable {
+        if (!TestExecutionTracker.isTestRunning()) { // guard rail: only run during test execution
+            return joinPoint.proceed();
+        }
+
+        final var endpoint =
+                Optional.ofNullable(ApiTrackingFilter.getCurrentEndpoint()).orElse("UNKNOWN_ENDPOINT");
+
+        final var repository = joinPoint.getTarget();
+        final var tableName = resolveEntityTableName(repository);
+
+        var method = joinPoint.getSignature().toShortString();
+
+        if (method.contains(CRUD_REPOSITORY)) {
+            // If the invoked method belongs to CrudRepository (e.g., findById, deleteAll),
+            // it will appear as CrudRepository.methodName in the report.
+            // To improve traceability, CrudRepository is replaced with the actual repository class name
+            // that invoked the method.
+            method = method.replace(CRUD_REPOSITORY, getRepositoryName(repository));
+        }
+
+        apiTableQueries
+                .computeIfAbsent(endpoint, k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(tableName, k -> new LinkedHashSet<>())
+                .add(method);
+
+        return joinPoint.proceed();
+    }
+
+    private String resolveEntityTableName(final Object repository) {
+        final var entityClass = extractEntityClassFromRepository(repository);
+        if (entityClass != null) {
+            return resolveJpaTableName(entityClass);
+        }
+        return UNKNOWN_TABLE;
+    }
+
+    private Class<?> extractEntityClassFromRepository(Object repositoryClass) {
+        for (Type iface : repositoryClass.getClass().getGenericInterfaces()) {
+            if (iface instanceof Class<?> ifaceClass) {
+                for (Type superIface : ifaceClass.getGenericInterfaces()) {
+                    if (superIface instanceof ParameterizedType paramType) {
+                        Type rawType = paramType.getRawType();
+                        if (rawType instanceof Class<?> rawClass && Repository.class.isAssignableFrom(rawClass)) {
+
+                            final var entityType = paramType.getActualTypeArguments()[0];
+                            if (entityType instanceof Class<?> entityClass) {
+                                return entityClass;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private String convertCamelCaseToSnakeRegex(final String input) {
+        return input.replaceAll("([A-Z])(?=[A-Z])", "$1_")
+                .replaceAll("([a-z])([A-Z])", "$1_$2")
+                .toLowerCase();
+    }
+
+    private String resolveJpaTableName(final Class<?> entityClass) {
+        final var name = entityManager.getMetamodel().getEntities().stream()
+                .filter(e -> e.getJavaType().equals(entityClass))
+                .map(EntityType::getName)
+                .findFirst()
+                .orElse(UNKNOWN_TABLE);
+
+        return convertCamelCaseToSnakeRegex(name);
+    }
+
+    private String getRepositoryName(final Object repositoryInstance) {
+        final var genericInterfaces = repositoryInstance.getClass().getGenericInterfaces();
+
+        for (final var genericInterface : genericInterfaces) {
+            if (genericInterface instanceof Class<?> repoInterface) {
+
+                if (CrudRepository.class.isAssignableFrom(repoInterface)) {
+                    return repoInterface.getSimpleName();
+                }
+            }
+        }
+
+        return "UNKNOWN_REPOSITORY"; // Default fallback
+    }
+}

--- a/common/src/test/java/org/hiero/mirror/common/aspect/RepositoryUsageTrackerAspect.java
+++ b/common/src/test/java/org/hiero/mirror/common/aspect/RepositoryUsageTrackerAspect.java
@@ -5,7 +5,6 @@ package org.hiero.mirror.common.aspect;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.EntityType;
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -71,12 +70,12 @@ public class RepositoryUsageTrackerAspect {
         return UNKNOWN_TABLE;
     }
 
-    private Class<?> extractEntityClassFromRepository(Object repositoryClass) {
-        for (Type iface : repositoryClass.getClass().getGenericInterfaces()) {
+    private Class<?> extractEntityClassFromRepository(final Object repositoryClass) {
+        for (final var iface : repositoryClass.getClass().getGenericInterfaces()) {
             if (iface instanceof Class<?> ifaceClass) {
-                for (Type superIface : ifaceClass.getGenericInterfaces()) {
+                for (final var superIface : ifaceClass.getGenericInterfaces()) {
                     if (superIface instanceof ParameterizedType paramType) {
-                        Type rawType = paramType.getRawType();
+                        final var rawType = paramType.getRawType();
                         if (rawType instanceof Class<?> rawClass && Repository.class.isAssignableFrom(rawClass)) {
 
                             final var entityType = paramType.getActualTypeArguments()[0];

--- a/common/src/test/java/org/hiero/mirror/common/config/CommonIntegrationTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/config/CommonIntegrationTest.java
@@ -18,7 +18,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
-@Import(CommonTestConfiguration.class)
+@Import({CommonTestConfiguration.class, TableUsageReportConfiguration.class})
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:cleanup.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:cleanup.sql")
 @SpringBootTest

--- a/common/src/test/java/org/hiero/mirror/common/config/TableUsageReportConfiguration.java
+++ b/common/src/test/java/org/hiero/mirror/common/config/TableUsageReportConfiguration.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.config;
+
+import jakarta.persistence.EntityManager;
+import org.hiero.mirror.common.aspect.RepositoryUsageTrackerAspect;
+import org.hiero.mirror.common.filter.ApiTrackingFilter;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TableUsageReportConfiguration {
+
+    @Bean
+    public RepositoryUsageTrackerAspect repositoryUsageTrackerAspect(EntityManager entityManager) {
+        return new RepositoryUsageTrackerAspect(entityManager);
+    }
+
+    @Bean
+    public ApiTrackingFilter apiTrackingFilter() {
+        return new ApiTrackingFilter();
+    }
+}

--- a/common/src/test/java/org/hiero/mirror/common/config/TableUsageReportConfiguration.java
+++ b/common/src/test/java/org/hiero/mirror/common/config/TableUsageReportConfiguration.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Bean;
 public class TableUsageReportConfiguration {
 
     @Bean
-    public RepositoryUsageTrackerAspect repositoryUsageTrackerAspect(EntityManager entityManager) {
+    public RepositoryUsageTrackerAspect repositoryUsageTrackerAspect(final EntityManager entityManager) {
         return new RepositoryUsageTrackerAspect(entityManager);
     }
 

--- a/common/src/test/java/org/hiero/mirror/common/filter/ApiTrackingFilter.java
+++ b/common/src/test/java/org/hiero/mirror/common/filter/ApiTrackingFilter.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class ApiTrackingFilter implements Filter {
+
+    private static final ThreadLocal<String> currentEndpoint = new ThreadLocal<>();
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+        final var httpRequest = (HttpServletRequest) request;
+        currentEndpoint.set(httpRequest.getRequestURI());
+        chain.doFilter(request, response);
+        currentEndpoint.remove();
+    }
+
+    public static String getCurrentEndpoint() {
+        return currentEndpoint.get();
+    }
+}

--- a/common/src/test/java/org/hiero/mirror/common/util/MarkdownReportGenerator.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/MarkdownReportGenerator.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import lombok.CustomLog;
+import org.hiero.mirror.common.aspect.RepositoryUsageTrackerAspect;
+
+@CustomLog
+public class MarkdownReportGenerator {
+
+    public static void generateTableUsageReport() {
+        final var apiTableQueries = RepositoryUsageTrackerAspect.getApiTableQueries();
+        final var path = Paths.get("build/table-usage-report.md");
+
+        try (final var writer = Files.newBufferedWriter(path)) {
+            writer.write("# API Repository Calls & Database Tables Report\n\n");
+
+            for (final var entry : apiTableQueries.entrySet()) {
+                writer.write("## API Endpoint: " + entry.getKey() + "\n");
+
+                for (final var tableEntry : entry.getValue().entrySet()) {
+                    writer.write("### Table: " + tableEntry.getKey() + "\n");
+
+                    for (final var query : tableEntry.getValue()) {
+                        writer.write("- " + query + "\n");
+                    }
+                    writer.write("\n");
+                }
+                writer.write("\n");
+            }
+
+        } catch (IOException e) {
+            log.warn("Unexpected error occurred: {}", e.getMessage());
+        }
+    }
+}

--- a/common/src/test/java/org/hiero/mirror/common/util/TestExecutionTracker.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/TestExecutionTracker.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.util;
+
+import lombok.Getter;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+public class TestExecutionTracker implements TestExecutionListener {
+
+    @Getter
+    private static boolean testRunning = false;
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            testRunning = true;
+        }
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
+        if (testIdentifier.isTest()) {
+            testRunning = false;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces support for tracking database table usage by API endpoint during test execution. The goal is to generate a Markdown report per module after tests run, showing which repositories and tables are used by which endpoints. The said report is generated if one test, a whole test suite or all tests are ran in a module.

The logic is implemented in the common module and used across test scopes in all modules.

`ApiTrackingFilter.java `-  storing the current API endpoint URI 
`RepositoryUsageTrackerAspect.java `- class used to intercept the calls to repository and extract the table name that is used.
`TestExecutionTracker.java` - tracks whether tests are currently running. Main goal is to act as a rail guard so the report is generated only in test scope
`MarkdownReportGenerator.java` - class used to generate the table usage report
**Related issue(s)**:

Fixes #11286

**Notes for reviewer**:
There are custom repositories that dont implement CrudRepository, JpaRepository or any other Spring Data interface. In those cases, the current code is unable to extract the table (it is shown as UNKNOWN_TABLE), however, the repository and the method are logged in the report. For Jooq repositories, the data is double logged. Once with correct table name from the customImpl repository, and once with UNKNOWN_TABLE for the interface that extends JooqRepository. This behavior can also serve as a useful indicator for refactoring opportunities.
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
