### PR TITLE
Disable failing web3 acceptance test in testnet-eu

### DIFF
--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -77,7 +77,7 @@ spec:
         persistentVolume:
           size: 90Gi
     test:
-      cucumberTags: "@acceptance and not @estimateprecompile"
+      cucumberTags: "@acceptance and not @call and not @estimateprecompile"
       enabled: true
       env:
         HIERO_MIRROR_TEST_ACCEPTANCE_WEB3_MODULARIZEDSERVICES: "true"


### PR DESCRIPTION
**Description**:

This PR disables failing web3 acceptance test in testnet-eu.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

See #11693. This is a workaround to bring testnet-eu back online before we understand and address the test failure. Also note there's no fine-grained tag to only disable the `Validate eth_call` test case.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
