### PR TITLE
Align contract create gas estimation in mono workflow with the one from modularized

### DIFF
--- a/web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -37,11 +37,6 @@ public class GasCalculatorHederaV19 extends LondonGasCalculator {
     }
 
     @Override
-    public long codeDepositGasCost(final int codeSize) {
-        return 0L;
-    }
-
-    @Override
     public long logOperationGasCost(
             final MessageFrame frame, final long dataOffset, final long dataLength, final int numTopics) {
         final var gasCost = GasCalculatorHederaUtil.logOperationGasCost(

--- a/web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -2,6 +2,7 @@
 
 package com.hedera.services.contracts.gascalculator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -49,7 +50,7 @@ class GasCalculatorHederaV19Test {
 
     @Test
     void gasDepositCost() {
-        assertEquals(0L, subject.codeDepositGasCost(1));
+        assertThat(subject.codeDepositGasCost(1)).isGreaterThan(0L);
     }
 
     @Test

--- a/web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
+++ b/web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22Test.java
@@ -2,6 +2,7 @@
 
 package com.hedera.services.contracts.gascalculator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.fees.HbarCentExchange;
@@ -34,7 +35,7 @@ class GasCalculatorHederaV22Test {
 
     @Test
     void gasDepositCost() {
-        assertEquals(0L, subject.codeDepositGasCost(37));
+        assertThat(subject.codeDepositGasCost(37)).isGreaterThan(0L);
     }
 
     @Test

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAddressThisTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallAddressThisTest.java
@@ -78,7 +78,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
-        final long actualGas = mirrorNodeEvmProperties.isModularizedServices() ? 120170 : 57764L;
+        final long actualGas = 120170;
         long expectedGas = longValueOf.applyAsLong(contractCallService.processCall(serviceParameters));
         assertThat(isWithinExpectedGasRange(expectedGas, actualGas))
                 .withFailMessage(ESTIMATE_GAS_ERROR_MESSAGE, expectedGas, actualGas)
@@ -153,7 +153,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(TestNestedAddressThis::deploy);
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
-        final long actualGas = mirrorNodeEvmProperties.isModularizedServices() ? 170000L : 95401L;
+        final long actualGas = 170000L;
         long expectedGas = longValueOf.applyAsLong(contractCallService.processCall(serviceParameters));
         assertThat(isWithinExpectedGasRange(expectedGas, actualGas))
                 .withFailMessage(ESTIMATE_GAS_ERROR_MESSAGE, expectedGas, actualGas)

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
@@ -770,7 +770,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, senderAddress);
-        final var actualGas = mirrorNodeEvmProperties.isModularizedServices() ? 1413995L : 175242L;
+        final var actualGas = 1413995L;
 
         // When
         final var result = contractExecutionService.processCall(serviceParameters);
@@ -788,7 +788,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
-        final var actualGas = mirrorNodeEvmProperties.isModularizedServices() ? 1413995L : 175242L;
+        final var actualGas = 1413995L;
 
         // When
         final var result = contractExecutionService.processCall(serviceParameters);


### PR DESCRIPTION
**Description**:
This PR aligns contract create gas estimation logic to be aligned with the logic from the modularized code. The difference is quite big, so tolerances achieved by the binary search algorithm were not enough in this case.

**Related issue(s)**:

Fixes #11737 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
