### PR TITLE
Deploy v0.137.0-rc2 to staging

### DIFF
--- a/clusters/mainnet-staging-na/common/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.136.0-rc1'
+      version: '0.137.0-rc2'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.136.0-rc1'
+      version: '0.137.0-rc2'
   dependsOn:
     - name: mirror
       namespace: common


### PR DESCRIPTION
**Description**:

This PR deploys v0.137.0-rc2 to staging.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

To test `/network/stake` endpoint in rest-java, we need to make k6 test case changes, enabling the routes is unrelated since the automated k6 tests run against k8s services, not traefik ingress controller.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
