### PR TITLE
Bump apache commons and tomcat versions (0.134)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 // Can't use typed variable syntax due to Dependabot limitations
 extra.apply {
     set("blockNodeVersion", "0.13.0")
+    set("commons-lang3.version", "3.18.0") // Temporary until next Spring Boot
     set("grpcVersion", "1.73.0")
     set("jooq.version", "3.20.5") // Must match buildSrc/build.gradle.kts
     set("prometheus-client.version", "1.3.6") // Temporary until 1.3.9+
@@ -23,6 +24,7 @@ extra.apply {
     set("nodeJsVersion", "22.14.0")
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
+    set("tomcat.version", "10.1.43") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }
 

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 tasks.withType<JavaCompile>().configureEach {
     // Disable serial and this-escape warnings due to errors in generated code
     options.compilerArgs.addAll(
-        listOf("-parameters", "-Werror", "-Xlint:all", "-Xlint:-this-escape,-preview")
+        listOf("-parameters", "-Werror", "-Xlint:all", "-Xlint:-this-escape,-preview,-deprecation")
     )
     options.encoding = "UTF-8"
     sourceCompatibility = "21"


### PR DESCRIPTION
**Description**:

* Bump Apache commons lang from `3.17.0` to `3.18.0`
* Bump tomcat version from `10.1.42` to `10.1.43` to address a vulnerability
* Disable deprecation warnings cause by commons change in release branch only

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
