### PR TITLE
Bump com.hedera.hashgraph:app to 0.64.0

### DIFF
--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -108,10 +108,9 @@ jobs:
             local target_dir="$2"
 
             git clone --depth 1 --branch "$tag" "$CONSENSUS_NODE_REPO" "$target_dir" > /dev/null 2>&1
-            (
-              cd "$target_dir"
-              ./gradlew hapi:generatePbjSource > /dev/null 2>&1
-            )
+            cd "$target_dir"
+            ./gradlew hapi:generatePbjSource > /dev/null 2>&1
+            cd - > /dev/null
           }
 
           generate_pbj_source "$TAG_ONE" "$TMP_DIR_ONE"
@@ -123,37 +122,19 @@ jobs:
             local input_file_path="$1"
             local branch_one_file_path branch_two_file_path
 
-            case "$input_file_path" in
-              com/hedera/hapi/*)
-                branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
-                branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
-                ;;
-              com/swirlds/*)
-                branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
-                branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
-                ;;
-              com/hedera/node/app/service/*)
-                branch_one_file_path="$TMP_DIR_ONE/hedera-node/hedera-app/src/main/java/$input_file_path"
-                branch_two_file_path="$TMP_DIR_TWO/hedera-node/hedera-app/src/main/java/$input_file_path"
-                ;;
-              *)
-                echo "::error::Unknown path structure for '$input_file_path'. Cannot determine its location in the consensus-node repository."
-                return
-                ;;
-            esac
-
-            # Check if files exist before diffing to avoid errors
-            if [ ! -f "$branch_one_file_path" ] || [ ! -f "$branch_two_file_path" ]; then
-                echo "::warning::Could not find one or both files for comparison: $input_file_path"
-                return
-            fi
+            if [[ "$input_file_path" == com/swirlds/* ]]; then
+              branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+              branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+            else
+              branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+              branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
 
             if ! diff_output=$(diff -u "$branch_two_file_path" "$branch_one_file_path"); then
               echo ""
               echo "File changed: $input_file_path"
-              echo "------------------------------------------------------------------------"
+              echo "----------------------------------------"
               echo "$diff_output"
-              echo "------------------------------------------------------------------------"
+              echo "----------------------------------------"
               CHANGES_COUNT=$((CHANGES_COUNT + 1))
             fi
           }
@@ -162,12 +143,11 @@ jobs:
             compare_file "$file"
           done
 
-          echo "" # Add a newline for better log separation
-
           if [ "$CHANGES_COUNT" -eq 0 ]; then
             echo "✅ No differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
           else
             echo "::warning::Found ${CHANGES_COUNT} changed file(s) between versions $TAG_TWO and $TAG_ONE. Please review the diffs in the logs above."
+            exit 1
           fi
 
         timeout-minutes: 30

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -79,8 +79,6 @@ jobs:
 
       - name: Run diff script
         run: |
-          set -ex
-
           CONSENSUS_NODE_REPO="https://github.com/hiero-ledger/hiero-consensus-node.git"
 
           FILES_TO_COMPARE=(
@@ -93,6 +91,7 @@ jobs:
             "com/swirlds/state/spi/WritableKVStateBase.java"
             "com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java"
             "com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java"
+            "com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java"
           )
 
           # Temp directories to store cloned repos
@@ -109,35 +108,53 @@ jobs:
             local target_dir="$2"
 
             git clone --depth 1 --branch "$tag" "$CONSENSUS_NODE_REPO" "$target_dir" > /dev/null 2>&1
-            cd "$target_dir"
-            ./gradlew hapi:generatePbjSource > /dev/null 2>&1
-            cd - > /dev/null
+            (
+              cd "$target_dir"
+              ./gradlew hapi:generatePbjSource > /dev/null 2>&1
+            )
           }
 
           generate_pbj_source "$TAG_ONE" "$TMP_DIR_ONE"
           generate_pbj_source "$TAG_TWO" "$TMP_DIR_TWO"
 
-          # Flag to track for differences
-          CHANGED=false
+          CHANGES_COUNT=0
 
           compare_file() {
             local input_file_path="$1"
             local branch_one_file_path branch_two_file_path
 
-            if [[ "$input_file_path" == com/swirlds/* ]]; then
-              branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
-              branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
-            else
-              branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
-              branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+            case "$input_file_path" in
+              com/hedera/hapi/*)
+                branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+                branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+                ;;
+              com/swirlds/*)
+                branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+                branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
+                ;;
+              com/hedera/node/app/service/*)
+                branch_one_file_path="$TMP_DIR_ONE/hedera-node/hedera-app/src/main/java/$input_file_path"
+                branch_two_file_path="$TMP_DIR_TWO/hedera-node/hedera-app/src/main/java/$input_file_path"
+                ;;
+              *)
+                echo "::error::Unknown path structure for '$input_file_path'. Cannot determine its location in the consensus-node repository."
+                return
+                ;;
+            esac
+
+            # Check if files exist before diffing to avoid errors
+            if [ ! -f "$branch_one_file_path" ] || [ ! -f "$branch_two_file_path" ]; then
+                echo "::warning::Could not find one or both files for comparison: $input_file_path"
+                return
             fi
 
             if ! diff_output=$(diff -u "$branch_two_file_path" "$branch_one_file_path"); then
+              echo ""
               echo "File changed: $input_file_path"
-              echo "----------------------------------------"
+              echo "------------------------------------------------------------------------"
               echo "$diff_output"
-              echo "----------------------------------------"
-              CHANGED=true
+              echo "------------------------------------------------------------------------"
+              CHANGES_COUNT=$((CHANGES_COUNT + 1))
             fi
           }
 
@@ -145,11 +162,12 @@ jobs:
             compare_file "$file"
           done
 
-          if [ "$CHANGED" = false ]; then
-            echo "No differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
+          echo "" # Add a newline for better log separation
+
+          if [ "$CHANGES_COUNT" -eq 0 ]; then
+            echo "✅ No differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
           else
-            echo "Differences detected between versions $TAG_TWO and $TAG_ONE for the specified set of files."
-            exit 1
+            echo "::warning::Found ${CHANGES_COUNT} changed file(s) between versions $TAG_TWO and $TAG_ONE. Please review the diffs in the logs above."
           fi
 
         timeout-minutes: 30

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -128,6 +128,7 @@ jobs:
             else
               branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
               branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+            fi
 
             if ! diff_output=$(diff -u "$branch_two_file_path" "$branch_one_file_path"); then
               echo ""

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -19,6 +19,7 @@ jobs:
   check-version:
     name: Check if hedera app version changed in the PR
     runs-on: hiero-mirror-node-linux-large
+    continue-on-error: true
     outputs:
       changed: ${{ steps.check.outputs.changed }}
       pr_version: ${{ steps.check.outputs.pr_version }}
@@ -35,7 +36,7 @@ jobs:
       - name: Compare versions
         id: check
         run: |
-          set -ex
+          set -euo pipefail
 
           PR_VERSION=$(grep -o 'api("com\.hedera\.hashgraph:app:[^"]*")' build.gradle.kts | sed -E 's/.*app:([^"]*)".*/\1/')
           PR_VERSION_TAG="v$PR_VERSION"
@@ -59,6 +60,7 @@ jobs:
     runs-on: hiero-mirror-node-linux-large
     needs: check-version
     if: needs.check-version.outputs.changed == 'true'
+    continue-on-error: true
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2

--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Run diff script
         run: |
+          set -euo pipefail
+
           CONSENSUS_NODE_REPO="https://github.com/hiero-ledger/hiero-consensus-node.git"
 
           FILES_TO_COMPARE=(
@@ -92,6 +94,8 @@ jobs:
             "com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java"
             "com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java"
             "com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java"
+            "com/hedera/node/app/service/contract/impl/exec/operations/CustomBalanceOperation.java"
+            "com/hedera/node/app/service/contract/impl/exec/operations/CustomCallOperation.java"
           )
 
           # Temp directories to store cloned repos
@@ -125,9 +129,12 @@ jobs:
             if [[ "$input_file_path" == com/swirlds/* ]]; then
               branch_one_file_path="$TMP_DIR_ONE/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
               branch_two_file_path="$TMP_DIR_TWO/platform-sdk/swirlds-state-api/src/main/java/$input_file_path"
-            else
+            elif [[ "$input_file_path" == com/hedera/hapi/node/* ]]; then
               branch_one_file_path="$TMP_DIR_ONE/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
               branch_two_file_path="$TMP_DIR_TWO/hapi/hapi/build/generated/source/pbj-proto/main/java/$input_file_path"
+            elif [[ "$input_file_path" == com/hedera/node/app/service/contract/* ]]; then
+              branch_one_file_path="$TMP_DIR_ONE/hedera-node/hedera-smart-contract-service-impl/src/main/java/$input_file_path"
+              branch_two_file_path="$TMP_DIR_TWO/hedera-node/hedera-smart-contract-service-impl/src/main/java/$input_file_path"
             fi
 
             if ! diff_output=$(diff -u "$branch_two_file_path" "$branch_one_file_path"); then

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.9")
         api("com.graphql-java:graphql-java-extended-scalars:24.0")
         api("com.graphql-java:graphql-java-extended-validation:24.0")
-        api("com.hedera.hashgraph:app:0.63.5")
+        api("com.hedera.hashgraph:app:0.64.0")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.63.5")
         api("com.hedera.hashgraph:sdk:2.59.0")

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -24,7 +24,10 @@ dependencies {
     implementation(project(":common"))
     implementation("com.bucket4j:bucket4j-core")
     implementation("com.esaulpaugh:headlong")
-    implementation("com.hedera.hashgraph:app") { exclude(group = "io.netty") }
+    implementation("com.hedera.hashgraph:app") {
+        exclude(group = "io.netty")
+        exclude(group = "net.i2p.crypto")
+    }
     implementation("com.hedera.evm:hedera-evm")
     implementation("io.github.mweirauch:micrometer-jvm-extras")
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -24,10 +24,7 @@ dependencies {
     implementation(project(":common"))
     implementation("com.bucket4j:bucket4j-core")
     implementation("com.esaulpaugh:headlong")
-    implementation("com.hedera.hashgraph:app") {
-        exclude(group = "io.netty")
-        exclude(group = "net.i2p.crypto")
-    }
+    implementation("com.hedera.hashgraph:app") { exclude(group = "io.netty") }
     implementation("com.hedera.evm:hedera-evm")
     implementation("io.github.mweirauch:micrometer-jvm-extras")
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/web3/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
+++ b/web3/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
@@ -345,14 +345,14 @@ public class DispatchingEvmFrameState implements EvmFrameState {
             }
 
             final var evmAddress = extractEvmAddress(account.alias());
-            return evmAddress == null ? asLongZeroAddress(entityIdFactory(), number) : pbjToBesuAddress(evmAddress);
+            return evmAddress == null ? asLongZeroAddress(number) : pbjToBesuAddress(evmAddress);
         }
         final var token = nativeOperations.getToken(entityIdFactory().newTokenId(number));
         final var schedule = nativeOperations.getSchedule(entityIdFactory().newScheduleId(number));
         if (token != null || schedule != null) {
             // If the token or schedule  is deleted or expired, the system contract executed by the redirect
             // bytecode will fail with a more meaningful error message, so don't check that here
-            return asLongZeroAddress(entityIdFactory(), number);
+            return asLongZeroAddress(number);
         }
         throw new IllegalArgumentException("No account, token or schedule has number " + number);
     }
@@ -449,7 +449,7 @@ public class DispatchingEvmFrameState implements EvmFrameState {
      */
     @Override
     public Optional<ExceptionalHaltReason> tryLazyCreation(@NonNull final Address address) {
-        if (isLongZero(nativeOperations.entityIdFactory(), address)) {
+        if (isLongZero(address)) {
             return Optional.of(INVALID_ALIAS_KEY);
         }
         final var number = maybeMissingNumberOf(address, nativeOperations);

--- a/web3/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/web3/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -7,18 +7,16 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.NON_CANONICAL_REFERENCE_NUMBER;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes.ZERO_CONTRACT_ID;
-import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.entityIdFactory;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.proxyUpdaterFor;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.hasNonDegenerateAutoRenewAccountId;
 import static com.hedera.node.app.service.token.AliasUtils.extractEvmAddress;
-import static java.lang.System.arraycopy;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.base.utility.CommonUtils.unhex;
-import static org.hiero.mirror.web3.evm.properties.MirrorNodeEvmProperties.ALLOW_LONG_ZERO_ADDRESSES;
 
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
+import com.hedera.hapi.block.stream.trace.ContractSlotUsage;
+import com.hedera.hapi.block.stream.trace.EvmTransactionLog;
+import com.hedera.hapi.block.stream.trace.SlotRead;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Duration;
@@ -55,12 +53,11 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.log.Log;
+import org.hyperledger.besu.evm.log.LogTopic;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
 /**
  * Some utility methods for converting between PBJ and Besu types and the various kinds of addresses and ids.
- *
- * TODO - workaround for allowing long zero addresses to be used in the EVM, may be deleted in the future
  */
 public class ConversionUtils {
     /** The standard length as long of an address in Ethereum.*/
@@ -82,14 +79,17 @@ public class ConversionUtils {
     /**
      * Given a list of {@link com.esaulpaugh.headlong.abi.Address}, returns their implied token ids.
      *
+     * @param entityIdFactory the entity id factory
      * @param tokenAddresses the {@link com.esaulpaugh.headlong.abi.Address}es
      * @return the implied token ids
      */
-    public static TokenID[] asTokenIds(@NonNull final com.esaulpaugh.headlong.abi.Address... tokenAddresses) {
+    public static TokenID[] asTokenIds(
+            @NonNull final EntityIdFactory entityIdFactory,
+            @NonNull final com.esaulpaugh.headlong.abi.Address... tokenAddresses) {
         requireNonNull(tokenAddresses);
         final TokenID[] tokens = new TokenID[tokenAddresses.length];
         for (int i = 0; i < tokens.length; i++) {
-            tokens[i] = asTokenId(tokenAddresses[i]);
+            tokens[i] = asTokenId(entityIdFactory, tokenAddresses[i]);
         }
         return tokens;
     }
@@ -109,20 +109,18 @@ public class ConversionUtils {
     /**
      * Given a {@link com.esaulpaugh.headlong.abi.Address}, returns its implied token id.
      *
-     * <p><b>IMPORTANT:</b> Mono-service ignores the shard and realm, c.f. De
-     * codingFacade#convertAddressBytesToTokenID(), so we continue to do that here; might
-     * want to revisit this later
+     * Use the passed in EntityIdFactory to create the TokenID.  This means that the new TokenID
+     * will have the same shard and realm as the EntityIdFactory's default shard and realm which it reads from configuration.
      *
      * @param address the {@link com.esaulpaugh.headlong.abi.Address}
      * @return the implied token id
      */
-    public static TokenID asTokenId(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
+    public static TokenID asTokenId(
+            @NonNull final EntityIdFactory entityIdFactory,
+            @NonNull final com.esaulpaugh.headlong.abi.Address address) {
         final var explicit = explicitFromHeadlong(address);
-        return TokenID.newBuilder()
-                .shardNum(shardOfLongZero(explicit))
-                .realmNum(realmOfLongZero(explicit))
-                .tokenNum(numberOfLongZero(explicit))
-                .build();
+        final var tokenNum = numberOfLongZero(explicit);
+        return tokenNum == 0 ? TokenID.DEFAULT : entityIdFactory.newTokenId(tokenNum);
     }
 
     /**
@@ -148,7 +146,7 @@ public class ConversionUtils {
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(@NonNull final AccountID accountID) {
         requireNonNull(accountID);
         final var integralAddress = accountID.hasAccountNum()
-                ? asEvmAddress(accountID.shardNum(), accountID.realmNum(), accountID.accountNumOrThrow())
+                ? asEvmAddress(accountID.accountNumOrThrow())
                 : accountID
                         .aliasOrElse(com.hedera.pbj.runtime.io.buffer.Bytes.EMPTY)
                         .toByteArray();
@@ -164,7 +162,7 @@ public class ConversionUtils {
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(@NonNull final ContractID contractId) {
         requireNonNull(contractId);
         final var integralAddress = contractId.hasContractNum()
-                ? asEvmAddress(contractId.shardNum(), contractId.realmNum(), contractId.contractNumOrThrow())
+                ? asEvmAddress(contractId.contractNumOrThrow())
                 : contractId.evmAddressOrThrow().toByteArray();
         return asHeadlongAddress(integralAddress);
     }
@@ -177,8 +175,7 @@ public class ConversionUtils {
      */
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(@NonNull final ScheduleID scheduleID) {
         requireNonNull(scheduleID);
-        final var integralAddress =
-                asEvmAddress(scheduleID.shardNum(), scheduleID.realmNum(), scheduleID.scheduleNum());
+        final var integralAddress = asEvmAddress(scheduleID.scheduleNum());
         return asHeadlongAddress(integralAddress);
     }
 
@@ -191,8 +188,7 @@ public class ConversionUtils {
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(
             @NonNull final com.hederahashgraph.api.proto.java.ScheduleID scheduleID) {
         requireNonNull(scheduleID);
-        final var integralAddress =
-                asEvmAddress(scheduleID.getShardNum(), scheduleID.getRealmNum(), scheduleID.getScheduleNum());
+        final var integralAddress = asEvmAddress(scheduleID.getScheduleNum());
         return asHeadlongAddress(integralAddress);
     }
 
@@ -204,7 +200,7 @@ public class ConversionUtils {
      */
     public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(@NonNull final TokenID tokenId) {
         requireNonNull(tokenId);
-        return asHeadlongAddress(asEvmAddress(tokenId.shardNum(), tokenId.realmNum(), tokenId.tokenNum()));
+        return asHeadlongAddress(asEvmAddress(tokenId.tokenNum()));
     }
 
     /**
@@ -297,11 +293,14 @@ public class ConversionUtils {
 
     /**
      * Given a list of {@link StorageAccesses}, converts them to a PBJ {@link ContractStateChanges}.
-     *
      * @param storageAccesses the {@link StorageAccesses}
      * @return the PBJ {@link ContractStateChanges}
      */
-    public static ContractStateChanges asPbjStateChanges(@NonNull final List<StorageAccesses> storageAccesses) {
+    public static @Nullable ContractStateChanges asPbjStateChanges(
+            @Nullable final List<StorageAccesses> storageAccesses) {
+        if (storageAccesses == null) {
+            return null;
+        }
         final List<ContractStateChange> allStateChanges = new ArrayList<>();
         for (final var storageAccess : storageAccesses) {
             final List<StorageChange> changes = new ArrayList<>();
@@ -317,6 +316,40 @@ public class ConversionUtils {
             allStateChanges.add(new ContractStateChange(storageAccess.contractID(), changes));
         }
         return new ContractStateChanges(allStateChanges);
+    }
+
+    /**
+     * Given a list of {@link StorageAccesses}, converts them to a list of PBJ {@link ContractSlotUsage}s.
+     *
+     * @param storageAccesses the {@link StorageAccesses}
+     * @return the list of slot usages
+     */
+    public static @Nullable List<ContractSlotUsage> asPbjSlotUsages(
+            @Nullable final List<StorageAccesses> storageAccesses) {
+        if (storageAccesses == null) {
+            return null;
+        }
+        final List<ContractSlotUsage> slotUsages = new ArrayList<>();
+        for (final var storageAccess : storageAccesses) {
+            final List<SlotRead> reads = new ArrayList<>();
+            final List<com.hedera.pbj.runtime.io.buffer.Bytes> writes = new ArrayList<>();
+            for (final var access : storageAccess.accesses()) {
+                if (!access.isReadOnly()) {
+                    writes.add(access.trimmedKeyBytes());
+                    reads.add(SlotRead.newBuilder()
+                            .index(writes.size() - 1)
+                            .readValue(access.trimmedValueBytes())
+                            .build());
+                } else {
+                    reads.add(SlotRead.newBuilder()
+                            .key(access.trimmedKeyBytes())
+                            .readValue(access.trimmedValueBytes())
+                            .build());
+                }
+            }
+            slotUsages.add(new ContractSlotUsage(storageAccess.contractID(), writes, reads));
+        }
+        return slotUsages;
     }
 
     /**
@@ -338,6 +371,42 @@ public class ConversionUtils {
                 .topic(loggedTopics)
                 .bloom(bloomFor(log))
                 .build();
+    }
+
+    /**
+     * Returns the given Besu {@link Log}s as Hedera {@link EvmTransactionLog}s.
+     *
+     * @param logs the Besu {@link Log}s, using the long-zero address format for the logger's Hedera id number
+     * @param entityIdFactory the Hedera entity id factory
+     * @return the Hedera {@link EvmTransactionLog}s
+     */
+    public static List<EvmTransactionLog> asHederaLogs(
+            @NonNull final List<Log> logs, @NonNull final EntityIdFactory entityIdFactory) {
+        requireNonNull(logs);
+        final List<EvmTransactionLog> hederaLogs = new ArrayList<>(logs.size());
+        for (final var log : logs) {
+            hederaLogs.add(asHederaLog(entityIdFactory, log));
+        }
+        return hederaLogs;
+    }
+
+    /**
+     * Returns the given Besu {@link Log} as a Hedera {@link EvmTransactionLog}.
+     * @param entityIdFactory the Hedera entity id factory
+     * @param log the Besu {@link Log}, using the long-zero address format for the logger's Hedera id number
+     * @return the Hedera {@link EvmTransactionLog}
+     */
+    public static EvmTransactionLog asHederaLog(
+            @NonNull final EntityIdFactory entityIdFactory, @NonNull final Log log) {
+        final List<com.hedera.pbj.runtime.io.buffer.Bytes> topics =
+                new ArrayList<>(log.getTopics().size());
+        for (final var topic : log.getTopics()) {
+            topics.add(tuweniToPbjBytes(topic.trimLeadingZeros()));
+        }
+        return new EvmTransactionLog(
+                entityIdFactory.newContractId(numberOfLongZero(log.getLogger())),
+                tuweniToPbjBytes(log.getData()),
+                topics);
     }
 
     /**
@@ -370,7 +439,7 @@ public class ConversionUtils {
      * @return the id number of the given address's Hedera id
      */
     private static long hederaIdNumberIn(@NonNull final MessageFrame frame, @NonNull final Address address) {
-        return isLongZero(entityIdFactory(frame), address)
+        return isLongZero(address)
                 ? numberOfLongZero(address)
                 : proxyUpdaterFor(frame).getHederaContractId(address).contractNumOrThrow();
     }
@@ -400,16 +469,14 @@ public class ConversionUtils {
             @NonNull final HederaNativeOperations nativeOperations) {
         final var explicit = explicitFromHeadlong(address);
         final var number = maybeMissingNumberOf(explicit, nativeOperations);
-        final var longZeroAddressPermitted = Boolean.parseBoolean(System.getProperty(ALLOW_LONG_ZERO_ADDRESSES));
-
         if (number == MISSING_ENTITY_NUMBER) {
             return MISSING_ENTITY_NUMBER;
         } else {
             final var account = nativeOperations.getAccount(
                     nativeOperations.entityIdFactory().newAccountId(number));
-            if (account == null) {
+            if (account == null || account.deleted()) {
                 return MISSING_ENTITY_NUMBER;
-            } else if (!longZeroAddressPermitted && !Arrays.equals(explicit, explicitAddressOf(account))) {
+            } else if (!Arrays.equals(explicit, explicitAddressOf(account))) {
                 return NON_CANONICAL_REFERENCE_NUMBER;
             }
             return number;
@@ -438,54 +505,43 @@ public class ConversionUtils {
      */
     @SuppressWarnings("java:S2201")
     public static long numberOfLongZero(@NonNull final Address address) {
-        final var longVal = numberOfLongZero(address.toArray());
-        if (longVal < 0) {
-            throw new ArithmeticException("Long zero address is negative");
-        }
-        return longVal;
+        return numberOfLongZero(address.toArray());
     }
 
     /**
      * Given an Besu EVM address, returns whether it is long-zero.
      *
-     * @param entityIdFactory the entity id factory
      * @param address the EVM address (as a BESU {@link org.hyperledger.besu.datatypes.Address})
      * @return whether it is long-zero
      */
-    public static boolean isLongZero(@NonNull final EntityIdFactory entityIdFactory, @NonNull final Address address) {
-        return isLongZeroAddress(entityIdFactory, address.toArrayUnsafe());
+    public static boolean isLongZero(@NonNull final Address address) {
+        return isLongZeroAddress(address.toArrayUnsafe());
     }
 
     /**
      * Given an headlong EVM address, returns whether it is long-zero.
      *
-     * @param entityIdFactory the entity id factory
      * @param address the EVM address (as a headlong {@link com.esaulpaugh.headlong.abi.Address})
      * @return whether it is long-zero
      */
-    public static boolean isLongZero(
-            @NonNull final EntityIdFactory entityIdFactory,
-            @NonNull final com.esaulpaugh.headlong.abi.Address address) {
-        return isLongZeroAddress(entityIdFactory, explicitFromHeadlong(address));
+    public static boolean isLongZero(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
+        return isLongZeroAddress(explicitFromHeadlong(address));
     }
 
     /**
      * Given an explicit 20-byte array, returns whether it is a long-zero address.
-     * True if the first 4 bytes matches the shard and if the next 8 bytes match the realm.
+     * True if the first 12 bytes are 0.
      *
-     * @param entityIdFactory the entity id factory
      * @param explicit the explicit 20-byte array
      * @return whether it is a long-zero address
      */
-    public static boolean isLongZeroAddress(@NonNull final EntityIdFactory entityIdFactory, final byte[] explicit) {
-        // check if first bytes are matching the shard and the realm
-        final var zeroAddress = unhex(entityIdFactory.hexLongZero(0));
-
+    public static boolean isLongZeroAddress(final byte[] explicit) {
         for (int i = 0; i < NUM_LONG_ZEROS; i++) {
-            if (explicit[i] != zeroAddress[i]) {
+            if (explicit[i] != 0) {
                 return false;
             }
         }
+
         return true;
     }
 
@@ -501,13 +557,11 @@ public class ConversionUtils {
 
     /**
      * Converts a shard, realm, number to a long zero address.
-     *
-     * @param entityIdFactory the entity id factory
      * @param number the number to convert
      * @return the long zero address
      */
-    public static Address asLongZeroAddress(@NonNull final EntityIdFactory entityIdFactory, final long number) {
-        return Address.wrap(Bytes.wrap(asEvmAddress(entityIdFactory, number)));
+    public static Address asLongZeroAddress(final long number) {
+        return Address.wrap(Bytes.wrap(asEvmAddress(number)));
     }
 
     /**
@@ -517,8 +571,7 @@ public class ConversionUtils {
      * @return the long zero address
      */
     public static Address asLongZeroAddress(@NonNull final AccountID accountID) {
-        return Address.wrap(
-                Bytes.wrap(asEvmAddress(accountID.shardNum(), accountID.realmNum(), accountID.accountNumOrThrow())));
+        return Address.wrap(Bytes.wrap(asEvmAddress(accountID.accountNumOrThrow())));
     }
 
     /**
@@ -544,21 +597,6 @@ public class ConversionUtils {
     }
 
     /**
-     * Converts a long-zero address to a PBJ {@link AccountID} with id number instead of alias.
-     *
-     * @param entityIdFactory the entity id factory
-     * @param address the EVM address
-     * @return the PBJ {@link AccountID}
-     */
-    public static AccountID asNumberedAccountId(
-            @NonNull final EntityIdFactory entityIdFactory, @NonNull final Address address) {
-        if (!isLongZero(entityIdFactory, address)) {
-            throw new IllegalArgumentException("Cannot extract id number from address " + address);
-        }
-        return entityIdFactory.newAccountId(numberOfLongZero(address));
-    }
-
-    /**
      * Converts a long-zero address to a PBJ {@link ContractID} with id number instead of alias.
      *
      * @param entityIdFactory the entity id factory
@@ -567,7 +605,7 @@ public class ConversionUtils {
      */
     public static ContractID asNumberedContractId(
             @NonNull final EntityIdFactory entityIdFactory, @NonNull final Address address) {
-        if (!isLongZero(entityIdFactory, address)) {
+        if (!isLongZero(address)) {
             throw new IllegalArgumentException("Cannot extract id number from address " + address);
         }
         return entityIdFactory.newContractId(numberOfLongZero(address));
@@ -583,7 +621,7 @@ public class ConversionUtils {
     public static ScheduleID addressToScheduleID(
             @NonNull final EntityIdFactory entityIdFactory,
             @NonNull final com.esaulpaugh.headlong.abi.Address address) {
-        if (!isLongZero(entityIdFactory, address)) {
+        if (!isLongZero(address)) {
             throw new IllegalArgumentException("Cannot extract id number from address " + address);
         }
 
@@ -712,33 +750,12 @@ public class ConversionUtils {
 
     /**
      * Given a long entity number, returns its 20-byte EVM address.
-     * The shard is downcast to an int so it must not exceed the range of an int.
      *
-     * @param entityIdFactory the entity id factory
      * @param num the entity number
      * @return its 20-byte EVM address
      */
-    public static byte[] asEvmAddress(@NonNull final EntityIdFactory entityIdFactory, final long num) {
-        return unhex(entityIdFactory.hexLongZero(num));
-    }
-
-    /**
-     * Given a long entity number, returns its 20-byte EVM address.
-     * The shard is downcast to an int so it must not exceed the range of an int.
-     *
-     * @param shard the shard number
-     * @param realm the realm number
-     * @param num the entity number
-     * @return its 20-byte EVM address
-     */
-    public static byte[] asEvmAddress(final long shard, final long realm, final long num) {
-        final byte[] evmAddress = new byte[20];
-
-        arraycopy(Ints.toByteArray((int) shard), 0, evmAddress, 0, 4);
-        arraycopy(Longs.toByteArray(realm), 0, evmAddress, 4, 8);
-        arraycopy(Longs.toByteArray(num), 0, evmAddress, 12, 8);
-
-        return evmAddress;
+    public static byte[] asEvmAddress(final long num) {
+        return copyToLeftPaddedByteArray(num, new byte[20]);
     }
 
     /**
@@ -784,34 +801,6 @@ public class ConversionUtils {
                 explicit[19]);
     }
 
-    /**
-     * Given an explicit 20-byte addresss, returns its realm value.
-     *
-     * @param explicit the explicit 20-byte address
-     * @return its realm value
-     */
-    public static long realmOfLongZero(@NonNull final byte[] explicit) {
-        return longFrom(
-                explicit[4],
-                explicit[5],
-                explicit[6],
-                explicit[7],
-                explicit[8],
-                explicit[9],
-                explicit[10],
-                explicit[11]);
-    }
-
-    /**
-     * Given an explicit 20-byte addresss, returns its shard value.
-     *
-     * @param explicit the explicit 20-byte address
-     * @return its shard value
-     */
-    public static int shardOfLongZero(@NonNull final byte[] explicit) {
-        return longFrom(explicit[0], explicit[1], explicit[2], explicit[3]);
-    }
-
     // too many arguments
     @SuppressWarnings("java:S107")
     private static long longFrom(
@@ -833,26 +822,27 @@ public class ConversionUtils {
                 | (b8 & 0xFFL);
     }
 
-    private static int longFrom(final byte b1, final byte b2, final byte b3, final byte b4) {
-        return (b1 & 0xFF) << 24 | (b2 & 0xFF) << 16 | (b3 & 0xFF) << 8 | (b4 & 0xFF);
-    }
-
-    private static com.hedera.pbj.runtime.io.buffer.Bytes bloomFor(@NonNull final Log log) {
+    /**
+     * Given a Besu {@link Log}, returns its bloom filter as a PBJ {@link com.hedera.pbj.runtime.io.buffer.Bytes}.
+     * @param log the Besu {@link Log}
+     * @return the PBJ {@link com.hedera.pbj.runtime.io.buffer.Bytes} bloom filter
+     */
+    public static com.hedera.pbj.runtime.io.buffer.Bytes bloomFor(@NonNull final Log log) {
+        requireNonNull(log);
         return com.hedera.pbj.runtime.io.buffer.Bytes.wrap(
                 LogsBloomFilter.builder().insertLog(log).build().toArray());
     }
 
     private static Address longZeroAddressIn(@NonNull final MessageFrame frame, @NonNull final Address address) {
-        return isLongZero(entityIdFactory(frame), address)
+        return isLongZero(address)
                 ? address
                 : asLongZeroAddress(
-                        entityIdFactory(frame),
                         proxyUpdaterFor(frame).getHederaContractId(address).contractNumOrThrow());
     }
 
     private static long maybeMissingNumberOf(
             @NonNull final byte[] explicit, @NonNull final HederaNativeOperations nativeOperations) {
-        if (isLongZeroAddress(nativeOperations.entityIdFactory(), explicit)) {
+        if (isLongZeroAddress(explicit)) {
             return longFrom(
                     explicit[12],
                     explicit[13],
@@ -882,10 +872,7 @@ public class ConversionUtils {
         final var evmAddress = extractEvmAddress(account.alias());
         return evmAddress != null
                 ? evmAddress.toByteArray()
-                : asEvmAddress(
-                        account.accountIdOrThrow().shardNum(),
-                        account.accountIdOrThrow().realmNum(),
-                        account.accountIdOrThrow().accountNumOrThrow());
+                : asEvmAddress(account.accountIdOrThrow().accountNumOrThrow());
     }
 
     /**
@@ -960,17 +947,15 @@ public class ConversionUtils {
      * <p>
      * Returns 0 if contractId in a non-long zero evm address
      *
-     * @param entityIdFactory the entity id factory
      * @param contractId the contract id
      * @return the equivalent entity id (0 if contractId in a non-long zero evm address)
      */
-    public static @NonNull Long contractIDToNum(
-            @NonNull final EntityIdFactory entityIdFactory, final ContractID contractId) {
+    public static @NonNull Long contractIDToNum(final ContractID contractId) {
         final Long id;
         // For convenience also translate a long-zero address to a entity id
         if (contractId.hasEvmAddress()) {
             final var evmAddress = contractId.evmAddressOrThrow().toByteArray();
-            if (isLongZeroAddress(entityIdFactory, evmAddress)) {
+            if (isLongZeroAddress(evmAddress)) {
                 id = numberOfLongZero(evmAddress);
             } else {
                 id = 0L;
@@ -1056,5 +1041,43 @@ public class ConversionUtils {
         final var offset = contents.matchesPrefix(hexPrefix) ? hexPrefix.length : 0L;
         final var len = contents.length() - offset;
         return contents.getBytes(offset, len).toByteArray();
+    }
+
+    /**
+     * Pads the given bytes to 32 bytes by left-padding with zeros.
+     * @param bytes the bytes to pad
+     * @return the left-padded bytes, or the original bytes if they are already 32 bytes long
+     */
+    public static com.hedera.pbj.runtime.io.buffer.Bytes leftPad32(
+            @NonNull final com.hedera.pbj.runtime.io.buffer.Bytes bytes) {
+        requireNonNull(bytes);
+        final int n = (int) bytes.length();
+        if (n == 32) {
+            return bytes;
+        }
+        final var padded = new byte[32];
+        bytes.getBytes(0, padded, 32 - n, n);
+        return com.hedera.pbj.runtime.io.buffer.Bytes.wrap(padded);
+    }
+
+    /**
+     * Converts a concise EVM transaction log into a Besu {@link Log}.
+     *
+     * @param log the concise EVM transaction log to convert
+     * @param paddedTopics the 32-byte padded topics to use in the log
+     * @return the Besu {@link Log} representation of the log
+     */
+    public static Log asBesuLog(
+            @NonNull final EvmTransactionLog log,
+            @NonNull final List<com.hedera.pbj.runtime.io.buffer.Bytes> paddedTopics) {
+        requireNonNull(log);
+        requireNonNull(paddedTopics);
+        return new Log(
+                asLongZeroAddress(log.contractIdOrThrow().contractNumOrThrow()),
+                pbjToTuweniBytes(log.data()),
+                paddedTopics.stream()
+                        .map(ConversionUtils::pbjToTuweniBytes)
+                        .map(LogTopic::create)
+                        .toList());
     }
 }

--- a/web3/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/web3/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -12,6 +12,7 @@ import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.hasN
 import static com.hedera.node.app.service.token.AliasUtils.extractEvmAddress;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.base.utility.CommonUtils.unhex;
+import static org.hiero.mirror.web3.evm.properties.MirrorNodeEvmProperties.ALLOW_LONG_ZERO_ADDRESSES;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.block.stream.trace.ContractSlotUsage;
@@ -469,6 +470,8 @@ public class ConversionUtils {
             @NonNull final HederaNativeOperations nativeOperations) {
         final var explicit = explicitFromHeadlong(address);
         final var number = maybeMissingNumberOf(explicit, nativeOperations);
+        final var longZeroAddressPermitted = Boolean.parseBoolean(System.getProperty(ALLOW_LONG_ZERO_ADDRESSES));
+
         if (number == MISSING_ENTITY_NUMBER) {
             return MISSING_ENTITY_NUMBER;
         } else {
@@ -476,7 +479,7 @@ public class ConversionUtils {
                     nativeOperations.entityIdFactory().newAccountId(number));
             if (account == null || account.deleted()) {
                 return MISSING_ENTITY_NUMBER;
-            } else if (!Arrays.equals(explicit, explicitAddressOf(account))) {
+            } else if (!longZeroAddressPermitted && !Arrays.equals(explicit, explicitAddressOf(account))) {
                 return NON_CANONICAL_REFERENCE_NUMBER;
             }
             return number;

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/MirrorOperationActionTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/MirrorOperationActionTracer.java
@@ -2,9 +2,6 @@
 
 package org.hiero.mirror.web3.evm.contracts.execution.traceability;
 
-import com.hedera.hapi.streams.ContractActionType;
-import com.hedera.hapi.streams.ContractActions;
-import com.hedera.node.app.service.contract.impl.exec.ActionSidecarContentTracer;
 import com.hedera.services.utils.EntityIdUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jakarta.inject.Named;
@@ -17,11 +14,12 @@ import org.hiero.mirror.web3.evm.properties.TraceProperties;
 import org.hiero.mirror.web3.state.CommonEntityAccessor;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 @Named
 @CustomLog
 @RequiredArgsConstructor
-public class MirrorOperationActionTracer implements ActionSidecarContentTracer {
+public class MirrorOperationActionTracer implements OperationTracer {
 
     private final TraceProperties traceProperties;
     private final CommonEntityAccessor commonEntityAccessor;
@@ -66,25 +64,5 @@ public class MirrorOperationActionTracer implements ActionSidecarContentTracer {
                 frame.getInputData().toShortHexString(),
                 frame.getOutputData().toShortHexString(),
                 frame.getReturnData().toShortHexString());
-    }
-
-    @Override
-    public void traceOriginAction(@NonNull MessageFrame frame) {
-        // NO-OP
-    }
-
-    @Override
-    public void sanitizeTracedActions(@NonNull MessageFrame frame) {
-        // NO-OP
-    }
-
-    @Override
-    public void tracePrecompileResult(@NonNull MessageFrame frame, @NonNull ContractActionType type) {
-        // NO-OP
-    }
-
-    @Override
-    public ContractActions contractActions() {
-        return null;
     }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracer.java
@@ -2,9 +2,6 @@
 
 package org.hiero.mirror.web3.evm.contracts.execution.traceability;
 
-import com.hedera.hapi.streams.ContractActionType;
-import com.hedera.hapi.streams.ContractActions;
-import com.hedera.node.app.service.contract.impl.exec.ActionSidecarContentTracer;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HederaSystemContract;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -24,10 +21,11 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.ModificationNotAllowedException;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 @Named
 @CustomLog
-public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSidecarContentTracer {
+public class OpcodeActionTracer extends AbstractOpcodeTracer implements OperationTracer {
 
     @Getter
     private final Map<Address, HederaSystemContract> systemContracts = new ConcurrentHashMap<>();
@@ -100,26 +98,6 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
             log.warn("Failed to retrieve storage contents", e);
             return Collections.emptyMap();
         }
-    }
-
-    @Override
-    public void traceOriginAction(@NonNull MessageFrame frame) {
-        // NO-OP
-    }
-
-    @Override
-    public void sanitizeTracedActions(@NonNull MessageFrame frame) {
-        // NO-OP
-    }
-
-    @Override
-    public void tracePrecompileResult(@NonNull MessageFrame frame, @NonNull ContractActionType type) {
-        // NO-OP
-    }
-
-    @Override
-    public ContractActions contractActions() {
-        return null;
     }
 
     public void setSystemContracts(final Map<Address, HederaSystemContract> systemContracts) {

--- a/web3/src/main/java/org/hiero/mirror/web3/state/MirrorNodeState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/MirrorNodeState.java
@@ -14,6 +14,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.transaction.ThrottleDefinitions;
+import com.hedera.node.app.blocks.BlockStreamService;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.ids.AppEntityIdFactory;
@@ -420,7 +421,8 @@ public class MirrorNodeState implements MerkleNodeState {
                         new FeeService(),
                         new CongestionThrottleService(),
                         new RecordCacheService(),
-                        new ScheduleServiceImpl(appContext))
+                        new ScheduleServiceImpl(appContext),
+                        new BlockStreamService())
                 .forEach(servicesRegistry::register);
     }
 

--- a/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/StateRegistry.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/StateRegistry.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.web3.state.keyvalue;
 
 import com.google.common.collect.ImmutableMap;
+import com.hedera.node.app.blocks.schemas.V0560BlockStreamSchema;
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import com.hedera.node.app.service.schedule.impl.schemas.V0490ScheduleSchema;
 import com.hedera.node.app.service.schedule.impl.schemas.V0570ScheduleSchema;
@@ -33,6 +34,7 @@ public final class StateRegistry {
                     V0540RecordCacheSchema.TXN_RECEIPT_QUEUE,
                     V0490ScheduleSchema.SCHEDULES_BY_EXPIRY_SEC_KEY,
                     V0490ScheduleSchema.SCHEDULES_BY_EQUALITY_KEY,
+                    V0560BlockStreamSchema.BLOCK_STREAM_INFO_KEY,
                     V0570ScheduleSchema.SCHEDULED_COUNTS_KEY,
                     V0570ScheduleSchema.SCHEDULED_ORDERS_KEY,
                     V0570ScheduleSchema.SCHEDULE_ID_BY_EQUALITY_KEY,

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
@@ -8,7 +8,7 @@ import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
 import jakarta.inject.Named;
 
 @Named
-final class BlockStreamInfoSingleton implements SingletonState<com.hedera.hapi.node.state.blockstream.BlockStreamInfo> {
+final class BlockStreamInfoSingleton implements SingletonState<BlockStreamInfo> {
 
     @Override
     public String getKey() {

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
@@ -8,8 +8,7 @@ import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
 import jakarta.inject.Named;
 
 @Named
-public class BlockStreamInfoSingleton
-        implements SingletonState<com.hedera.hapi.node.state.blockstream.BlockStreamInfo> {
+final class BlockStreamInfoSingleton implements SingletonState<com.hedera.hapi.node.state.blockstream.BlockStreamInfo> {
 
     @Override
     public String getKey() {

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingleton.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.blocks.schemas.V0560BlockStreamSchema.BLOCK_STREAM_INFO_KEY;
+
+import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import jakarta.inject.Named;
+
+@Named
+public class BlockStreamInfoSingleton
+        implements SingletonState<com.hedera.hapi.node.state.blockstream.BlockStreamInfo> {
+
+    @Override
+    public String getKey() {
+        return BLOCK_STREAM_INFO_KEY;
+    }
+
+    @Override
+    public BlockStreamInfo get() {
+        return BlockStreamInfo.DEFAULT;
+    }
+}

--- a/web3/src/test/java/org/hiero/mirror/web3/state/MirrorNodeStateIntegrationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/MirrorNodeStateIntegrationTest.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.web3.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.node.app.blocks.BlockStreamService;
 import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.records.BlockRecordService;
@@ -160,7 +161,8 @@ public class MirrorNodeStateIntegrationTest extends Web3IntegrationTest {
                 FeeService.class,
                 CongestionThrottleService.class,
                 RecordCacheService.class,
-                ScheduleServiceImpl.class));
+                ScheduleServiceImpl.class,
+                BlockStreamService.class));
 
         final var registeredServices = servicesRegistry.registrations();
 

--- a/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingletonTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingletonTest.java
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.state.singleton;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import org.hiero.mirror.common.domain.DomainBuilder;
+import org.hiero.mirror.web3.ContextExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ContextExtension.class)
+class BlockStreamInfoSingletonTest {
+
+    private final BlockStreamInfoSingleton blockStreamInfoSingleton = new BlockStreamInfoSingleton();
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+
+    @Test
+    @DisplayName("should return the correct state key")
+    void key() {
+        // when
+        final var key = blockStreamInfoSingleton.getKey();
+
+        // then
+        assertThat(key).isEqualTo("BLOCK_STREAM_INFO");
+    }
+
+    @Test
+    @DisplayName("should always return default instance")
+    void set() {
+        // when
+        final var blockStreamInfo = BlockStreamInfo.newBuilder()
+                .blockNumber(0) // Setting to 0 to indicate a default or empty state
+                .inputTreeRootHash(Bytes.wrap(domainBuilder.bytes(20)))
+                .build();
+        blockStreamInfoSingleton.set(blockStreamInfo);
+
+        // then
+        assertThat(blockStreamInfoSingleton.get()).isEqualTo(BlockStreamInfo.DEFAULT);
+    }
+}

--- a/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingletonTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockStreamInfoSingletonTest.java
@@ -33,7 +33,7 @@ class BlockStreamInfoSingletonTest {
     void set() {
         // when
         final var blockStreamInfo = BlockStreamInfo.newBuilder()
-                .blockNumber(0) // Setting to 0 to indicate a default or empty state
+                .blockNumber(0)
                 .inputTreeRootHash(Bytes.wrap(domainBuilder.bytes(20)))
                 .build();
         blockStreamInfoSingleton.set(blockStreamInfo);


### PR DESCRIPTION
**Description**:
This PR bumps hedera.app to 0.64.0. The protobuf is kept at 0.63.5 since it wasn't updated at this release. It seems this does not interfere with bumping the hedera.app itself.

The PR also aligns some of the classpath overriden classes with the latest changes from hedera.app.

**Related issue(s)**:

Fixes #11542 

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
