### PR TITLE
Revert bump Cucumber to 7.25.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("com.salesforce.servicelibs:reactor-grpc-stub:$reactorGrpcVersion")
         api("commons-beanutils:commons-beanutils:1.11.0")
         api("commons-io:commons-io:2.19.0")
-        api("io.cucumber:cucumber-bom:7.25.0")
+        api("io.cucumber:cucumber-bom:7.23.0")
         api("io.github.mweirauch:micrometer-jvm-extras:0.2.2")
         api("io.grpc:grpc-bom:$grpcVersion")
         api("io.hypersistence:hypersistence-utils-hibernate-63:3.10.3")


### PR DESCRIPTION
**Description**:

Revert bump Cucumber to 7.25.0 as it requires junit 5.13

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
