### PR TITLE
Load web3 resources during k8s readiness probe

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/state/ApplicationWarmup.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/ApplicationWarmup.java
@@ -29,47 +29,59 @@ final class ApplicationWarmup {
     private final MirrorNodeEvmProperties evmProperties;
 
     /**
-     * Call simple read only contract function to load web3
+     * Calls simple read only contract function to load web3
      * resources before k8s readiness elapses. Method is async to
-     * run it in a separate thread and not block the main one by
+     * run in a separate thread and not block the main one by
      * potentially waiting for the contract call to complete.
+     * As ApplicationReadyEvent, the method will start after
+     * app context is initialized and all beans are created.
      */
     @Async
     @EventListener(ApplicationReadyEvent.class)
     public void warmupCall() {
-        if (evmProperties.isModularizedServices()) {
-            final var evmVersions = evmProperties.getEvmVersions();
-            evmVersions.descendingMap().entrySet().stream().forEach(entry -> {
-                final var blockType =
-                        new BlockType(String.valueOf(entry.getValue().minor()), entry.getKey());
-                try {
-                    ContractExecutionParameters contractExecutionParameters = getContractExecutionParameters(blockType);
-                    contractCallService.callContract(contractExecutionParameters);
-                } catch (Exception e) {
-                    log.warn("Warmup call for block {} failed: {}", blockType, e.getMessage());
-                }
-            });
+        if (!evmProperties.isModularizedServices()) {
+            return;
+        }
+
+        initializeResources(BlockType.LATEST);
+        final var evmVersions = evmProperties.getEvmVersions();
+        evmVersions.descendingMap().entrySet().stream().forEach(entry -> {
+            final var blockType = new BlockType(String.valueOf(entry.getValue().minor()), entry.getKey());
+            initializeResources(blockType);
+        });
+    }
+
+    /**
+     * Triggers resources initialization for particular evm version
+     * by contract call, based on provided block number
+     */
+    private void initializeResources(BlockType blockType) {
+        try {
+            final var contractExecutionParameters = getContractExecutionParameters(blockType);
+            contractCallService.callContract(contractExecutionParameters);
+        } catch (RuntimeException e) {
+            log.error("Warmup call for block {} failed:", blockType, e);
         }
     }
 
     /**
-     * Prepare contract execution parameters to call simple read-only function
+     * Prepares contract execution parameters to call simple read-only function
      * (isToken() of HTS precompile in this case) using the system treasury account as sender
      */
     private ContractExecutionParameters getContractExecutionParameters(BlockType blockType) {
-        final Address HTS_PRECOMPILE_ADDRESS = Address.fromHexString("0x0000000000000000000000000000000000000167");
-        final Bytes IS_TOKEN_CALL_DATA =
+        final var htsPrecompileAddress = Address.fromHexString("0x0000000000000000000000000000000000000167");
+        final var isTokenCallData =
                 Bytes.fromHexString("0x997b63220000000000000000000000000000000000000000000000000000000000000000");
 
         return ContractExecutionParameters.builder()
                 .block(blockType)
-                .callData(IS_TOKEN_CALL_DATA)
+                .callData(isTokenCallData)
                 .callType(CallType.ETH_CALL)
                 .gas(1_000_000L)
                 .isEstimate(false)
                 .isModularized(true)
                 .isStatic(true)
-                .receiver(HTS_PRECOMPILE_ADDRESS)
+                .receiver(htsPrecompileAddress)
                 .sender(new HederaEvmAccount(Address.fromHexString("0x0000000000000000000000000000000000000002")))
                 .build();
     }


### PR DESCRIPTION
**Description**:
Use ApplicationReadyEvent to load resources by calling simple contract before k8s readiness elapses.

**Related issue(s)**:

Fixes #11802 

**Notes for the reviewer**
The contract call for the oldest EVM version is failing with PAYER_ACCOUNT_NOT_FOUND, the calls with the other EVM versions are passing.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
