### PR TITLE
Fix failing acceptance tests for dissociate tokens in call.feature 

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -657,7 +657,7 @@ public class CallFeature extends AbstractFeature {
                 asAddress(thirdReceiver),
                 new BigInteger("1"),
                 new BigInteger("0"));
-        var response = callContract(data, precompileContractAddress);
+        var response = callContract(data, precompileContractAddress, 2_000_000);
         var resultList = response.getResultAsListDecimal();
         var statusAfterAssociate = resultList.get(0);
         var statusAfterDissociate = resultList.get(1);
@@ -680,7 +680,7 @@ public class CallFeature extends AbstractFeature {
                 asAddress(secondReceiverAlias),
                 new BigInteger("0"),
                 new BigInteger("1"));
-        var response = callContract(data, precompileContractAddress);
+        var response = callContract(data, precompileContractAddress, 2_000_000);
         var resultList = response.getResultAsListDecimal();
         var statusAfterAssociate = resultList.get(0);
         var statusAfterDissociate = resultList.get(1);

--- a/test/src/test/resources/features/contract/call.feature
+++ b/test/src/test/resources/features/contract/call.feature
@@ -1,4 +1,4 @@
-@contractbase @fullsuite @acceptance @web3 @call
+@contractbase @fullsuite @acceptance @web3 @call @ethcall
 Feature: eth_call Contract Base Coverage Feature
 
   Scenario Outline: Validate eth_call


### PR DESCRIPTION
There were dissociate tokens  failing tests on testnet in call.feature. The tests were failing with INSUFFICIENT_GAS 
This PR adds a workaround that increases the gas that is passed only for those 2 failing tests
Also a new ethcall tag is added to the test suite for distinction

**Related issue(s)**:

Fixes #11693 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
