### PR TITLE
Update TestUtil to use toEvmAddress() from SDK

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -3,7 +3,6 @@
 package org.hiero.mirror.test.e2e.acceptance.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -205,6 +204,6 @@ public abstract class AbstractNetworkClient implements Cleanable {
                 .isEqualTo(
                         account.getPublicKey().isECDSA()
                                 ? account.getPublicKey().toEvmAddress().toString()
-                                : asHexAddress(account.getAccountId()).replace("0x", ""));
+                                : account.getAccountId().toEvmAddress());
     }
 }

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -2,8 +2,6 @@
 
 package org.hiero.mirror.test.e2e.acceptance.client;
 
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
-
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.ContractCallQuery;
@@ -214,7 +212,7 @@ public class ContractClient extends AbstractNetworkClient {
     }
 
     public String getClientAddress() {
-        return asHexAddress(sdkClient.getClient().getOperatorAccountId());
+        return sdkClient.getClient().getOperatorAccountId().toEvmAddress();
     }
 
     public record ExecuteContractResult(

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/EthereumClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/EthereumClient.java
@@ -2,9 +2,6 @@
 
 package org.hiero.mirror.test.e2e.acceptance.client;
 
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
-
 import com.hedera.hashgraph.sdk.ContractExecuteTransaction;
 import com.hedera.hashgraph.sdk.ContractFunctionParameters;
 import com.hedera.hashgraph.sdk.ContractFunctionResult;
@@ -101,7 +98,7 @@ public class EthereumClient extends AbstractNetworkClient {
                                 acceptanceTestProperties.getNetwork().getChainId(),
                                 getNonce(signerKey),
                                 maxContractFunctionGas(),
-                                asHexAddress(contractId),
+                                contractId.toEvmAddress(),
                                 value,
                                 callData,
                                 BigInteger.valueOf(20000L), // maxPriorityGas
@@ -111,7 +108,7 @@ public class EthereumClient extends AbstractNetworkClient {
                                 acceptanceTestProperties.getNetwork().getChainId(),
                                 getNonce(signerKey),
                                 maxContractFunctionGas(),
-                                asAddress(contractId).toString(),
+                                contractId.toEvmAddress(),
                                 value,
                                 callData,
                                 BigInteger.valueOf(20000L), // maxPriorityGas

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/NetworkAdapter.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/NetworkAdapter.java
@@ -3,7 +3,6 @@
 package org.hiero.mirror.test.e2e.acceptance.client;
 
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 
 import com.esaulpaugh.headlong.abi.TupleType;
 import com.esaulpaugh.headlong.util.Strings;
@@ -50,7 +49,7 @@ public class NetworkAdapter extends EncoderDecoderFacade {
                         .data(data)
                         .estimate(isEstimate)
                         .from(from.isEmpty() ? contractClient.getClientAddress() : from)
-                        .to(asHexAddress(deployedContract.contractId()));
+                        .to(deployedContract.contractId().toEvmAddress());
 
                 return mirrorClient.contractsCall(contractCallRequestBody);
             } catch (Exception e) {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -119,7 +119,7 @@ public class CallFeature extends AbstractFeature {
     @Given("I successfully create ERC contract")
     public void createNewERCtestContract() {
         deployedErcTestContract = getContract(ERC);
-        ercContractAddress = asHexAddress(deployedErcTestContract.contractId());
+        ercContractAddress = deployedErcTestContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create Precompile contract")
@@ -132,7 +132,8 @@ public class CallFeature extends AbstractFeature {
     @Given("I successfully create EstimateGas contract")
     public void createNewEstimateTestContract() throws IOException {
         deployedEstimatePrecompileContract = getContract(ESTIMATE_GAS);
-        estimateContractAddress = asHexAddress(deployedEstimatePrecompileContract.contractId());
+        estimateContractAddress =
+                deployedEstimatePrecompileContract.contractId().toEvmAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         adminAddress = asAddress(admin);
         receiverAccountId = accountClient.getAccount(AccountNameEnum.ALICE);

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -49,7 +49,6 @@ import com.hedera.hashgraph.sdk.TokenId;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 import lombok.CustomLog;
@@ -130,7 +129,7 @@ public class CallFeature extends AbstractFeature {
     }
 
     @Given("I successfully create EstimateGas contract")
-    public void createNewEstimateTestContract() throws IOException {
+    public void createNewEstimateTestContract() {
         deployedEstimatePrecompileContract = getContract(ESTIMATE_GAS);
         estimateContractAddress =
                 deployedEstimatePrecompileContract.contractId().toEvmAddress();

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -8,7 +8,6 @@ import static org.hiero.mirror.rest.model.TransactionTypes.CONTRACTCALL;
 import static org.hiero.mirror.rest.model.TransactionTypes.CONTRACTCREATEINSTANCE;
 import static org.hiero.mirror.rest.model.TransactionTypes.CRYPTOCREATEACCOUNT;
 import static org.hiero.mirror.rest.model.TransactionTypes.CRYPTOTRANSFER;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -140,7 +139,7 @@ public class ContractFeature extends BaseContractFeature {
         }
 
         var from = contractClient.getClientAddress();
-        var to = asHexAddress(deployedParentContract.contractId());
+        var to = deployedParentContract.contractId().toEvmAddress();
 
         var contractCallRequestGetAccountBalance = ModelBuilder.contractCallRequest()
                 .data(GET_ACCOUNT_BALANCE_SELECTOR)

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -16,7 +16,6 @@ import static org.hiero.mirror.test.e2e.acceptance.steps.ERCContractFeature.Cont
 import static org.hiero.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.TOKEN_URI_SELECTOR;
 import static org.hiero.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.TOTAL_SUPPLY_SELECTOR;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.hedera.hashgraph.sdk.NftId;
@@ -208,7 +207,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Given("I successfully create an erc contract from contract bytes with balance 0")
     public void createNewContract() {
         deployedErcContract = getContract(ERC);
-        ercTestContractSolidityAddress = asHexAddress(deployedErcContract.contractId());
+        ercTestContractSolidityAddress = deployedErcContract.contractId().toEvmAddress();
     }
 
     @Then("I create a new token with freeze status 2 and kyc status 1")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -13,7 +13,6 @@ import static org.hiero.mirror.test.e2e.acceptance.steps.EquivalenceFeature.Cont
 import static org.hiero.mirror.test.e2e.acceptance.steps.EquivalenceFeature.ContractMethods.GET_CODE_HASH;
 import static org.hiero.mirror.test.e2e.acceptance.steps.EquivalenceFeature.ContractMethods.GET_CODE_SIZE;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 
 import com.esaulpaugh.headlong.abi.TupleType;
 import io.cucumber.java.en.Given;
@@ -45,13 +44,15 @@ public class EquivalenceFeature extends AbstractFeature {
     @Given("I successfully create selfdestruct contract")
     public void createNewSelfDestructContract() {
         equivalenceDestructContract = getContract(EQUIVALENCE_DESTRUCT);
-        equivalenceDestructContractSolidityAddress = asHexAddress(equivalenceDestructContract.contractId());
+        equivalenceDestructContractSolidityAddress =
+                equivalenceDestructContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create equivalence call contract")
     public void createNewEquivalenceCallContract() {
         equivalenceCallContract = getContract(EQUIVALENCE_CALL);
-        equivalenceCallContractSolidityAddress = asHexAddress(equivalenceCallContract.contractId());
+        equivalenceCallContractSolidityAddress =
+                equivalenceCallContract.contractId().toEvmAddress();
     }
 
     @RetryAsserts

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -105,7 +105,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Given("I successfully create EstimateGas contract from contract bytes")
     public void createNewEstimateContract() {
         deployedContract = getContract(ESTIMATE_GAS);
-        contractSolidityAddress = asHexAddress(deployedContract.contractId());
+        contractSolidityAddress = deployedContract.contractId().toEvmAddress();
         newAccountEvmAddress =
                 PrivateKey.generateECDSA().getPublicKey().toEvmAddress().toString();
         receiverAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.BOB);
@@ -126,7 +126,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Given("I successfully create Precompile contract from contract bytes")
     public void createNewPrecompileContract() {
         deployedPrecompileContract = getContract(PRECOMPILE);
-        precompileSolidityAddress = asHexAddress(deployedPrecompileContract.contractId());
+        precompileSolidityAddress = deployedPrecompileContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create ERC contract from contract bytes")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -132,7 +132,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Given("I successfully create ERC contract from contract bytes")
     public void createNewERCContract() {
         deployedERCContract = getContract(ERC);
-        ercSolidityAddress = asAddress(deployedERCContract.contractId()).toString();
+        ercSolidityAddress = deployedERCContract.contractId().toEvmAddress();
     }
 
     @Then("the mirror node REST API should return status {int} for the estimate contract creation")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -128,7 +128,6 @@ import com.hedera.hashgraph.sdk.TokenUpdateTransaction;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
@@ -189,7 +188,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private String precompileTestContractSolidityAddress;
 
     @Given("I create estimate precompile contract with 0 balance")
-    public void createNewEstimateContract() throws IOException {
+    public void createNewEstimateContract() {
         deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE);
         estimatePrecompileContractSolidityAddress =
                 deployedEstimatePrecompileContract.contractId().toEvmAddress();

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -205,8 +205,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Given("I create erc test contract with 0 balance")
     public void createNewERCContract() {
         deployedErcTestContract = getContract(ERC);
-        ercTestContractSolidityAddress =
-                asAddress(deployedErcTestContract.contractId()).toString();
+        ercTestContractSolidityAddress = deployedErcTestContract.contractId().toEvmAddress();
     }
 
     @Given("I get exchange rates")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -191,7 +191,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Given("I create estimate precompile contract with 0 balance")
     public void createNewEstimateContract() throws IOException {
         deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE);
-        estimatePrecompileContractSolidityAddress = asHexAddress(deployedEstimatePrecompileContract.contractId());
+        estimatePrecompileContractSolidityAddress =
+                deployedEstimatePrecompileContract.contractId().toEvmAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         adminAddress = asAddress(admin);
         receiverAccount = accountClient.getAccount(AccountClient.AccountNameEnum.BOB);
@@ -216,7 +217,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Given("I successfully create Precompile contract with 0 balance")
     public void createNewPrecompileTestContract() {
         deployedPrecompileContract = getContract(PRECOMPILE);
-        precompileTestContractSolidityAddress = asHexAddress(deployedPrecompileContract.contractId());
+        precompileTestContractSolidityAddress =
+                deployedPrecompileContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create fungible tokens")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PARENT_CONTRACT;
 import static org.hiero.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CREATE_CHILD;
 import static org.hiero.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.GET_BYTE_CODE;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 import static org.web3j.crypto.transaction.type.TransactionType.EIP1559;
 import static org.web3j.crypto.transaction.type.TransactionType.EIP2930;
 
@@ -69,7 +68,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
         deployedParentContract = ethereumContractCreate(PARENT_CONTRACT);
 
         gasConsumedSelector = Objects.requireNonNull(mirrorClient
-                .getContractInfo(asHexAddress(deployedParentContract.contractId()))
+                .getContractInfo(deployedParentContract.contractId().toEvmAddress())
                 .getBytecode());
     }
 

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -33,7 +33,6 @@ import static org.hiero.mirror.test.e2e.acceptance.steps.PrecompileContractFeatu
 import static org.hiero.mirror.test.e2e.acceptance.steps.PrecompileContractFeature.ContractMethods.IS_KYC_GRANTED_SELECTOR;
 import static org.hiero.mirror.test.e2e.acceptance.steps.PrecompileContractFeature.ContractMethods.IS_TOKEN_FROZEN_SELECTOR;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -97,19 +96,20 @@ public class HistoricalFeature extends AbstractEstimateFeature {
     @Given("I successfully create estimateGas contract")
     public void createNewEstimateContract() {
         deployedEstimateContract = getContract(ESTIMATE_GAS);
-        estimateContractSolidityAddress = asHexAddress(deployedEstimateContract.contractId());
+        estimateContractSolidityAddress = deployedEstimateContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create estimate precompile contract")
     public void createNewEstimatePrecompileContract() {
         deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE);
-        estimatePrecompileContractSolidityAddress = asHexAddress(deployedEstimatePrecompileContract.contractId());
+        estimatePrecompileContractSolidityAddress =
+                deployedEstimatePrecompileContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create erc contract")
     public void createNewErcContract() {
         deployedErcContract = getContract(ERC);
-        ercContractSolidityAddress = asHexAddress(deployedErcContract.contractId());
+        ercContractSolidityAddress = deployedErcContract.contractId().toEvmAddress();
     }
 
     @Given("I successfully create precompile contract")
@@ -400,7 +400,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
 
         var data = encodeData(BALANCE_OF_SELECTOR, adminAddress);
         var initialBlockNumber = getLastBlockNumber();
-        var response = callContract(data, asHexAddress(tokenId));
+        var response = callContract(data, tokenId.toEvmAddress());
         var initialBalance = response.getResultAsNumber();
 
         waitForNextBlock();
@@ -545,7 +545,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var tokenId = tokenClient.getToken(tokenName).tokenId();
         var data = encodeData(ALLOWANCE_DIRECT_SELECTOR, adminAddress, receiverAccountAddress);
         var initialBlockNumber = getLastBlockNumber();
-        var response = callContract(data, asHexAddress(tokenId));
+        var response = callContract(data, tokenId.toEvmAddress());
         var initialAllowance = response.getResultAsNumber();
 
         waitForNextBlock();
@@ -566,7 +566,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         verifyMirrorTransactionsResponse(mirrorClient, 200);
         var initialBlockNumber = getLastBlockNumber();
         var data = encodeData(GET_APPROVED_DIRECT_SELECTOR, new BigInteger("1"));
-        var response = callContract(data, asHexAddress(tokenId));
+        var response = callContract(data, tokenId.toEvmAddress());
         var initialApprovedAddress = response.getResultAsAddress();
 
         waitForNextBlock();

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -116,7 +116,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
     public void createNewPrecompileContract() {
         deployedPrecompileContract = getContract(PRECOMPILE);
         precompileContractSolidityAddress =
-                asAddress(deployedPrecompileContract.contractId()).toString();
+                deployedPrecompileContract.contractId().toEvmAddress();
     }
 
     @Given("I create admin and receiver accounts")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -28,7 +28,6 @@ import static org.hiero.mirror.test.e2e.acceptance.steps.PrecompileContractFeatu
 import static org.hiero.mirror.test.e2e.acceptance.steps.PrecompileContractFeature.ContractMethods.TOTAL_SUPPLY_SELECTOR;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.ZERO_ADDRESS;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
-import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.asHexAddress;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.getAbiFunctionAsJsonString;
 import static org.hiero.mirror.test.e2e.acceptance.util.TestUtil.nextBytes;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -102,7 +101,8 @@ public class PrecompileContractFeature extends AbstractFeature {
     @Given("I successfully create and verify a precompile contract from contract bytes")
     public void createNewContract() {
         deployedPrecompileContract = getContract(PRECOMPILE);
-        precompileTestContractSolidityAddress = asHexAddress(deployedPrecompileContract.contractId());
+        precompileTestContractSolidityAddress =
+                deployedPrecompileContract.contractId().toEvmAddress();
         contractClientAddress = asAddress(contractClient.getClientAddress());
     }
 
@@ -692,7 +692,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat((long) fractionalFee.get(3)).isEqualTo(MAX_FEE_AMOUNT);
         assertFalse((boolean) fractionalFee.get(4));
         assertThat(fractionalFee.get(5).toString().toLowerCase())
-                .isEqualTo(contractClient.getClientAddress().toLowerCase());
+                .isEqualTo("0x" + contractClient.getClientAddress().toLowerCase());
     }
 
     // ETHCALL-033
@@ -708,10 +708,12 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat((long) royaltyFee.get(0)).isEqualTo(NUMERATOR_VALUE);
         assertThat((long) royaltyFee.get(1)).isEqualTo(DENOMINATOR_VALUE);
         assertThat(royaltyFee.get(5).toString().toLowerCase())
-                .isEqualTo(asHexAddress(tokenClient
-                        .getSdkClient()
-                        .getExpandedOperatorAccountId()
-                        .getAccountId()));
+                .isEqualTo("0x"
+                        + tokenClient
+                                .getSdkClient()
+                                .getExpandedOperatorAccountId()
+                                .getAccountId()
+                                .toEvmAddress());
     }
 
     // ETHCALL-034
@@ -728,10 +730,12 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat(royaltyFee.get(3).toString()).hasToString(fungibleTokenCustomFeeAddress.toString());
         assertFalse((boolean) royaltyFee.get(4));
         assertThat(royaltyFee.get(5).toString().toLowerCase())
-                .hasToString(asHexAddress(tokenClient
-                        .getSdkClient()
-                        .getExpandedOperatorAccountId()
-                        .getAccountId()));
+                .hasToString("0x"
+                        + tokenClient
+                                .getSdkClient()
+                                .getExpandedOperatorAccountId()
+                                .getAccountId()
+                                .toEvmAddress());
     }
 
     private void tokenKeyCheck(final Tuple result) {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -33,6 +33,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hiero.mirror.common.CommonProperties;
 import org.hiero.mirror.common.util.DomainUtils;
+import org.hiero.mirror.test.e2e.acceptance.client.ContractClient;
 import org.hiero.mirror.test.e2e.acceptance.client.TokenClient;
 import org.hiero.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
@@ -75,57 +76,39 @@ public class TestUtil {
     }
 
     public static Address asAddress(final String address) {
-        final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
-        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
-        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
-    }
-    /*
-       When toSolidityAddress() is fixed upstream to not encode shard & realm
-       we can change below asAddress methods to something like this.
-
-       final var address = accountId.getAccountId().toSolidityAddress();
-       return asAddress(address);
-
-       Possibly some .replace("0x", "") can be removed after the switch back to toSolidityAddress()
-       getClientAddress() - can be changed as well
-       accountAmount(), nftAmount(), asAddressArray() - places where these are used probably should be reverted as to not have to go through asAddress 2 times
-    */
-    public static Address asAddress(final ExpandedAccountId accountId) {
-        return asAddress(accountId.getAccountId().num);
+        return toAddressFromHex(address);
     }
 
-    public static Address asAddress(final TokenId tokenId) {
-        return asAddress(tokenId.num);
+    public static Address asAddress(ExpandedAccountId accountId) {
+        return toAddressFromHex(accountId.getAccountId().toEvmAddress());
     }
 
-    public static Address asAddress(final ContractId contractId) {
-        return asAddress(contractId.num);
+    public static Address asAddress(TokenId tokenId) {
+        return toAddressFromHex(tokenId.toEvmAddress());
     }
 
-    public static Address asAddress(final AccountId accountId) {
-        return asAddress(accountId.num);
+    public static Address asAddress(ContractId contractId) {
+        return toAddressFromHex(contractId.toEvmAddress());
     }
 
-    public static Address asAddress(final TokenClient tokenClient) {
-        final var num =
-                tokenClient.getSdkClient().getExpandedOperatorAccountId().getAccountId().num;
-        return asAddress(num);
+    public static Address asAddress(AccountId accountId) {
+        return toAddressFromHex(accountId.toEvmAddress());
+    }
+
+    public static Address asAddress(ContractClient contractClient) {
+        return toAddressFromHex(contractClient.getClientAddress());
+    }
+
+    public static Address asAddress(TokenClient tokenClient) {
+        return toAddressFromHex(tokenClient
+                .getSdkClient()
+                .getExpandedOperatorAccountId()
+                .getAccountId()
+                .toEvmAddress());
     }
 
     public static Address asAddress(final long num) {
         return Address.wrap(Address.toChecksumAddress(BigInteger.valueOf(num)));
-    }
-
-    public static String asHexAddress(final AccountId accountId) {
-        return asAddress(accountId.num).toString().toLowerCase();
-    }
-
-    public static String asHexAddress(final ContractId contractId) {
-        return asAddress(contractId.num).toString().toLowerCase();
-    }
-
-    public static String asHexAddress(final TokenId tokenId) {
-        return asAddress(tokenId.num).toString().toLowerCase();
     }
 
     public static Tuple accountAmount(String account, Long amount, boolean isApproval) {
@@ -238,6 +221,13 @@ public class TestUtil {
         long seconds = Long.parseLong(parts[0]);
         long nanos = Long.parseLong(parts[1]);
         return Instant.ofEpochSecond(seconds, nanos);
+    }
+
+    private static Address toAddressFromHex(String hex) {
+        final var normalized = hex.startsWith("0x") ? hex : "0x" + hex;
+        final var addressBytes = Bytes.fromHexString(normalized);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
     }
 
     public static class TokenTransferListBuilder {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -79,27 +79,27 @@ public class TestUtil {
         return toAddressFromHex(address);
     }
 
-    public static Address asAddress(ExpandedAccountId accountId) {
+    public static Address asAddress(final ExpandedAccountId accountId) {
         return toAddressFromHex(accountId.getAccountId().toEvmAddress());
     }
 
-    public static Address asAddress(TokenId tokenId) {
+    public static Address asAddress(final TokenId tokenId) {
         return toAddressFromHex(tokenId.toEvmAddress());
     }
 
-    public static Address asAddress(ContractId contractId) {
+    public static Address asAddress(final ContractId contractId) {
         return toAddressFromHex(contractId.toEvmAddress());
     }
 
-    public static Address asAddress(AccountId accountId) {
+    public static Address asAddress(final AccountId accountId) {
         return toAddressFromHex(accountId.toEvmAddress());
     }
 
-    public static Address asAddress(ContractClient contractClient) {
+    public static Address asAddress(final ContractClient contractClient) {
         return toAddressFromHex(contractClient.getClientAddress());
     }
 
-    public static Address asAddress(TokenClient tokenClient) {
+    public static Address asAddress(final TokenClient tokenClient) {
         return toAddressFromHex(tokenClient
                 .getSdkClient()
                 .getExpandedOperatorAccountId()
@@ -223,7 +223,7 @@ public class TestUtil {
         return Instant.ofEpochSecond(seconds, nanos);
     }
 
-    private static Address toAddressFromHex(String hex) {
+    private static Address toAddressFromHex(final String hex) {
         final var normalized = hex.startsWith("0x") ? hex : "0x" + hex;
         final var addressBytes = Bytes.fromHexString(normalized);
         final var addressAsInteger = addressBytes.toUnsignedBigInteger();


### PR DESCRIPTION
**Description**:

This PR adapts acceptance tests to use newly added `toEvmAddress()` method from latest java sdk.
Reverts workarounds from https://github.com/hiero-ledger/hiero-mirror-node/pull/11292 and use `toEvmAddress()` instead of deprecated `toSolidityAddress()`.


Fixes #11646

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
