### PR TITLE
Recover from invalid ContractID in failed EthereumTransaction

### DIFF
--- a/importer/src/test/java/org/hiero/mirror/importer/domain/EntityIdServiceImplTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/EntityIdServiceImplTest.java
@@ -217,6 +217,13 @@ class EntityIdServiceImplTest extends ImporterIntegrationTest {
         assertThat(entityIdService.lookup(contractId)).hasValue(EntityId.of(100));
     }
 
+    @Test
+    void lookupContractNumInvalid() {
+        var contractId =
+                ContractID.newBuilder().setContractNum(1514739994982350848L).build();
+        assertThat(entityIdService.lookup(contractId)).isEmpty();
+    }
+
     @MethodSource("shardAndRealmData")
     @ParameterizedTest
     void lookupContractEvmAddress(long shard, long realm) {


### PR DESCRIPTION
**Description**:

Recover from invalid ContractID in failed EthereumTransaction

**Related issue(s)**:

Fixes #11819

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
