### PR TITLE
Contract result not returned for eth transaction hash

### DIFF
--- a/rest/__tests__/service/contractService.test.js
+++ b/rest/__tests__/service/contractService.test.js
@@ -1468,31 +1468,88 @@ describe('ContractService.getContractTransactionDetailsByHash tests', () => {
     expect(contractDetails).toHaveLength(0);
   });
 
-  test('Match earliest transaction by same hash', async () => {
-    const transactionDetails = await ContractService.getContractTransactionDetailsByHash(ethereumTxHashBuffer, [], 1);
-    expect(transactionDetails).toEqual([expectedTransactionDetails[0]]);
-  });
-
-  test('Match all transactions by same hash', async () => {
+  test('Match latest transaction by same hash', async () => {
     const transactionDetails = await ContractService.getContractTransactionDetailsByHash(ethereumTxHashBuffer);
-    expect(transactionDetails).toEqual(expectedTransactionDetails);
+    expect(transactionDetails).toEqual([expectedTransactionDetails[3]]);
   });
 
-  test('Match all transactions with no duplicates and wrong nonces', async () => {
-    const transactionDetails = await ContractService.getContractTransactionDetailsByHash(ethereumTxHashBuffer, [
-      duplicateTransactionResult,
-      wrongNonceTransactionResult,
-    ]);
-    expect(transactionDetails).toEqual([expectedTransactionDetails[0], expectedTransactionDetails[3]]);
+  test('Match latest transaction with no duplicates and wrong nonces', async () => {
+    const transactionDetails = await ContractService.getContractTransactionDetailsByHash(ethereumTxHashBuffer);
+    expect(transactionDetails).toEqual([expectedTransactionDetails[3]]);
+  });
+});
+
+describe('ContractService.getContractTransactionDetailsByHash negative tests', () => {
+  const ethereumTxHash = '4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+  const ethereumTxHashBuffer = Buffer.from(ethereumTxHash, 'hex');
+  const ethereumTxType = TransactionType.getProtoId('ETHEREUMTRANSACTION');
+  const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
+  const consensusGasExhaustedTransactionResult = TransactionResult.getProtoId('CONSENSUS_GAS_EXHAUSTED');
+
+  const inputContractResults = [
+    {
+      consensus_timestamp: 1,
+      payer_account_id: entityId10.num,
+      type: ethereumTxType,
+      transaction_result: duplicateTransactionResult,
+      transaction_index: 1,
+      transaction_hash: ethereumTxHash,
+      transaction_nonce: 11,
+      gasLimit: 1000,
+    },
+    {
+      consensus_timestamp: 2,
+      payer_account_id: entityId10.num,
+      type: ethereumTxType,
+      transaction_result: consensusGasExhaustedTransactionResult,
+      transaction_index: 1,
+      transaction_hash: ethereumTxHash,
+      transaction_nonce: 12,
+      gasLimit: 1000,
+    },
+    {
+      consensus_timestamp: 3,
+      payer_account_id: entityId10.num,
+      type: ethereumTxType,
+      transaction_result: consensusGasExhaustedTransactionResult,
+      transaction_index: 1,
+      transaction_hash: ethereumTxHash,
+      transaction_nonce: 12,
+      gasLimit: 1000,
+    },
+  ];
+
+  const expectedTransactionDetails = [
+    {
+      consensusTimestamp: 1,
+      entityId: entityId0.getEncodedId(),
+      hash: ethereumTxHashBuffer,
+      payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(duplicateTransactionResult),
+    },
+    {
+      consensusTimestamp: 2,
+      entityId: entityId0.getEncodedId(),
+      hash: ethereumTxHashBuffer,
+      payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(consensusGasExhaustedTransactionResult),
+    },
+    {
+      consensusTimestamp: 3,
+      entityId: entityId0.getEncodedId(),
+      hash: ethereumTxHashBuffer,
+      payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(consensusGasExhaustedTransactionResult),
+    },
+  ];
+
+  beforeEach(async () => {
+    await integrationDomainOps.loadContractResults(inputContractResults);
   });
 
-  test('Match the earliest non successful transaction', async () => {
-    const transactionDetails = await ContractService.getContractTransactionDetailsByHash(
-      ethereumTxHashBuffer,
-      [successTransactionResult],
-      1
-    );
-    expect(transactionDetails).toEqual([expectedTransactionDetails[1]]);
+  test('Match the latest non successful transaction', async () => {
+    const transactionDetails = await ContractService.getContractTransactionDetailsByHash(ethereumTxHashBuffer);
+    expect(transactionDetails).toEqual([expectedTransactionDetails[2]]);
   });
 });
 

--- a/rest/__tests__/service/contractService.test.js
+++ b/rest/__tests__/service/contractService.test.js
@@ -1431,24 +1431,28 @@ describe('ContractService.getContractTransactionDetailsByHash tests', () => {
       entityId: entityId0.getEncodedId(),
       hash: ethereumTxHashBuffer,
       payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(successTransactionResult),
     },
     {
       consensusTimestamp: 2,
       entityId: entityId0.getEncodedId(),
       hash: ethereumTxHashBuffer,
       payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(duplicateTransactionResult),
     },
     {
       consensusTimestamp: 3,
       entityId: entityId0.getEncodedId(),
       hash: ethereumTxHashBuffer,
       payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(wrongNonceTransactionResult),
     },
     {
       consensusTimestamp: 4,
       entityId: entityId0.getEncodedId(),
       hash: ethereumTxHashBuffer,
       payerAccountId: entityId10.getEncodedId(),
+      transactionResult: Number.parseInt(successTransactionResult),
     },
   ];
 

--- a/rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx-latest-failed.json
+++ b/rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx-latest-failed.json
@@ -1,5 +1,5 @@
 {
-  "description": "Contract results api call for an ethereum transaction hash matching more than one tx",
+  "description": "Contract results api call for an ethereum transaction hash matching more than one failed tx",
   "setup": {
     "contractresults": [
       {
@@ -9,11 +9,51 @@
         "consensus_timestamp": "167654000123456",
         "contract_id": 5001,
         "created_contract_ids": [7001],
-        "error_message": "WRONG_NONCE",
+        "error_message": "CONSENSUS_GAS_EXHAUSTED",
         "function_parameters": [7, 7],
         "function_result": [8, 8],
         "gas_consumed": null,
         "gas_limit": 1000000,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "sender_id": 8001,
+        "transaction_result": 279,
+        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "transaction_index": 1,
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "167654000123457",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "CONSENSUS_GAS_EXHAUSTED",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_consumed": null,
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "sender_id": 8001,
+        "transaction_result": 279,
+        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "transaction_index": 1,
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "167654000123458",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "WRONG_NONCE",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_consumed": null,
+        "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
         "sender_id": 8001,
@@ -26,10 +66,10 @@
         "amount": 30,
         "bloom": [5, 5],
         "call_result": [6, 6],
-        "consensus_timestamp": "167654000123457",
+        "consensus_timestamp": "167654000123459",
         "contract_id": 5001,
         "created_contract_ids": [7001],
-        "error_message": "",
+        "error_message": "DUPLICATE_TRANSACTION",
         "function_parameters": [7, 7],
         "function_result": [8, 8],
         "gas_consumed": null,
@@ -37,27 +77,7 @@
         "gas_used": 123,
         "payer_account_id": 8001,
         "sender_id": 8001,
-        "transaction_result": 22,
-        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1,
-        "transaction_nonce": 0
-      },
-      {
-        "amount": 30,
-        "bloom": [5, 5],
-        "call_result": [6, 6],
-        "consensus_timestamp": "167654000123458",
-        "contract_id": 5001,
-        "created_contract_ids": [7001],
-        "error_message": "CONSENSUS_GAS_EXHAUSTED",
-        "function_parameters": [7, 7],
-        "function_result": [8, 8],
-        "gas_consumed": null,
-        "gas_limit": 987654,
-        "gas_used": 123,
-        "payer_account_id": 8001,
-        "sender_id": 8001,
-        "transaction_result": 279,
+        "transaction_result": 11,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
         "transaction_index": 1,
         "transaction_nonce": 0
@@ -79,7 +99,7 @@
         "transaction_hash": "519a008fabde4d",
         "type": 50,
         "valid_start_timestamp": 167654000123400,
-        "result": 312
+        "result": 279
       },
       {
         "consensus_timestamp": 167654000123457,
@@ -87,7 +107,7 @@
         "transaction_hash": "519a008fabde5d",
         "type": 50,
         "valid_start_timestamp": 167654000123401,
-        "result": 22
+        "result": 279
       },
       {
         "consensus_timestamp": 167654000123458,
@@ -95,7 +115,7 @@
         "transaction_hash": "519a008fabde5d",
         "type": 50,
         "valid_start_timestamp": 167654000123402,
-        "result": 279
+        "result": 312
       },
       {
         "consensus_timestamp": 167654000123459,
@@ -103,13 +123,6 @@
         "transaction_hash": "519a008fabde6d",
         "valid_start_timestamp": 167654000123400,
         "result": 11
-      },
-      {
-        "consensus_timestamp": 167654000123460,
-        "payerAccountId": "8001",
-        "transaction_hash": "519a008fabde7d",
-        "valid_start_timestamp": 167654000123400,
-        "result": 10
       }
     ],
     "ethereumtransactions": [
@@ -136,6 +149,14 @@
         "payer_account_id": 8001,
         "value": "0x0077359400",
         "_value_description": "2000000000 tinybars, in importer java BigInteger.toByteArray always adds extra 0x00"
+      },
+      {
+        "call_data": "0x0606",
+        "consensus_timestamp": 167654000123459,
+        "hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "payer_account_id": 8001,
+        "value": "0x0077359400",
+        "_value_description": "2000000000 tinybars, in importer java BigInteger.toByteArray always adds extra 0x00"
       }
     ]
   },
@@ -155,9 +176,9 @@
     "chain_id": "0x",
     "contract_id": "0.0.5001",
     "created_contract_ids": ["0.0.7001"],
-    "error_message": null,
+    "error_message": "CONSENSUS_GAS_EXHAUSTED",
     "address": "0x0000000000000000000000000000000000001389",
-    "failed_initcode": null,
+    "failed_initcode": "0x0606",
     "from": "0x0000000000000000000000000000000000001f41",
     "function_parameters": "0x0606",
     "gas_consumed": null,
@@ -170,10 +191,10 @@
     "max_priority_fee_per_gas": "0x",
     "nonce": 1,
     "r": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
-    "result": "SUCCESS",
+    "result": "CONSENSUS_GAS_EXHAUSTED",
     "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
     "state_changes": [],
-    "status": "0x1",
+    "status": "0x0",
     "timestamp": "167654.000123457",
     "to": "0x0000000000000000000000000000000000001389",
     "transaction_index": 1,

--- a/rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx.json
+++ b/rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx.json
@@ -174,7 +174,7 @@
     "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
     "state_changes": [],
     "status": "0x1",
-    "timestamp": "167654.000123456",
+    "timestamp": "167654.000123457",
     "to": "0x0000000000000000000000000000000000001389",
     "transaction_index": 1,
     "type": 2,

--- a/rest/controllers/contractController.js
+++ b/rest/controllers/contractController.js
@@ -39,6 +39,7 @@ import {
   ContractStateViewModel,
   ContractViewModel,
 } from '../viewmodel';
+import ContractTransactionHash from '../model/contractTransactionHash.js';
 
 const contractSelectFields = [
   Entity.AUTO_RENEW_ACCOUNT_ID,
@@ -70,6 +71,7 @@ const contractCreateType = Number(TransactionType.getProtoId('CONTRACTCREATEINST
 const ethereumTransactionType = Number(TransactionType.getProtoId('ETHEREUMTRANSACTION'));
 const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
 const wrongNonceTransactionResult = TransactionResult.getProtoId('WRONG_NONCE');
+const successTransactionResult = TransactionResult.getProtoId('SUCCESS');
 
 /**
  * Extracts the sql where clause, params, order and limit values to be used from the provided contract query
@@ -1114,12 +1116,7 @@ class ContractController extends BaseController {
     const excludeTransactionResults = [duplicateTransactionResult, wrongNonceTransactionResult];
     const {transactionIdOrHash} = req.params;
     if (utils.isValidEthHash(transactionIdOrHash)) {
-      const detailsByHash = await ContractService.getContractTransactionDetailsByHash(
-        utils.parseHexStr(transactionIdOrHash),
-        excludeTransactionResults,
-        1
-      );
-      transactionDetails = detailsByHash[0];
+      transactionDetails = await this.getEthTransactionDetails(transactionIdOrHash, excludeTransactionResults);
     } else {
       const transactionId = TransactionId.fromString(transactionIdOrHash);
       const nonce = getLastNonceParamValue(req.query);
@@ -1217,6 +1214,41 @@ class ContractController extends BaseController {
         contractDetails.contractIds
       ),
     ]);
+  };
+
+  getEthTransactionDetails = async (transactionIdOrHash, excludeTransactionResults) => {
+    const detailsByHash = await ContractService.getContractTransactionDetailsByHash(
+      utils.parseHexStr(transactionIdOrHash),
+      excludeTransactionResults
+    );
+
+    const detailsByHashSuccessful = detailsByHash.filter((t) => t.transactionResult === successTransactionResult);
+    // If there is more than 1 successful transaction -> return the first successful.
+    if (detailsByHashSuccessful.length > 1) {
+      this.sortTransactionsByConsensusTimestampAsc(detailsByHashSuccessful);
+    }
+    let transactionDetails = detailsByHashSuccessful[0];
+
+    if (!transactionDetails) {
+      // If there are no successful transactions -> return the earliest unsuccessful.
+      const detailsByHashUnsuccessful = detailsByHash.filter((t) => t.transactionResult !== successTransactionResult);
+      if (detailsByHashUnsuccessful.length > 1) {
+        this.sortTransactionsByConsensusTimestampAsc(detailsByHashUnsuccessful);
+      }
+      transactionDetails = detailsByHashUnsuccessful[0];
+    }
+    return transactionDetails;
+  };
+
+  sortTransactionsByConsensusTimestampAsc = (transactions) => {
+    if (transactions.length > 1) {
+      transactions.sort((a, b) => {
+        if (a.consensusTimestamp < b.consensusTimestamp) return -1;
+        if (a.consensusTimestamp > b.consensusTimestamp) return 1;
+        return 0;
+      });
+    }
+    return transactions;
   };
 
   getContractActions = async (req, res) => {

--- a/rest/controllers/contractController.js
+++ b/rest/controllers/contractController.js
@@ -39,7 +39,6 @@ import {
   ContractStateViewModel,
   ContractViewModel,
 } from '../viewmodel';
-import ContractTransactionHash from '../model/contractTransactionHash.js';
 
 const contractSelectFields = [
   Entity.AUTO_RENEW_ACCOUNT_ID,

--- a/rest/model/contractTransactionHash.js
+++ b/rest/model/contractTransactionHash.js
@@ -16,6 +16,7 @@ class ContractTransactionHash {
     this.entityId = transactionHash[ContractTransactionHash.ENTITY_ID];
     this.hash = transactionHash[ContractTransactionHash.HASH];
     this.payerAccountId = transactionHash[ContractTransactionHash.PAYER_ACCOUNT_ID];
+    this.transactionResult = transactionHash[ContractTransactionHash.TRANSACTION_RESULT];
   }
 }
 

--- a/rest/service/contractService.js
+++ b/rest/service/contractService.js
@@ -197,7 +197,8 @@ class ContractService extends BaseService {
   static transactionHashDetailsQuery = `select ${ContractTransactionHash.HASH}, 
                                               ${ContractTransactionHash.PAYER_ACCOUNT_ID}, 
                                               ${ContractTransactionHash.CONSENSUS_TIMESTAMP}, 
-                                              ${ContractTransactionHash.ENTITY_ID}
+                                              ${ContractTransactionHash.ENTITY_ID},
+                                              ${ContractTransactionHash.TRANSACTION_RESULT}
                                               from ${ContractTransactionHash.tableName} 
                                        where ${ContractTransactionHash.HASH} = $1 
                                        `;


### PR DESCRIPTION
**Description**:
Improve the contract results endpoint to return the successful results with priority when the eth transaction hash is passed and there are multiple results with the same eth transaction hash. If there is no successful result, the latest failed result is returned.

Fixes #11770 
