### PR TITLE
remove spring cloud #11630

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
         api("org.mapstruct:mapstruct-processor:$mapStructVersion")
         api("org.msgpack:jackson-dataformat-msgpack:0.9.10")
         api("org.springdoc:springdoc-openapi-webflux-ui:1.8.0")
-        api("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
         api("org.mockito:mockito-inline:5.2.0")
         api("org.web3j:core:4.12.2")
         api("software.amazon.awssdk:bom:2.32.9")

--- a/charts/README.md
+++ b/charts/README.md
@@ -124,6 +124,30 @@ a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standa
 4. Create an [External HTTPS load balancer](https://cloud.google.com/load-balancing/docs/https/ext-https-lb-simple) and
    create a Backend Service(s) that utilizes the automatically created NEGs pointing to the traffic pods.
 
+### Removed Spring Cloud Dependencies
+
+This chart no longer uses Spring Cloud features (e.g., dynamic properties, leader election). All dependencies from `org.springframework.cloud` have been removed. Configuration is now static and driven via Kubernetes ConfigMaps and Secrets.
+
+- `application.yml` no longer supports `spring.cloud.*` properties.
+- Leader election logic in the importer has been removed.
+- Logger configurations referencing Spring Cloud packages should be removed from `application.yml`.
+
+### Kubernetes API Access for Monitor
+
+The monitor component now uses the Fabric8 Kubernetes client to access the Kubernetes API directly, enabling it to watch `pods` and `configmaps`. Ensure that the appropriate role-based permissions are granted.
+
+Minimal RBAC permissions needed:
+
+```yaml
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+```
+
 ## Testing
 
 To verify the chart installation is successful, you can run the helm tests. These tests are not automatically executed

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -294,7 +294,7 @@ prometheusRules:
       severity: warning
 
 rbac:
-  enabled: true
+  enabled: false
 
 readinessProbe:
   httpGet:

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -296,7 +296,7 @@ prometheusRules:
       application: grpc
 
 rbac:
-  enabled: true
+  enabled: false
 
 readinessProbe:
   httpGet:

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -439,7 +439,7 @@ prometheusRules:
       area: downloader
 
 rbac:
-  enabled: true
+  enabled: false
 
 readinessProbe:
   httpGet:

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -292,7 +292,7 @@ prometheusRules:
       severity: warning
 
 rbac:
-  enabled: true
+  enabled: false
 
 readinessProbe:
   httpGet:

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -289,7 +289,7 @@ prometheusRules:
       severity: warning
 
 rbac:
-  enabled: true
+  enabled: false
 
 readinessProbe:
   httpGet:

--- a/graphql/build.gradle.kts
+++ b/graphql/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
         exclude(group = "org.springframework.security")
     }
     implementation(project(":common"))
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation("com.graphql-java:graphql-java-extended-scalars")
     implementation("com.graphql-java:graphql-java-extended-validation")
     implementation("io.github.mweirauch:micrometer-jvm-extras")
@@ -26,8 +25,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-graphql")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))

--- a/graphql/src/main/resources/application.yml
+++ b/graphql/src/main/resources/application.yml
@@ -16,8 +16,6 @@ logging:
     root: warn
     org.hiero.mirror.graphql: info
     org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
 management:

--- a/grpc/build.gradle.kts
+++ b/grpc/build.gradle.kts
@@ -7,7 +7,6 @@ plugins { id("spring-conventions") }
 dependencies {
     implementation(project(":common"))
     implementation(project(":protobuf"))
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.ongres.scram:client")
     implementation("io.github.mweirauch:micrometer-jvm-extras")
@@ -25,8 +24,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     runtimeOnly(
         group = "io.netty",
         name = "netty-resolver-dns-native-macos",

--- a/grpc/src/main/resources/application.yml
+++ b/grpc/src/main/resources/application.yml
@@ -24,8 +24,6 @@ logging:
     org.hiero.mirror.grpc: info
     io.grpc.netty.shaded.io.grpc.netty.NettyServerHandler: error
     org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
     # io.grpc: debug
     # org.hibernate.SQL: debug
     # org.hibernate.type.descriptor.sql.BasicBinder: trace

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 dependencies {
     val blockNodeVersion: String by rootProject.extra
 
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation(platform("software.amazon.awssdk:bom"))
     implementation(project(":common"))
     implementation("com.esaulpaugh:headlong")
@@ -38,9 +37,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.retry:spring-retry")
-    implementation("org.springframework.cloud:spring-cloud-kubernetes-fabric8-leader")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     implementation("software.amazon.awssdk:netty-nio-client")
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")

--- a/importer/src/main/java/org/hiero/mirror/importer/config/HealthCheckConfiguration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/config/HealthCheckConfiguration.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.importer.ImporterProperties;
-import org.hiero.mirror.importer.leader.LeaderService;
-import org.hiero.mirror.importer.parser.ParserProperties;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.annotation.Bean;
@@ -20,8 +18,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @RequiredArgsConstructor
 class HealthCheckConfiguration {
-
-    private final LeaderService leaderService;
     private final ImporterProperties importerProperties;
     private final Collection<ParserProperties> parserProperties;
 
@@ -31,7 +27,7 @@ class HealthCheckConfiguration {
         Map<String, HealthIndicator> healthIndicators = parserProperties.stream()
                 .collect(Collectors.toMap(
                         k -> k.getStreamType().toString(),
-                        v -> new StreamFileHealthIndicator(leaderService, registry, importerProperties, v)));
+                        v -> new StreamFileHealthIndicator(registry, importerProperties, v)));
 
         return CompositeHealthContributor.fromMap(healthIndicators);
     }

--- a/importer/src/main/java/org/hiero/mirror/importer/config/ImporterConfiguration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/config/ImporterConfiguration.java
@@ -5,16 +5,11 @@ package org.hiero.mirror.importer.config;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.importer.ImporterProperties;
-import org.hiero.mirror.importer.leader.LeaderAspect;
-import org.hiero.mirror.importer.leader.LeaderService;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
-import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
@@ -30,19 +25,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 class ImporterConfiguration {
 
     private final ImporterProperties importerProperties;
-
-    @Bean
-    @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
-    @ConditionalOnProperty(value = "spring.cloud.kubernetes.leader.enabled")
-    LeaderAspect leaderAspect() {
-        return new LeaderAspect();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    LeaderService leaderService() {
-        return Boolean.TRUE::booleanValue; // Leader election not available outside Kubernetes
-    }
 
     @Bean
     FlywayConfigurationCustomizer flywayConfigurationCustomizer() {

--- a/importer/src/main/java/org/hiero/mirror/importer/leader/LeaderAspect.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/leader/LeaderAspect.java
@@ -28,11 +28,6 @@ public class LeaderAspect implements LeaderService {
         log.info("Starting as follower");
     }
 
-    @Override
-    public boolean isLeader() {
-        return leader.get();
-    }
-
     @Around("execution(@org.hiero.mirror.importer.leader.Leader * *(..)) && @annotation(leaderAnnotation)")
     public Object leader(ProceedingJoinPoint joinPoint, Leader leaderAnnotation) throws Throwable {
         String targetClass = joinPoint.getTarget().getClass().getSimpleName();

--- a/importer/src/main/resources/application.yml
+++ b/importer/src/main/resources/application.yml
@@ -46,8 +46,6 @@ logging:
     root: warn
     org.hiero.mirror.importer: info
     org.flywaydb.core.internal.command.DbMigrate: info
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
     #org.hibernate.type.descriptor.sql.BasicBinder: trace
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"

--- a/monitor/build.gradle.kts
+++ b/monitor/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation(project(":common")) {
         exclude("com.google.protobuf", "protobuf-java")
         exclude("org.springframework.boot", "spring-boot-starter-data-jpa")
@@ -30,10 +29,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("io.fabric8:kubernetes-client")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-kubernetes-fabric8-autoconfig")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     runtimeOnly(
         group = "io.netty",
         name = "netty-resolver-dns-native-macos",

--- a/monitor/src/main/resources/application.yml
+++ b/monitor/src/main/resources/application.yml
@@ -26,8 +26,6 @@ logging:
     com.hedera.hashgraph.sdk.Executable: error
     com.hedera.hashgraph.sdk.TransactionReceiptQuery: error
     org.hiero.mirror.monitor: info
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
 management:

--- a/rest-java/build.gradle.kts
+++ b/rest-java/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor")
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation(project(":common"))
     implementation("io.github.mweirauch:micrometer-jvm-extras")
     implementation("io.micrometer:micrometer-registry-prometheus")
@@ -20,8 +19,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))
     testImplementation("org.mockito:mockito-inline")

--- a/rest-java/src/main/resources/application.yml
+++ b/rest-java/src/main/resources/application.yml
@@ -27,8 +27,6 @@ logging:
     root: warn
     org.hiero.mirror.restjava: info
     org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
 management:

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -20,7 +20,6 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation(project(":common"))
     implementation("com.bucket4j:bucket4j-core")
     implementation("com.esaulpaugh:headlong")
@@ -37,8 +36,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.retry:spring-retry")
-    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-    implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))
     testImplementation("io.vertx:vertx-core")

--- a/web3/src/main/resources/application.yml
+++ b/web3/src/main/resources/application.yml
@@ -19,8 +19,6 @@ logging:
     root: warn
     org.hiero.mirror.web3: info
     org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
-    org.springframework.cloud.kubernetes.commons.config.ConfigUtils: error
-    org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
 management:


### PR DESCRIPTION
## Removal of spring cloud

Updated the relevant files for removal of spring clouds feature like leader elections or dynamic properties.

- [x]  Remove any dependency from groupId **org.springframework.cloud** in Gradle
- [x] Remove unused leader election logic in importer
- [x] Add fabric8 client dependency for monitor that directly uses k8s APIs
- [x] Remove **org.springframework.cloud** logger config in **application.yml**
- [x] Update chart README around custom config file mounting
- [x] Adjust all charts to remove role permissions except maybe monitor and test changes by running wrapper chart locally:

     ```rules:
  - apiGroups: [""]
    resources: ["configmaps"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["pods"]
    verbs: ["get"]

updated rbac enabled to false

``` 
 rbac:
 -  enabled: false
```

for role.yml and rolebinding.yml in values.yml file

