### PR TITLE
Fix contract result logs topics formatting when empty

### DIFF
--- a/rest/__tests__/viewmodel/contractLogViewModel.test.js
+++ b/rest/__tests__/viewmodel/contractLogViewModel.test.js
@@ -80,4 +80,22 @@ describe('ContractLogViewModel', () => {
       root_contract_id: null,
     });
   });
+
+  test('ContractLogViewModel - empty topic buffer is replaced with ZERO_UINT256', () => {
+    expect(
+      new ContractLogViewModel({
+        ...defaultContractLog,
+        topic0: Buffer.alloc(0), // empty buffer
+        topic1: null,
+        topic2: Buffer.alloc(0), // empty buffer
+        topic3: null,
+      })
+    ).toEqual({
+      ...defaultExpected,
+      topics: [
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      ],
+    });
+  });
 });

--- a/rest/viewmodel/contractResultLogViewModel.js
+++ b/rest/viewmodel/contractResultLogViewModel.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import EntityId from '../entityId';
-import {filterKeys} from '../constants';
+import {filterKeys, ZERO_UINT256} from '../constants';
 import {toHexString} from '../utils';
 
 /**
@@ -26,7 +26,12 @@ class ContractResultLogViewModel {
   }
 
   _formatTopics(topics) {
-    return topics.filter((topic) => topic !== null).map((topic) => toHexString(topic, true, 64));
+    return topics
+      .filter((topic) => topic !== null)
+      .map((topic) => {
+        const hex = toHexString(topic, true, 64);
+        return hex === '0x' ? ZERO_UINT256 : hex;
+      });
   }
 }
 


### PR DESCRIPTION
**Description**:
This PR ensures that empty topic buffers in /contracts/results/logs are serialized as 0x00000...00000000000000000000 instead of "0x", to comply with the JSON-RPC spec `(^0x[0-9a-fA-F]{64}$)`.

**Related issue(s)**:

Fixes #11659

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
