### PR TITLE
Bump netty and tomcat for MadeYouReset vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,11 @@ extra.apply {
     set("grpcVersion", "1.74.0")
     set("jooq.version", "3.20.5") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
+    set("netty.version", "4.1.124.Final") // Temporary until next Spring Boot
     set("nodeJsVersion", "22.17.1")
     set("protobufVersion", "4.31.1")
     set("reactorGrpcVersion", "1.2.4")
+    set("tomcat.version", "10.1.44") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }
 


### PR DESCRIPTION
**Description**:

Bump versions of HTTP servers for [MadeYouReset](https://www.imperva.com/blog/madeyoureset-turning-http-2-server-against-itself/) vulnerability:

* Bump netty from 4.1.123.Final to 4.1.124.Final
* Bump tomcat from 10.1.43 to 10.1.44

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
