### PR TITLE
Fix failing k6 contractCallRedirectApprove

### DIFF
--- a/tools/k6/src/web3/test/modificationTests/contractCallRedirectApprove.js
+++ b/tools/k6/src/web3/test/modificationTests/contractCallRedirectApprove.js
@@ -5,8 +5,8 @@ import {PrecompileModificationTestTemplate} from '../commonPrecompileModificatio
 
 const contract = __ENV.PRECOMPILE_CONTRACT;
 const selector = '0x911ce425'; //approveRedirect
-const token = __ENV.TOKEN_ADDRESS;
-const spender = __ENV.ACCOUNT_ADDRESS;
+const token = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ADDRESS;
+const spender = __ENV.FUNGIBLE_TOKEN_WITH_FREEZE_KEY_ASSOCIATED_ACCOUNT_ADDRESS;
 const amount = __ENV.AMOUNT;
 const runMode = __ENV.RUN_WITH_VARIABLES;
 const testName = 'contractCallRedirectApprove';


### PR DESCRIPTION

This PR fixes failing modification test for contractCallRedirectApprove. Change in the deploy branch is also needed because the PRECOMPILE_CONTRACT is redeployed

Fixes #11661 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
