### PR TITLE
Add workaround for sender is a smart contract simulations

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -224,7 +224,8 @@ public class TransactionExecutionService {
         if (account == null) {
             throwPayerAccountNotFoundException(SENDER_NOT_FOUND);
         } else if (account.smartContract()) {
-            throwPayerAccountNotFoundException(SENDER_IS_SMART_CONTRACT);
+            // If the sender is a smart contract, use the treasury account to allow simulation to proceed
+            return EntityIdUtils.toAccountId(systemEntity.treasuryAccount());
         }
 
         return accountIDNum;

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
@@ -600,7 +600,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     @Test
-    void ethCallWithValueAndSenderContractFails() {
+    void ethCallWithValueAndSenderContractSucceeds() {
         // Given
         final var receiverEntity = accountEntityWithEvmAddressPersist();
         final var receiverAddress = getAliasAddressFromEntity(receiverEntity);
@@ -610,14 +610,8 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 getContractExecutionParametersWithValue(Bytes.EMPTY, contractAddress, receiverAddress, 10L);
 
         // Then
-        if (mirrorNodeEvmProperties.isModularizedServices()) {
-            assertThatThrownBy(() -> contractExecutionService.processCall(serviceParameters))
-                    .isInstanceOf(MirrorEvmTransactionException.class)
-                    .hasMessage(PAYER_ACCOUNT_NOT_FOUND.name());
-        } else {
-            final var result = contractExecutionService.processCall(serviceParameters);
-            assertThat(result).isEqualTo(HEX_PREFIX);
-        }
+        final var result = contractExecutionService.processCall(serviceParameters);
+        assertThat(result).isEqualTo(HEX_PREFIX);
 
         assertGasLimit(serviceParameters);
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/TransactionExecutionServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/TransactionExecutionServiceTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.state.token.Account;
@@ -194,29 +193,6 @@ class TransactionExecutionServiceTest {
             } else {
                 when(aliasesReadableKVState.get(any())).thenReturn(null);
                 when(accountReadableKVState.get(any())).thenReturn(mock(Account.class));
-            }
-
-            var callServiceParameters = buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, senderAddress);
-
-            // Then
-            assertThatThrownBy(() -> transactionExecutionService.execute(callServiceParameters, DEFAULT_GAS))
-                    .isInstanceOf(MirrorEvmTransactionException.class)
-                    .hasMessage(PAYER_ACCOUNT_NOT_FOUND.name());
-        }
-
-        @MockitoSettings(strictness = Strictness.LENIENT)
-        @ParameterizedTest
-        @MethodSource("invalidSenderAddress")
-        void testExecuteContractCallInvalidSenderContract(final Address senderAddress) {
-            // Given
-            final var smartContractAccount = mock(Account.class);
-            when(smartContractAccount.smartContract()).thenReturn(true);
-            if (isMirror(senderAddress)) {
-                when(accountReadableKVState.get(any())).thenReturn(smartContractAccount);
-            } else {
-                final var accountID = mock(AccountID.class);
-                when(aliasesReadableKVState.get(any())).thenReturn(accountID);
-                when(accountReadableKVState.get(accountID)).thenReturn(smartContractAccount);
             }
 
             var callServiceParameters = buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, senderAddress);


### PR DESCRIPTION
**Description**:

This PR adds a workaround for smart contract senders to execute contract call simulations.

Previously we failed fast with SENDER_IS_SMART_CONTRACT status but this causes problems for smart accounts.

Modularized codebase does not allow top level payer to be a smart contract.

Workaround is: if the from address is a smart contract we just assign the treasury account as a sender.

We have the same logic when the from is the zero address  -> 

```
 if (params.getSender().canonicalAddress().isZero() && params.getValue() == 0L) {
            return EntityIdUtils.toAccountId(systemEntity.treasuryAccount());
 }
```

Added `isAssociated` test with the workaround flow.

Fixes #11547 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
