### PR TITLE
Bump Spring Boot from 3.5.3 to 3.5.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,13 +19,10 @@ extra.apply {
     set("commons-lang3.version", "3.18.0") // Temporary until next Spring Boot
     set("grpcVersion", "1.73.0")
     set("jooq.version", "3.20.5") // Must match buildSrc/build.gradle.kts
-    set("prometheus-client.version", "1.3.10") // Temporary until next Spring Boot
     set("mapStructVersion", "1.6.3")
     set("nodeJsVersion", "22.17.1")
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
-    set("reactor-bom.version", "2024.0.8") // Temporary until next Spring Boot
-    set("tomcat.version", "10.1.43") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("org.jooq:jooq-postgres-extensions:${jooqVersion}")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.14.0")
     implementation("org.owasp:dependency-check-gradle:12.1.3")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.3")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.4")
     implementation("org.testcontainers:postgresql:1.21.3")
     implementation("org.web3j:web3j-gradle-plugin:4.14.0")
 }

--- a/charts/hedera-mirror-importer/templates/secret.yaml
+++ b/charts/hedera-mirror-importer/templates/secret.yaml
@@ -10,7 +10,7 @@ type: Opaque
 data:
   {{- $config := deepCopy .Values.config }}
   {{- if .Values.addressBook }}
-  {{- $addressBookConfig := dict "hedera" (dict "mirror" (dict "importer" (dict "initialAddressBook" "/usr/etc/hiero/addressbook.bin" ))) }}
+  {{- $addressBookConfig := dict "hiero" (dict "mirror" (dict "importer" (dict "initialAddressBook" "/usr/etc/hiero/addressbook.bin" ))) }}
   {{- $config = merge $config $addressBookConfig }}
   addressbook.bin: {{ .Values.addressBook }}
   {{- end }}


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 3.5.3 to 3.5.4
* Fix legacy `hedera.mirror.importer.initialAddressBook` property used in chart
* Remove temporary overrides for Prometheus, Reactor, and Tomcat

**Related issue(s)**:

**Notes for reviewer**:

commons-lang3 is still on 3.17 in 3.5.4

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
