### PR TITLE
Add simple block node E2E tests

### DIFF
--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testImplementation("com.github.vertical-blank:sql-formatter")
     testImplementation("commons-beanutils:commons-beanutils")
     testImplementation("io.grpc:grpc-inprocess")
+    testImplementation("io.grpc:grpc-netty")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.apache.commons:commons-math3")
     testImplementation("org.awaitility:awaitility")

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/block/BlockRootHashDigest.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/block/BlockRootHashDigest.java
@@ -10,7 +10,6 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import lombok.Data;
 import org.hiero.mirror.common.util.DomainUtils;
 
 /**
@@ -18,8 +17,7 @@ import org.hiero.mirror.common.util.DomainUtils;
  * merkle tree are padded with SHA2-384 hash of an empty bytearray to be perfect binary trees. Note none of the methods
  * are reentrant.
  */
-@Data
-class BlockRootHashDigest {
+public final class BlockRootHashDigest {
 
     private static final byte[] EMPTY_HASH = createSha384Digest().digest(new byte[0]);
 

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
@@ -55,11 +55,4 @@ class AbstractBlockNodeIntegrationTest extends ImporterIntegrationTest {
                 channelBuilderProvider,
                 blockProperties);
     }
-
-    protected BlockNodeProperties node(String host, int port) {
-        var properties = new BlockNodeProperties();
-        properties.setHost(host);
-        properties.setPort(port);
-        return properties;
-    }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
@@ -40,7 +40,7 @@ abstract class AbstractBlockNodeIntegrationTest extends ImporterIntegrationTest 
             new InProcessManagedChannelBuilderProvider();
     private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
-    protected BlockNodeSubscriber getBlockNodeSubscriber(List<BlockNodeProperties> nodes) {
+    protected final BlockNodeSubscriber getBlockNodeSubscriber(List<BlockNodeProperties> nodes) {
         var blockProperties = new BlockProperties();
         blockProperties.setNodes(nodes);
         boolean isInProcess = nodes.getFirst().getPort() == -1;

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.annotation.Resource;
+import java.util.List;
+import org.hiero.mirror.importer.ImporterIntegrationTest;
+import org.hiero.mirror.importer.downloader.CommonDownloaderProperties;
+import org.hiero.mirror.importer.downloader.StreamFileNotifier;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
+import org.hiero.mirror.importer.repository.RecordFileRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractBlockNodeIntegrationTest extends ImporterIntegrationTest {
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    protected StreamFileNotifier streamFileNotifier;
+
+    @Resource
+    private BlockFileTransformer blockFileTransformer;
+
+    @Resource
+    private BlockStreamReader blockStreamReader;
+
+    @Resource
+    private CommonDownloaderProperties commonDownloaderProperties;
+
+    @Resource
+    private ManagedChannelBuilderProvider managedChannelBuilderProvider;
+
+    @Resource
+    private RecordFileRepository recordFileRepository;
+
+    private final ManagedChannelBuilderProvider inProcessManagedChannelBuilderProvider =
+            new InProcessManagedChannelBuilderProvider();
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    protected BlockNodeSubscriber getBlockNodeSubscriber(List<BlockNodeProperties> nodes) {
+        var blockProperties = new BlockProperties();
+        blockProperties.setNodes(nodes);
+        boolean isInProcess = nodes.getFirst().getPort() == -1;
+        var blockStreamVerifier =
+                new BlockStreamVerifier(blockFileTransformer, recordFileRepository, streamFileNotifier, meterRegistry);
+        var channelBuilderProvider =
+                isInProcess ? inProcessManagedChannelBuilderProvider : managedChannelBuilderProvider;
+        return new BlockNodeSubscriber(
+                blockStreamReader,
+                blockStreamVerifier,
+                commonDownloaderProperties,
+                channelBuilderProvider,
+                blockProperties);
+    }
+
+    protected BlockNodeProperties node(String host, int port) {
+        var properties = new BlockNodeProperties();
+        properties.setHost(host);
+        properties.setPort(port);
+        return properties;
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/AbstractBlockNodeIntegrationTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AbstractBlockNodeIntegrationTest extends ImporterIntegrationTest {
+abstract class AbstractBlockNodeIntegrationTest extends ImporterIntegrationTest {
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     protected StreamFileNotifier streamFileNotifier;

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/SingleBlockNodeTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/SingleBlockNodeTest.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.stream.LongStream;
+import org.hiero.mirror.common.domain.transaction.RecordFile;
+import org.hiero.mirror.importer.downloader.block.simulator.BlockGenerator;
+import org.hiero.mirror.importer.downloader.block.simulator.BlockNodeSimulator;
+import org.hiero.mirror.importer.exception.BlockStreamException;
+import org.hiero.mirror.importer.exception.InvalidStreamFileException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+final class SingleBlockNodeTest extends AbstractBlockNodeIntegrationTest {
+
+    private BlockNodeSimulator simulator;
+    private BlockNodeSubscriber subscriber;
+
+    @AfterEach
+    void cleanup() {
+        if (subscriber != null) {
+            subscriber.close();
+            subscriber = null;
+        }
+
+        if (simulator != null) {
+            simulator.close();
+            simulator = null;
+        }
+    }
+
+    @Test
+    void multipleBlocks() {
+        // given
+        var generator = new BlockGenerator(0);
+        simulator = new BlockNodeSimulator()
+                .withChunksPerBlock(2)
+                .withBlocks(generator.next(10))
+                .start();
+        subscriber = getBlockNodeSubscriber(List.of(simulator.toClientProperties()));
+
+        // when
+        subscriber.get();
+
+        // then
+        var captor = ArgumentCaptor.forClass(RecordFile.class);
+        verify(streamFileNotifier, times(10)).verified(captor.capture());
+        assertThat(captor.getAllValues())
+                .map(RecordFile::getIndex)
+                .containsExactlyElementsOf(LongStream.range(0, 10).boxed().toList());
+    }
+
+    @Test
+    void outOfOrder() {
+        // given
+        var generator = new BlockGenerator(0);
+        simulator = new BlockNodeSimulator()
+                .withBlocks(generator.next(10))
+                .withHttpChannel()
+                .withOutOrder()
+                .start();
+        subscriber = getBlockNodeSubscriber(List.of(simulator.toClientProperties()));
+
+        // when, then
+        assertThatThrownBy(subscriber::get)
+                .isInstanceOf(BlockStreamException.class)
+                .hasCauseInstanceOf(InvalidStreamFileException.class);
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockGenerator.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockGenerator.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block.simulator;
+
+import com.hedera.hapi.block.stream.input.protoc.EventHeader;
+import com.hedera.hapi.block.stream.input.protoc.RoundHeader;
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.output.protoc.TransactionResult;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.block.stream.protoc.BlockProof;
+import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Hex;
+import org.hiero.block.api.protoc.BlockItemSet;
+import org.hiero.mirror.common.util.DomainUtils;
+import org.hiero.mirror.importer.parser.domain.RecordItemBuilder;
+import org.hiero.mirror.importer.reader.block.BlockRootHashDigest;
+
+public final class BlockGenerator {
+    private static final byte[] START_OF_BLOCK_STATE_HASH = new byte[48];
+
+    private final RecordItemBuilder recordItemBuilder = new RecordItemBuilder();
+
+    private int blockNumber;
+    private byte[] previousBlockRootHash;
+
+    public BlockGenerator(int startBlockNumber) {
+        blockNumber = startBlockNumber;
+        if (blockNumber == 0) {
+            previousBlockRootHash = new byte[48];
+        } else {
+            previousBlockRootHash = recordItemBuilder.randomBytes(48);
+        }
+    }
+
+    public List<BlockItemSet> next(int count) {
+        var blocks = new ArrayList<BlockItemSet>();
+        for (int i = 0; i < count; i++) {
+            blocks.add(next());
+        }
+        return blocks;
+    }
+
+    @SneakyThrows
+    private void calculateBlockRootHash(BlockItemSet block) {
+        var blockRootHashDigest = new BlockRootHashDigest();
+        blockRootHashDigest.setPreviousHash(previousBlockRootHash);
+        blockRootHashDigest.setStartOfBlockStateHash(START_OF_BLOCK_STATE_HASH);
+
+        for (var blockItem : block.getBlockItemsList()) {
+            switch (blockItem.getItemCase()) {
+                case EVENT_HEADER, EVENT_TRANSACTION, ROUND_HEADER -> blockRootHashDigest.addInputBlockItem(blockItem);
+                case BLOCK_HEADER, STATE_CHANGES, TRANSACTION_OUTPUT, TRANSACTION_RESULT ->
+                    blockRootHashDigest.addOutputBlockItem(blockItem);
+                default -> {
+                    // other block items aren't considered input / output
+                }
+            }
+        }
+
+        previousBlockRootHash = Hex.decodeHex(blockRootHashDigest.digest());
+    }
+
+    private BlockItemSet next() {
+        var builder = BlockItemSet.newBuilder();
+        // block header
+        builder.addBlockItems(BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder()
+                        .setBlockTimestamp(recordItemBuilder.timestamp())
+                        .setNumber(blockNumber)
+                        .build()));
+        // round header
+        builder.addBlockItems(BlockItem.newBuilder()
+                .setRoundHeader(
+                        RoundHeader.newBuilder().setRoundNumber(blockNumber + 1).build()));
+        // event header
+        builder.addBlockItems(BlockItem.newBuilder().setEventHeader(EventHeader.getDefaultInstance()));
+
+        // transactions
+        for (int i = 0; i < 10; i++) {
+            builder.addAllBlockItems(transactionUnit());
+        }
+
+        // block proof
+        builder.addBlockItems(BlockItem.newBuilder()
+                .setBlockProof(BlockProof.newBuilder()
+                        .setBlock(blockNumber)
+                        .setPreviousBlockRootHash(DomainUtils.fromBytes(previousBlockRootHash))
+                        .setStartOfBlockStateRootHash(DomainUtils.fromBytes(START_OF_BLOCK_STATE_HASH))));
+        var block = builder.build();
+        calculateBlockRootHash(block);
+        blockNumber++;
+        return block;
+    }
+
+    private List<BlockItem> transactionUnit() {
+        var recordItem = recordItemBuilder.cryptoTransfer().build();
+        var eventTransaction = BlockItem.newBuilder()
+                .setEventTransaction(EventTransaction.newBuilder()
+                        .setApplicationTransaction(recordItem.getTransaction().toByteString())
+                        .build())
+                .build();
+        var transactionResult = BlockItem.newBuilder()
+                .setTransactionResult(TransactionResult.newBuilder()
+                        .setConsensusTimestamp(recordItem.getTransactionRecord().getConsensusTimestamp())
+                        .setStatus(ResponseCodeEnum.SUCCESS)
+                        .setTransferList(recordItem.getTransactionRecord().getTransferList())
+                        .build())
+                .build();
+        // for simplicity, no state changes
+        return List.of(eventTransaction, transactionResult);
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockGenerator.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockGenerator.java
@@ -20,7 +20,7 @@ import org.hiero.mirror.importer.parser.domain.RecordItemBuilder;
 import org.hiero.mirror.importer.reader.block.BlockRootHashDigest;
 
 public final class BlockGenerator {
-    private static final byte[] START_OF_BLOCK_STATE_HASH = new byte[48];
+    private static final byte[] ALL_ZERO_HASH = new byte[48];
 
     private final RecordItemBuilder recordItemBuilder = new RecordItemBuilder();
 
@@ -30,7 +30,7 @@ public final class BlockGenerator {
     public BlockGenerator(int startBlockNumber) {
         blockNumber = startBlockNumber;
         if (blockNumber == 0) {
-            previousBlockRootHash = new byte[48];
+            previousBlockRootHash = ALL_ZERO_HASH;
         } else {
             previousBlockRootHash = recordItemBuilder.randomBytes(48);
         }
@@ -48,7 +48,7 @@ public final class BlockGenerator {
     private void calculateBlockRootHash(BlockItemSet block) {
         var blockRootHashDigest = new BlockRootHashDigest();
         blockRootHashDigest.setPreviousHash(previousBlockRootHash);
-        blockRootHashDigest.setStartOfBlockStateHash(START_OF_BLOCK_STATE_HASH);
+        blockRootHashDigest.setStartOfBlockStateHash(ALL_ZERO_HASH);
 
         for (var blockItem : block.getBlockItemsList()) {
             switch (blockItem.getItemCase()) {
@@ -89,7 +89,7 @@ public final class BlockGenerator {
                 .setBlockProof(BlockProof.newBuilder()
                         .setBlock(blockNumber)
                         .setPreviousBlockRootHash(DomainUtils.fromBytes(previousBlockRootHash))
-                        .setStartOfBlockStateRootHash(DomainUtils.fromBytes(START_OF_BLOCK_STATE_HASH))));
+                        .setStartOfBlockStateRootHash(DomainUtils.fromBytes(ALL_ZERO_HASH))));
         var block = builder.build();
         calculateBlockRootHash(block);
         blockNumber++;

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block.simulator;
+
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import io.grpc.ForwardingServerBuilder;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hiero.block.api.protoc.BlockItemSet;
+import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
+import org.hiero.block.api.protoc.ServerStatusRequest;
+import org.hiero.block.api.protoc.ServerStatusResponse;
+import org.hiero.block.api.protoc.SubscribeStreamRequest;
+import org.hiero.block.api.protoc.SubscribeStreamResponse;
+import org.hiero.mirror.importer.downloader.block.BlockNodeProperties;
+import org.springframework.util.CollectionUtils;
+
+public final class BlockNodeSimulator implements AutoCloseable {
+
+    private List<BlockItemSet> blocks = Collections.emptyList();
+    private int chunksPerBlock = 1;
+    private long firstBlockNumber;
+    private String host;
+    private boolean inProcessChannel = true;
+    private long lastBlockNumber;
+    private boolean outOfOrder = false;
+    private int port;
+    private Server server;
+    private boolean started = false;
+
+    @Override
+    @SneakyThrows
+    public void close() {
+        if (!started) {
+            return;
+        }
+
+        server.shutdown();
+        server.awaitTermination();
+        started = false;
+    }
+
+    public String getHost() {
+        validateState(started, "BlockNodeSimulator has not been started");
+        return host;
+    }
+
+    public int getPort() {
+        validateState(started, "BlockNodeSimulator has not been started");
+        return port;
+    }
+
+    @SneakyThrows
+    public BlockNodeSimulator start() {
+        validateState(!started, "BlockNodeSimulator has already been started");
+        validateState(!blocks.isEmpty(), "BlockNodeSimulator can't start with empty blocks");
+
+        var statusService = new BlockNodeServiceGrpc.BlockNodeServiceImplBase() {
+            @Override
+            public void serverStatus(
+                    ServerStatusRequest request, StreamObserver<ServerStatusResponse> responseObserver) {
+                var response = ServerStatusResponse.newBuilder()
+                        .setFirstAvailableBlock(firstBlockNumber)
+                        .setLastAvailableBlock(lastBlockNumber)
+                        .build();
+                responseObserver.onNext(response);
+                responseObserver.onCompleted();
+            }
+        };
+
+        var streamSubscribeService = new BlockStreamSubscribeServiceGrpc.BlockStreamSubscribeServiceImplBase() {
+            @Override
+            public void subscribeBlockStream(
+                    SubscribeStreamRequest request, StreamObserver<SubscribeStreamResponse> responseObserver) {
+                new SubscribeStreamContext(request, responseObserver).stream();
+            }
+        };
+
+        if (outOfOrder) {
+            Collections.shuffle(blocks);
+        }
+
+        ForwardingServerBuilder<?> serverBuilder;
+        if (inProcessChannel) {
+            host = RandomStringUtils.secure().nextAlphabetic(8);
+            serverBuilder = InProcessServerBuilder.forName(host);
+        } else {
+            host = "localhost";
+            serverBuilder = NettyServerBuilder.forPort(0);
+        }
+        // only support InProcess channel now, will expand to http channel
+        server = serverBuilder
+                .addService(statusService)
+                .addService(streamSubscribeService)
+                .build()
+                .start();
+        port = server.getPort();
+        started = true;
+        return this;
+    }
+
+    public BlockNodeProperties toClientProperties() {
+        validateState(started, "BlockNodeSimulator has not been started");
+        var properties = new BlockNodeProperties();
+        properties.setHost(host);
+        properties.setPort(port);
+        return properties;
+    }
+
+    public BlockNodeSimulator withBlocks(List<BlockItemSet> blocks) {
+        validateArg(!CollectionUtils.isEmpty(blocks), "blocks can't be empty");
+        this.blocks = new ArrayList<>(blocks);
+        firstBlockNumber = blocks.getFirst().getBlockItems(0).getBlockHeader().getNumber();
+        lastBlockNumber = blocks.getLast().getBlockItems(0).getBlockHeader().getNumber();
+        return this;
+    }
+
+    public BlockNodeSimulator withChunksPerBlock(int chunksPerBlock) {
+        validateArg(chunksPerBlock > 0, "chunksPerBlock must be greater than 0");
+        this.chunksPerBlock = chunksPerBlock;
+        return this;
+    }
+
+    public BlockNodeSimulator withHttpChannel() {
+        inProcessChannel = false;
+        return this;
+    }
+
+    public BlockNodeSimulator withOutOrder() {
+        this.outOfOrder = true;
+        return this;
+    }
+
+    private static void validateArg(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private static void validateState(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class SubscribeStreamContext {
+
+        private static final SubscribeStreamResponse SUCCESS = SubscribeStreamResponse.newBuilder()
+                .setStatus(SubscribeStreamResponse.Code.SUCCESS)
+                .build();
+
+        final SubscribeStreamRequest request;
+        final StreamObserver<SubscribeStreamResponse> responseObserver;
+
+        void stream() {
+            if (request.getStartBlockNumber() > lastBlockNumber) {
+                responseObserver.onNext(SubscribeStreamResponse.newBuilder()
+                        .setStatus(SubscribeStreamResponse.Code.INVALID_START_BLOCK_NUMBER)
+                        .build());
+                responseObserver.onCompleted();
+                return;
+            }
+
+            // no other sanity checks,  add when needed
+            int index = (int) (request.getStartBlockNumber() - firstBlockNumber);
+            for (; index < blocks.size(); index++) {
+                var block = blocks.get(index);
+                if (chunksPerBlock == 1) {
+                    responseObserver.onNext(blockResponse(blocks.get(index)));
+                } else {
+                    int chunkSize = Math.max(1, block.getBlockItemsCount() / chunksPerBlock);
+                    for (int startIndex = 0; startIndex < block.getBlockItemsCount(); startIndex += chunkSize) {
+                        int endIndex = Math.min(block.getBlockItemsCount(), startIndex + chunkSize);
+                        var chunk = block.getBlockItemsList().subList(startIndex, endIndex);
+                        responseObserver.onNext(blockResponse(chunk));
+                    }
+                }
+            }
+
+            responseObserver.onNext(SUCCESS);
+            responseObserver.onCompleted();
+        }
+
+        private static SubscribeStreamResponse blockResponse(BlockItemSet block) {
+            return SubscribeStreamResponse.newBuilder().setBlockItems(block).build();
+        }
+
+        private static SubscribeStreamResponse blockResponse(Collection<BlockItem> items) {
+            return blockResponse(
+                    BlockItemSet.newBuilder().addAllBlockItems(items).build());
+        }
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -1253,6 +1253,12 @@ public class RecordItemBuilder {
         return ByteString.copyFrom(bytes);
     }
 
+    public byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
     // Helper methods
     private AccountAmount accountAmount(EntityId accountId, long amount) {
         return accountAmount(accountId.toAccountID(), amount);
@@ -1263,12 +1269,6 @@ public class RecordItemBuilder {
                 .setAccountID(accountID)
                 .setAmount(amount)
                 .build();
-    }
-
-    private byte[] randomBytes(int length) {
-        byte[] bytes = new byte[length];
-        random.nextBytes(bytes);
-        return bytes;
     }
 
     private TransactionSidecarRecord.Builder contractActions() {


### PR DESCRIPTION
**Description**:

This PR adds a block node simulator for E2E testing with mirrornode.

- Add `BlockNodeSimulator` and `BlockGenerator`
- Add a base integration test class and two simple test cases

**Related issue(s)**:

Fixes #11543 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
