### PR TITLE
Generate table usage for nodejs REST API

### DIFF
--- a/rest/__tests__/globalTeardown.js
+++ b/rest/__tests__/globalTeardown.js
@@ -1,8 +1,97 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from 'fs';
 import log4js from 'log4js';
 
+import {TABLE_USAGE_OUTPUT_DIR} from './testutils.js';
+
+const CSV_HEADER = 'Endpoint,Source,Table\n';
+const MARKDOWN_ENDPOINT_HEADER = `### By Endpoint\n
+| Endpoint | Tables |
+|----------|--------|\n`;
+const MARKDOWN_TABLE_HEADER = `\n### By Table\n
+| Table | Endpoints |
+|-------|-----------|\n`;
+const REPORT_FILENAME = 'table-usage';
+
+const createTableUsageReport = () => {
+  if (process.env.GENERATE_TABLE_USAGE === 'false' || !fs.existsSync(TABLE_USAGE_OUTPUT_DIR)) {
+    return;
+  }
+
+  const tableUsage = {};
+  for (const dirent of fs.readdirSync(TABLE_USAGE_OUTPUT_DIR, {withFileTypes: true})) {
+    if (!dirent.isFile() || !dirent.name.endsWith('.json')) {
+      continue;
+    }
+
+    try {
+      Object.assign(
+        tableUsage,
+        JSON.parse(fs.readFileSync(`${TABLE_USAGE_OUTPUT_DIR}/${dirent.name}`, {encoding: 'utf8'}))
+      );
+    } catch (err) {
+      console.error(`Unable to read file ${dirent.name} - ${err}`);
+    }
+  }
+
+  writeReport(tableUsage, `${REPORT_FILENAME}.csv`, writeCsvReport);
+  writeReport(tableUsage, `${REPORT_FILENAME}.md`, writeMarkdownReport);
+};
+
+const writeCsvReport = (data, writeStream) => {
+  writeStream.write(CSV_HEADER);
+  for (const endpoint of Object.keys(data).sort()) {
+    const callerTables = data[endpoint];
+    for (const caller of Object.keys(callerTables).sort()) {
+      for (const table of callerTables[caller]) {
+        writeStream.write(`${endpoint},${caller},${table}\n`);
+      }
+    }
+  }
+};
+
+const writeMarkdownReport = (data, writeStream) => {
+  // By endpoint
+  writeStream.write(MARKDOWN_ENDPOINT_HEADER);
+  const usageByTable = {};
+  for (const endpoint of Object.keys(data).sort()) {
+    const callerTables = data[endpoint];
+    const tables = Array.from(new Set(Object.values(callerTables).flat())).sort();
+    writeStream.write(`| ${endpoint} | ${tables.join(',')}|\n`);
+
+    tables.forEach((table) => {
+      if (!table) {
+        return;
+      }
+
+      (usageByTable[table] ?? (usageByTable[table] = [])).push(endpoint);
+    });
+  }
+
+  // By table
+  writeStream.write(MARKDOWN_TABLE_HEADER);
+  for (const table of Object.keys(usageByTable).sort()) {
+    writeStream.write(`| ${table} | ${usageByTable[table].sort().join(',')} |\n`);
+  }
+};
+
+const writeReport = (data, filename, writeData) => {
+  const path = `${TABLE_USAGE_OUTPUT_DIR}/${filename}`;
+  let writeStream;
+
+  try {
+    writeStream = fs.createWriteStream(path);
+    writeData(data, writeStream);
+  } catch (err) {
+    console.error(`Unable to write file ${path} - ${err}`);
+  } finally {
+    writeStream?.close();
+  }
+};
+
 export default async () => {
+  createTableUsageReport();
   for (const dbContainer of globalThis.__DB_CONTAINERS__.values()) {
     await dbContainer.stop();
   }

--- a/rest/__tests__/integration/template.js
+++ b/rest/__tests__/integration/template.js
@@ -32,6 +32,7 @@ import {defaultBeforeAllTimeoutMillis, setupIntegrationTest} from '../integratio
 import {CreateBucketCommand, PutObjectCommand, S3} from '@aws-sdk/client-s3';
 import sinon from 'sinon';
 import integrationContainerOps from '../integrationContainerOps';
+import {writeTableUsage} from '../tableUsage';
 
 const groupSpecPath = $$GROUP_SPEC_PATH$$;
 
@@ -324,6 +325,8 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
     if (s3Ops) {
       await s3Ops.stop();
     }
+
+    await writeTableUsage(groupSpecPath);
   });
 
   afterEach(() => {

--- a/rest/__tests__/jestSetup.js
+++ b/rest/__tests__/jestSetup.js
@@ -19,3 +19,33 @@ process.env.CONFIG_PATH = '__tests__';
 beforeEach(() => {
   logger.info(expect.getState().currentTestName);
 });
+
+const defaultPrepareStackTrace = Error.prepareStackTrace;
+
+Error.prepareStackTrace = (error, structuredStackTrace) => {
+  if (defaultPrepareStackTrace) {
+    // the defaultPrepareStackTrace in tests oftentimes gets the function name wrong, however the line numbers are
+    // correct; the line number from structuredStackTrace[].getLineNumber is way off. So the logic here first gets the
+    // stacktrace with correct line numbers and then patches the function name.
+    const defaultStackTrace = defaultPrepareStackTrace(error, structuredStackTrace);
+    const lines = defaultStackTrace.split('\n');
+    if (lines.length === 1) {
+      return defaultStackTrace;
+    }
+
+    return [
+      lines[0],
+      ...lines.slice(1).map((line, index) => {
+        if (index >= structuredStackTrace.length) {
+          return line;
+        }
+        const functionName = structuredStackTrace[index].getFunctionName();
+        return line.replace(/at\s+[^ ]+\s/, `at ${functionName} `);
+      }),
+    ].join('\n');
+  }
+
+  return structuredStackTrace.length === 0
+    ? `${error.name}`
+    : `${error.name}\n    at ${structuredStackTrace.join('\n    at ')}`;
+};

--- a/rest/__tests__/tableUsage.js
+++ b/rest/__tests__/tableUsage.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from '@jest/globals';
+import fs from 'fs';
+import {parse} from 'pgsql-parser';
+
+import {apiPrefix} from '../constants';
+import {TABLE_USAGE_OUTPUT_DIR} from './testutils';
+
+const TABLE_EXISTS_SQL = `select table_name
+  from information_schema.tables
+  where table_schema = 'public' and table_name = any($1)`;
+
+const allQueries = {}; // SQL queries by endpoint, then by caller
+const enabled = process.env.GENERATE_TABLE_USAGE !== 'false';
+
+const getEndpoint = () => {
+  const {currentTestName} = expect.getState();
+  const extracted = (currentTestName.match(/^API specification tests - (.*) [^ ]*\.json.*$/) ?? [])[1];
+  if (!extracted) {
+    return null;
+  }
+
+  return `${apiPrefix}/${extracted.replaceAll(' ', '')}`;
+};
+
+/**
+ * Gets possible tables accessed by the PostgreSQL query
+ * @param node - The AST node
+ * @returns [string] - An array of tables extracted from the PostgreSQL query AST
+ */
+const getTablesForNode = (node) => {
+  if (Array.isArray(node)) {
+    return node.map(getTablesForNode).flat();
+  } else if (typeof node === 'object') {
+    if ('RangeVar' in node) {
+      return node['RangeVar'].relname;
+    } else {
+      return Object.values(node).map(getTablesForNode).flat();
+    }
+  }
+
+  return [];
+};
+
+const getTablesForQuery = async (query) => {
+  try {
+    // the result from the parser will also include non tables, e.g., named CTE used as a from item
+    const {stmts} = await parse(query);
+    return getTablesForNode(stmts);
+  } catch (err) {
+    logger.error(err);
+    return new Set();
+  }
+};
+
+const recordQuery = (callerInfo, query) => {
+  if (!shouldTrackTableUsage(callerInfo.path)) {
+    return;
+  }
+
+  const caller = `${callerInfo.function} (${callerInfo.file}:${callerInfo.line})`;
+  const endpoint = getEndpoint();
+  const callerQueries = allQueries[endpoint] ?? (allQueries[endpoint] = {});
+  const queries = callerQueries[caller] ?? (callerQueries[caller] = []);
+  queries.push(query);
+};
+
+const shouldTrackTableUsage = (callerFilePath) => {
+  if (!enabled || callerFilePath.includes('__tests__')) {
+    return false;
+  }
+
+  const {testPath} = expect.getState();
+  return testPath.endsWith('.spec.test.js') && !testPath.endsWith('route.spec.test.js');
+};
+
+const writeTableUsage = async (group) => {
+  if (Object.keys(allQueries).length === 0) {
+    return;
+  }
+
+  // two passes, first parses all queries and collect possible tables
+  let possibleTables = new Set();
+  const usage = {};
+  for (const [endpoint, callerQueries] of Object.entries(allQueries)) {
+    const callerTables = {};
+    for (const [caller, queries] of Object.entries(callerQueries)) {
+      const tables = [];
+      for (const query of queries) {
+        tables.push(...(await getTablesForQuery(query)));
+      }
+
+      callerTables[caller] = new Set(tables);
+      possibleTables = possibleTables.union(callerTables[caller]);
+    }
+
+    usage[endpoint] = callerTables;
+  }
+
+  // query to find which are tables
+  const knownTables = new Set();
+  const tables = Array.from(possibleTables);
+  let i = 0;
+  for (; i < tables.length; i += 512) {
+    const end = Math.min(i + 512, tables.length);
+    const {rows} = await pool.queryQuietly(TABLE_EXISTS_SQL, [tables.slice(i, end)]);
+    rows.forEach(({table_name}) => knownTables.add(table_name));
+  }
+
+  // remove non tables
+  for (const callerTables of Object.values(usage)) {
+    for (const caller of Object.keys(callerTables)) {
+      callerTables[caller] = Array.from(callerTables[caller].intersection(knownTables)).sort();
+    }
+  }
+
+  fs.mkdirSync(TABLE_USAGE_OUTPUT_DIR, {recursive: true});
+  fs.writeFileSync(`${TABLE_USAGE_OUTPUT_DIR}/${group}.json`, JSON.stringify(usage));
+};
+
+export {recordQuery, writeTableUsage};

--- a/rest/__tests__/testutils.js
+++ b/rest/__tests__/testutils.js
@@ -18,6 +18,8 @@ const invalidBase32Strs = [
   'AA======', // padding not accepted
 ];
 
+const TABLE_USAGE_OUTPUT_DIR = 'build/table-usage';
+
 const assertSqlQueryEqual = (actual, expected) => {
   expect(formatSqlQueryString(actual)).toEqual(formatSqlQueryString(expected));
 };
@@ -68,4 +70,5 @@ export {
   invalidBase32Strs,
   isV2Schema,
   valueToBuffer,
+  TABLE_USAGE_OUTPUT_DIR,
 };

--- a/rest/package-lock.json
+++ b/rest/package-lock.json
@@ -88,6 +88,7 @@
         "node-flywaydb": "^3.0.7",
         "nodemon": "^3.1.10",
         "pg-format": "^1.0.4",
+        "pgsql-parser": "^17.7.2",
         "rewire": "^8.0.0",
         "sinon": "^21.0.0",
         "supertest": "^7.1.1"
@@ -2497,6 +2498,13 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@pgsql/types": {
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/@pgsql/types/-/types-17.6.1.tgz",
+      "integrity": "sha512-Hk51+nyOxS7Dy5oySWywyNZxo5HndX1VDXT4ZEBD+p+vvMFM2Vc+sKSuByCiI8banou4edbgdnOC251IOuq7QQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -9075,6 +9083,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libpg-query": {
+      "version": "17.5.2",
+      "resolved": "https://registry.npmjs.org/libpg-query/-/libpg-query-17.5.2.tgz",
+      "integrity": "sha512-9VhuzWrWyZ6AalSCtF2+BDx/aHpp8JKLAsYa1qF77x7f+kJ5BxAXvdRYOduNNFqdwu67110eFpoBr6BtN4WH/A==",
+      "dev": true,
+      "license": "LICENSE IN LICENSE",
+      "dependencies": {
+        "@pgsql/types": "^17.6.1"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10088,6 +10106,28 @@
       "inBundle": true,
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-deparser": {
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/pgsql-deparser/-/pgsql-deparser-17.8.1.tgz",
+      "integrity": "sha512-d2qaFYFmFYBlkvSdao2pTQ8yDnmec+bB9gUTb2eza4tzQZI6B1QNAB3bOGWZubmWo2C1em2iCNioymvOfM0bMg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pgsql/types": "^17.6.1"
+      }
+    },
+    "node_modules/pgsql-parser": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/pgsql-parser/-/pgsql-parser-17.7.2.tgz",
+      "integrity": "sha512-pWokAnwbSbhOlu+jWK2cE4wfUE5KqCUycmlG2N5zB1OIA2ncVnffiiGeqr9Bfd5ZOWB7czCvOON/KKkh0iUirQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pgsql/types": "^17.6.1",
+        "libpg-query": "17.5.2",
+        "pgsql-deparser": "^17.8.1"
       }
     },
     "node_modules/picocolors": {

--- a/rest/package.json
+++ b/rest/package.json
@@ -62,6 +62,7 @@
     "node-flywaydb": "^3.0.7",
     "nodemon": "^3.1.10",
     "pg-format": "^1.0.4",
+    "pgsql-parser": "^17.7.2",
     "rewire": "^8.0.0",
     "sinon": "^21.0.0",
     "supertest": "^7.1.1"


### PR DESCRIPTION
**Description**:

This PR adds support of generating table usage for nodejs REST APIs

- Add SQL query tracking during spec based integration tests
- Analyze table usage from the saved queries and write info to file in spec test module `afterAll` hook
- Generate report in `globalTeardown`
- Patch error stacktrace for correct function name

**Related issue(s)**:

Close #11266

**Notes for reviewer**:

Example markdown report (trimmed down)

##### By Endpoint

| Endpoint | Tables |
|----------|--------|
| /api/v1/accounts | entity,entity_stake,token_account|
| /api/v1/accounts/{id} | account_balance,crypto_transfer,entity,entity_history,entity_stake,entity_stake_history,staking_reward_transfer,token_account,token_balance,token_transfer,transaction|
| /api/v1/accounts/{id}/allowances/crypto | crypto_allowance,entity|
| /api/v1/accounts/{id}/allowances/tokens | entity,token_allowance|

##### By Table

| Table | Endpoints |
|-------|-----------|
| account_balance | /api/v1/accounts/{id},/api/v1/balances,/api/v1/network/supply,/api/v1/tokens/{id}/balances |
| address_book | /api/v1/network/nodes,/api/v1/transactions/{id}/stateproof |
| address_book_entry | /api/v1/network/nodes,/api/v1/transactions/{id}/stateproof |
| address_book_service_endpoint | /api/v1/network/nodes |


Sample csv:

```
Endpoint,Source,Table
/api/v1/accounts,getAccounts (accounts.js:361),entity
/api/v1/accounts,getAccounts (accounts.js:361),entity_stake
/api/v1/accounts,getAccounts (accounts.js:361),token_account
/api/v1/accounts/{id},func (timestampRange.js:51),transaction
/api/v1/accounts/{id},getAccountBalanceTimestampRange (balances.js:189),account_balance
```

Note if the query calls a UDF, the logic isn't able to find the tables the UDF accesses, that's reflected in get transaction by transaciton hash API

The overhead when running all tests is about 7.5% locally, 67s v.s. 72s

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
