### PR TITLE
Show null topic fee schedule key when cleared (0.135)

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/mapper/CommonMapper.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/mapper/CommonMapper.java
@@ -5,6 +5,7 @@ package org.hiero.mirror.restjava.mapper;
 import com.google.common.collect.Range;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.KeyList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -23,10 +24,14 @@ import org.mapstruct.Named;
 @Mapper(mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_FROM_CONFIG)
 public interface CommonMapper {
 
-    String QUALIFIER_TIMESTAMP = "timestamp";
+    byte[] IMMUTABILITY_SENTINEL_KEY = com.hederahashgraph.api.proto.java.Key.newBuilder()
+            .setKeyList(KeyList.getDefaultInstance())
+            .build()
+            .toByteArray();
     int NANO_DIGITS = 9;
     Pattern PATTERN_ECDSA = Pattern.compile("^(3a21|32250a233a21|2a29080112250a233a21)([A-Fa-f0-9]{66})$");
     Pattern PATTERN_ED25519 = Pattern.compile("^(1220|32240a221220|2a28080112240a221220)([A-Fa-f0-9]{64})$");
+    String QUALIFIER_TIMESTAMP = "timestamp";
 
     default String mapEntityId(Long source) {
         if (source == null || source == 0) {
@@ -42,7 +47,7 @@ public interface CommonMapper {
     }
 
     default Key mapKey(byte[] source) {
-        if (source == null) {
+        if (source == null || Arrays.equals(source, IMMUTABILITY_SENTINEL_KEY)) {
             return null;
         }
 

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/CommonMapperTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/CommonMapperTest.java
@@ -58,6 +58,8 @@ class CommonMapperTest {
         var keyList = innerKeyList.toBuilder().addKeys(innerKeyListKey).build();
         var feeExemptKeyList =
                 FeeExemptKeyList.newBuilder().addAllKeys(keyList.getKeysList()).build();
+        var emptyKeyList = KeyList.newBuilder().build();
+        var emptyFeeExemptKeyList = FeeExemptKeyList.newBuilder().build();
         var expectedKeyList = List.of(
                 new org.hiero.mirror.rest.model.Key()
                         .key(Hex.encodeHexString(bytesEcdsa))
@@ -74,6 +76,8 @@ class CommonMapperTest {
         assertThat(commonMapper.mapKeyList(new byte[0])).isEmpty();
         assertThat(commonMapper.mapKeyList(keyList.toByteArray())).isEqualTo(expectedKeyList);
         assertThat(commonMapper.mapKeyList(feeExemptKeyList.toByteArray())).isEqualTo(expectedKeyList);
+        assertThat(commonMapper.mapKeyList(emptyKeyList.toByteArray())).isEmpty();
+        assertThat(commonMapper.mapKeyList(emptyFeeExemptKeyList.toByteArray())).isEmpty();
     }
 
     @SneakyThrows
@@ -98,6 +102,8 @@ class CommonMapperTest {
         var ed25519List = Key.newBuilder()
                 .setKeyList(KeyList.newBuilder().addKeys(ed25519))
                 .build();
+        var emptyKeyListKey =
+                Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build();
         var protobufEncoded = Key.newBuilder()
                 .setKeyList(KeyList.newBuilder().addKeys(ecdsa).addKeys(ed25519))
                 .build()
@@ -111,6 +117,7 @@ class CommonMapperTest {
         assertThat(commonMapper.mapKey(ed25519.toByteArray())).isEqualTo(toKey(bytesEd25519, TypeEnum.ED25519));
         assertThat(commonMapper.mapKey(ed25519.toByteArray())).isEqualTo(toKey(bytesEd25519, TypeEnum.ED25519));
         assertThat(commonMapper.mapKey(ed25519List.toByteArray())).isEqualTo(toKey(bytesEd25519, TypeEnum.ED25519));
+        assertThat(commonMapper.mapKey(emptyKeyListKey.toByteArray())).isNull();
         assertThat(commonMapper.mapKey(protobufEncoded)).isEqualTo(toKey(protobufEncoded, TypeEnum.PROTOBUF_ENCODED));
     }
 

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -187,11 +187,10 @@ public class TopicFeature extends AbstractFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
         var getTopicResponse = mirrorClient.getTopic(consensusTopicId.toString());
-        assertThat(getTopicResponse).isNotNull();
-        assertThat(getTopicResponse.getFeeScheduleKey().getType()).isEqualTo(TypeEnum.PROTOBUF_ENCODED);
-        assertThat(getTopicResponse.getFeeScheduleKey().getKey()).isEqualTo("3200");
-        assertThat(getTopicResponse.getCustomFees().getFixedFees()).isEmpty();
-        assertThat(getTopicResponse.getFeeExemptKeyList()).isEmpty();
+        assertThat(getTopicResponse)
+                .satisfies(r -> assertThat(r.getCustomFees().getFixedFees()).isEmpty())
+                .satisfies(r -> assertThat(r.getFeeExemptKeyList()).isEmpty())
+                .returns(null, Topic::getFeeScheduleKey);
     }
 
     @When("I successfully delete the topic")


### PR DESCRIPTION
**Description**:

This PR cherry-picks the fix to `release/0.135`:

- Show null fee_schedule_key when it's set to an empty key list key to indicate it's cleared
- Update acceptance test

**Related issue(s)**:

Fixes #11687 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
