### PR TITLE
Support clearing node grpc proxy endpoint (0.134)

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/node/AbstractNode.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/node/AbstractNode.java
@@ -37,7 +37,7 @@ public abstract class AbstractNode implements History {
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
     @JdbcTypeCode(SqlTypes.JSON)
-    @UpsertColumn(shouldCoalesce = false)
+    @UpsertColumn(coalesce = "case when ({0} -> ''port'')::integer = -1 then null else coalesce({0}, e_{0}) end")
     private ServiceEndpoint grpcProxyEndpoint;
 
     @Id

--- a/common/src/main/java/org/hiero/mirror/common/domain/node/ServiceEndpoint.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/node/ServiceEndpoint.java
@@ -5,4 +5,6 @@ package org.hiero.mirror.common.domain.node;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
-public record ServiceEndpoint(String domainName, String ipAddressV4, int port) {}
+public record ServiceEndpoint(String domainName, String ipAddressV4, int port) {
+    public static final ServiceEndpoint CLEAR = new ServiceEndpoint(null, null, -1);
+}

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractNodeTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractNodeTransactionHandler.java
@@ -35,6 +35,13 @@ public abstract class AbstractNodeTransactionHandler extends AbstractTransaction
 
     protected final ServiceEndpoint toServiceEndpoint(
             long consensusTimestamp, com.hederahashgraph.api.proto.java.ServiceEndpoint proto) {
+
+        // This won't happen for node create since consensus nodes reject default ServiceEndpoint
+        if (com.hederahashgraph.api.proto.java.ServiceEndpoint.getDefaultInstance()
+                .equals(proto)) {
+            return ServiceEndpoint.CLEAR;
+        }
+
         String ipAddress = StringUtils.EMPTY;
 
         try {


### PR DESCRIPTION
**Description**:

Support clearing the node.grpc_proxy_endpoint when ServiceEndpoint.getDefaultInstance() is set

**Related issue(s)**:

Fixes #11584

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
