### PR TITLE
Add github action for release branches comparison

### DIFF
--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -2,7 +2,6 @@
 
 name: Consensus node release branches compare
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -25,6 +24,11 @@ jobs:
       pr_version: ${{ steps.check.outputs.pr_version }}
       base_version: ${{ steps.check.outputs.base_version }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -56,6 +60,11 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.changed == 'true'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
         uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -21,16 +21,44 @@ jobs:
     name: Compare latest two releases of consensus node
     runs-on: hiero-mirror-node-linux-large
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check if hedera app version changed in the PR
+        id: check-hedera-app-line
+        run: |
+          set -ex
+
+          PR_VERSION=$(grep -o 'api("com\.hedera\.hashgraph:app:[^"]*")' build.gradle.kts | sed -E 's/.*app:([^"]*)".*/\1/')
+          PR_VERSION_TAG="v$PR_VERSION"
+
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git show origin/${{ github.base_ref }}:build.gradle.kts > base_build.gradle.kts
+          BASE_VERSION=$(grep -o 'api("com\.hedera\.hashgraph:app:[^"]*")' base_build.gradle.kts | sed -E 's/.*app:([^"]*)".*/\1/')
+          BASE_VERSION_TAG="v$BASE_VERSION"
+
+          echo "pr_version=$PR_VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "base_version=$BASE_VERSION_TAG" >> $GITHUB_OUTPUT
+
+          if [ "$PR_VERSION_TAG" != "$BASE_VERSION_TAG" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install JDK
+        if: steps.check-hedera-app-line.outputs.changed == 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: "temurin"
           java-version: 21
 
       - name: Setup Gradle
+        if: steps.check-hedera-app-line.outputs.changed == 'true'
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
 
       - name: Run diff script
+        if: steps.check-hedera-app-line.outputs.changed == 'true'
         run: |
           set -ex
 
@@ -50,31 +78,18 @@ jobs:
           TMP_DIR_ONE=$(mktemp -d)
           TMP_DIR_TWO=$(mktemp -d)
 
-          # Function to clean the temp directories after script finishes
-          cleanup() {
-            rm -rf "$TMP_DIR_ONE" "$TMP_DIR_TWO"
-          }
-          trap cleanup EXIT
-
-          TAGS=($(git ls-remote --tags "$CONSENSUS_NODE_REPO" | \
-                awk '{print $2}' | \
-                grep 'refs/tags/v0' | \
-                grep -v '\^{}' | \
-                sed 's#refs/tags/##' | \
-                sort -Vr))
-
-          TAG_ONE="${TAGS[0]}"
-          TAG_TWO="${TAGS[1]}"
+          TAG_ONE="${{ steps.check-hedera-app-line.outputs.pr_version }}"
+          TAG_TWO="${{ steps.check-hedera-app-line.outputs.base_version }}"
 
           echo "Comparing consensus node release versions $TAG_ONE and $TAG_TWO ..."
 
           git clone --depth 1 --branch "$TAG_ONE" "$CONSENSUS_NODE_REPO" "$TMP_DIR_ONE" > /dev/null 2>&1
           cd "$TMP_DIR_ONE"
-          ./gradlew build -q -x test -x spotlessCheck
+          ./gradlew hapi:generatePbjSource > /dev/null 2>&1
 
           git clone --depth 1 --branch "$TAG_TWO" "$CONSENSUS_NODE_REPO" "$TMP_DIR_TWO" > /dev/null 2>&1
           cd "$TMP_DIR_TWO"
-          ./gradlew build -q -x test -x spotlessCheck > /dev/null 2>&1
+          ./gradlew hapi:generatePbjSource > /dev/null 2>&1
 
           # Flag to track for differences
           CHANGED=false

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -9,17 +9,11 @@ on:
       - release/**
     paths:
       - "build.gradle.kts"
-  push:
-    branches:
-      - main
-      - release/**
-    tags:
-      - v*
 defaults:
   run:
     shell: bash
 permissions:
-  contents: write
+  contents: read
 env:
   LC_ALL: C.UTF-8
 jobs:

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -17,15 +17,19 @@ permissions:
 env:
   LC_ALL: C.UTF-8
 jobs:
-  run-diff-script:
-    name: Compare latest two releases of consensus node
+  check-version:
+    name: Check if hedera app version changed in the PR
     runs-on: hiero-mirror-node-linux-large
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      pr_version: ${{ steps.check.outputs.pr_version }}
+      base_version: ${{ steps.check.outputs.base_version }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Check if hedera app version changed in the PR
-        id: check-hedera-app-line
+      - name: Compare versions
+        id: check
         run: |
           set -ex
 
@@ -46,19 +50,25 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
+  run-diff-script:
+    name: Compare files of different releases
+    runs-on: hiero-mirror-node-linux-large
+    needs: check-version
+    if: needs.check-version.outputs.changed == 'true'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4.2.2
+
       - name: Install JDK
-        if: steps.check-hedera-app-line.outputs.changed == 'true'
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: "temurin"
           java-version: 21
 
       - name: Setup Gradle
-        if: steps.check-hedera-app-line.outputs.changed == 'true'
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
 
       - name: Run diff script
-        if: steps.check-hedera-app-line.outputs.changed == 'true'
         run: |
           set -ex
 
@@ -78,18 +88,23 @@ jobs:
           TMP_DIR_ONE=$(mktemp -d)
           TMP_DIR_TWO=$(mktemp -d)
 
-          TAG_ONE="${{ steps.check-hedera-app-line.outputs.pr_version }}"
-          TAG_TWO="${{ steps.check-hedera-app-line.outputs.base_version }}"
+          TAG_ONE="${{ needs.check-version.outputs.pr_version }}"
+          TAG_TWO="${{ needs.check-version.outputs.base_version }}"
 
           echo "Comparing consensus node release versions $TAG_ONE and $TAG_TWO ..."
 
-          git clone --depth 1 --branch "$TAG_ONE" "$CONSENSUS_NODE_REPO" "$TMP_DIR_ONE" > /dev/null 2>&1
-          cd "$TMP_DIR_ONE"
-          ./gradlew hapi:generatePbjSource > /dev/null 2>&1
+          generate_pbj_source() {
+            local tag="$1"
+            local target_dir="$2"
 
-          git clone --depth 1 --branch "$TAG_TWO" "$CONSENSUS_NODE_REPO" "$TMP_DIR_TWO" > /dev/null 2>&1
-          cd "$TMP_DIR_TWO"
-          ./gradlew hapi:generatePbjSource > /dev/null 2>&1
+            git clone --depth 1 --branch "$tag" "$CONSENSUS_NODE_REPO" "$target_dir" > /dev/null 2>&1
+            cd "$target_dir"
+            ./gradlew hapi:generatePbjSource > /dev/null 2>&1
+            cd - > /dev/null
+          }
+
+          generate_pbj_source "$TAG_ONE" "$TMP_DIR_ONE"
+          generate_pbj_source "$TAG_TWO" "$TMP_DIR_TWO"
 
           # Flag to track for differences
           CHANGED=false
@@ -106,10 +121,10 @@ jobs:
               branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
             fi
 
-            if ! diff -q "$branch_one_file_path" "$branch_two_file_path" >/dev/null 2>&1; then
+            if ! diff_output=$(diff -u "$branch_two_file_path" "$branch_one_file_path"); then
               echo "File changed: $input_file_path"
               echo "----------------------------------------"
-              diff -u "$branch_two_file_path" "$branch_one_file_path" || true
+              echo "$diff_output"
               echo "----------------------------------------"
               CHANGED=true
             fi
@@ -120,9 +135,9 @@ jobs:
           done
 
           if [ "$CHANGED" = false ]; then
-            echo "No file changes detected."
+            echo "No differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
           else
-            echo "Differences detected."
+            echo "Differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
             exit 1
           fi
 

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Consensus node release branches compare
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths:
+      - "build.gradle.kts"
+  push:
+    branches:
+      - main
+      - release/**
+    tags:
+      - v*
+defaults:
+  run:
+    shell: bash
+permissions:
+  contents: write
+env:
+  LC_ALL: C.UTF-8
+jobs:
+  run-diff-script:
+    name: Compare latest two releases of consensus node
+    runs-on: hiero-mirror-node-linux-large
+    steps:
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "temurin"
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+
+      - name: Run diff script
+        run: |
+          set -ex
+
+          CONSENSUS_NODE_REPO="https://github.com/hiero-ledger/hiero-consensus-node.git"
+
+          FILES_TO_COMPARE=(
+            "com/hedera/hapi/node/state/token/Account.java"
+            "com/hedera/hapi/node/state/token/Token.java"
+            "com/hedera/hapi/node/state/token/TokenRelation.java"
+            "com/hedera/hapi/node/state/file/File.java"
+            "com/hedera/hapi/node/state/schedule/Schedule.java"
+            "com/swirlds/state/spi/ReadableKVStateBase.java"
+            "com/swirlds/state/spi/WritableKVStateBase.java"
+          )
+
+          # Temp directories to store cloned repos
+          TMP_DIR_ONE=$(mktemp -d)
+          TMP_DIR_TWO=$(mktemp -d)
+
+          # Function to clean the temp directories after script finishes
+          cleanup() {
+            rm -rf "$TMP_DIR_ONE" "$TMP_DIR_TWO"
+          }
+          trap cleanup EXIT
+
+          TAGS=($(git ls-remote --tags "$CONSENSUS_NODE_REPO" | \
+                awk '{print $2}' | \
+                grep 'refs/tags/v0' | \
+                grep -v '\^{}' | \
+                sed 's#refs/tags/##' | \
+                sort -Vr))
+
+          TAG_ONE="${TAGS[0]}"
+          TAG_TWO="${TAGS[1]}"
+
+          echo "Comparing consensus node release versions $TAG_ONE and $TAG_TWO ..."
+
+          git clone --depth 1 --branch "$TAG_ONE" "$CONSENSUS_NODE_REPO" "$TMP_DIR_ONE" > /dev/null 2>&1
+          cd "$TMP_DIR_ONE"
+          ./gradlew build -q -x test -x spotlessCheck
+
+          git clone --depth 1 --branch "$TAG_TWO" "$CONSENSUS_NODE_REPO" "$TMP_DIR_TWO" > /dev/null 2>&1
+          cd "$TMP_DIR_TWO"
+          ./gradlew build -q -x test -x spotlessCheck > /dev/null 2>&1
+
+          # Flag to track for differences
+          CHANGED=false
+
+          compare_file() {
+            local input_file_path="$1"
+            local branch_one_file_path branch_two_file_path
+
+            if [[ "$input_file_path" == com/swirlds/* ]]; then
+              branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+              branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+            else
+              branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+              branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+            fi
+
+            if ! diff -q "$branch_one_file_path" "$branch_two_file_path" >/dev/null 2>&1; then
+              echo "File changed: $input_file_path"
+              echo "----------------------------------------"
+              diff -u "$branch_two_file_path" "$branch_one_file_path" || true
+              echo "----------------------------------------"
+              CHANGED=true
+            fi
+          }
+
+          for file in "${FILES_TO_COMPARE[@]}"; do
+            compare_file "$file"
+          done
+
+          if [ "$CHANGED" = false ]; then
+            echo "No file changes detected."
+          else
+            echo "Differences detected."
+            exit 1
+          fi
+
+        timeout-minutes: 30


### PR DESCRIPTION
**Description**:
This PR adds github action that compares the following files of the consensus node if the hedera app version specified in the PR and the one of the base branch of the mirror node differentiate: 

  com.hedera.hapi.node.state.token.Account
  com.hedera.hapi.node.state.token.Token
  com.hedera.hapi.node.state.token.TokenRelation
  com.swirlds.state.spi.ReadableKVStateBase
  com.swirlds.state.spi.WritableKVStateBase
  com.hedera.hapi.node.state.file.File
  com.hedera.hapi.node.state.schedule.Schedule

The action is triggered on PRs changing the hedera app version in the build.gradle.kts file.
The steps are the following:
```
1. Checkout Code: Mirror node repo is cloned into the runner, so we can execute git relation operations.
2. Check if hedera app version changed in the PR: Checks the PR diff of the build.gradle.kts against the base branch. If hedera app dependency line is changed the consecutive steps are executed, otherwise they are skipped and the action passes.
3. Install JDK
4. Setup Gradle
5. Run diff script: Target files are compared and if differences are found the step fails.
```
The step doing the comparison timeouts after 30 min in case something hangs.


**Related issue(s)**:

Fixes #11422 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
