### PR TITLE
Cleanup web3 temp directory on startup (0.136)

### DIFF
--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -370,4 +370,4 @@ volumes:
   temp:
     emptyDir:
       medium: Memory
-      sizeLimit: 500Mi
+      sizeLimit: 100Mi

--- a/web3/Dockerfile
+++ b/web3/Dockerfile
@@ -4,7 +4,7 @@ COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:21-jre-noble
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview -Djava.io.tmpdir=/tmp/web3"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness
 WORKDIR /app

--- a/web3/src/main/java/org/hiero/mirror/web3/Web3Application.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/Web3Application.java
@@ -2,16 +2,32 @@
 
 package org.hiero.mirror.web3;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.hiero.mirror.common.CommonConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.util.FileSystemUtils;
 
 @Import(CommonConfiguration.class)
 @SpringBootApplication
 public class Web3Application {
 
     public static void main(String[] args) {
+        cleanup();
         SpringApplication.run(Web3Application.class, args);
+    }
+
+    private static void cleanup() {
+        final var tmpDir = Path.of(System.getProperty("java.io.tmpdir", "/tmp/web3"));
+
+        try {
+            FileSystemUtils.deleteRecursively(tmpDir);
+            Files.createDirectories(tmpDir);
+        } catch (IOException ex) {
+            System.err.println("Could not delete tmp directory %s: %s".formatted(tmpDir, ex.getMessage()));
+        }
     }
 }


### PR DESCRIPTION
**Description**:

Cherry-pick #11771 to release/0.136:

* Change default temporary directory to application specific `/tmp/web3`
* Cleanup web3 temp directory on startup
* Lower tmp volume memory size from 500 MiB to 100 MiB

**Related issue(s)**:

Fixes #11760

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
