### PR TITLE
Show null topic fee schedule key when cleared

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/mapper/CommonMapper.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/mapper/CommonMapper.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Range;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.KeyList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.commons.codec.binary.Hex;
@@ -68,7 +69,7 @@ public interface CommonMapper {
 
     default List<Key> mapKeyList(byte[] source) {
         if (ArrayUtils.isEmpty(source)) {
-            return null;
+            return Collections.emptyList();
         }
 
         try {

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/CommonMapperTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/CommonMapperTest.java
@@ -59,7 +59,7 @@ class CommonMapperTest {
         var feeExemptKeyList =
                 FeeExemptKeyList.newBuilder().addAllKeys(keyList.getKeysList()).build();
         var emptyKeyList = KeyList.newBuilder().build();
-        var emptyFeeExemptyKeyList = FeeExemptKeyList.newBuilder().build();
+        var emptyFeeExemptKeyList = FeeExemptKeyList.newBuilder().build();
         var expectedKeyList = List.of(
                 new org.hiero.mirror.rest.model.Key()
                         .key(Hex.encodeHexString(bytesEcdsa))
@@ -72,12 +72,12 @@ class CommonMapperTest {
                         .type(TypeEnum.PROTOBUF_ENCODED));
 
         // Then
-        assertThat(commonMapper.mapKeyList(null)).isNull();
+        assertThat(commonMapper.mapKeyList(null)).isEmpty();
+        assertThat(commonMapper.mapKeyList(new byte[0])).isEmpty();
         assertThat(commonMapper.mapKeyList(keyList.toByteArray())).isEqualTo(expectedKeyList);
         assertThat(commonMapper.mapKeyList(feeExemptKeyList.toByteArray())).isEqualTo(expectedKeyList);
-        assertThat(commonMapper.mapKeyList(emptyKeyList.toByteArray())).isNull();
-        assertThat(commonMapper.mapKeyList(emptyFeeExemptyKeyList.toByteArray()))
-                .isNull();
+        assertThat(commonMapper.mapKeyList(emptyKeyList.toByteArray())).isEmpty();
+        assertThat(commonMapper.mapKeyList(emptyFeeExemptKeyList.toByteArray())).isEmpty();
     }
 
     @SneakyThrows

--- a/rest/api/v1/openapi.yml
+++ b/rest/api/v1/openapi.yml
@@ -3728,7 +3728,6 @@ components:
           type: boolean
         fee_exempt_key_list:
           description: Keys permitted to submit messages to the topic without paying custom fees
-          nullable: true
           type: array
           items:
             $ref: "#/components/schemas/Key"

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -187,11 +187,10 @@ public class TopicFeature extends AbstractFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
         var getTopicResponse = mirrorClient.getTopic(consensusTopicId.toString());
-        assertThat(getTopicResponse).isNotNull();
-        assertThat(getTopicResponse.getFeeScheduleKey().getType()).isEqualTo(TypeEnum.PROTOBUF_ENCODED);
-        assertThat(getTopicResponse.getFeeScheduleKey().getKey()).isEqualTo("3200");
-        assertThat(getTopicResponse.getCustomFees().getFixedFees()).isEmpty();
-        assertThat(getTopicResponse.getFeeExemptKeyList()).isEmpty();
+        assertThat(getTopicResponse)
+                .satisfies(r -> assertThat(r.getCustomFees().getFixedFees()).isEmpty())
+                .satisfies(r -> assertThat(r.getFeeExemptKeyList()).isEmpty())
+                .returns(null, Topic::getFeeScheduleKey);
     }
 
     @When("I successfully delete the topic")


### PR DESCRIPTION
**Description**:

This PR fixes the fee schedule key bug in topic by id endpoint

- Show null `fee_schedule_key` when it's set to an empty key list key to indicate it's cleared
- Update acceptance test

**Related issue(s)**:

Fixes #11687 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
