### PR TITLE
Switch to bitnamilegacy docker images

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     condition: minio.enabled
     name: minio
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 17.0.8
+    version: 17.0.21
   - name: loki
     condition: loki.enabled
     version: 6.29.0

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -2,6 +2,8 @@
 
 global:
   namespaceOverride: ""
+  security:
+    allowInsecureImages: true
 
 labels: {}
 
@@ -185,7 +187,13 @@ loki:
 minio:
   console:
     enabled: false
+  defaultInitContainers:
+    volumePermissions:
+      image:
+        repository: bitnamilegacy/os-shell
   enabled: false
+  image:
+    repository: bitnamilegacy/minio
   persistence:
     enabled: true
     size: 500Gi

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -31,11 +31,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 15.3.12
+    version: 15.3.17
   - condition: redis.enabled
     name: redis
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 20.11.5
+    version: 22.0.7
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -94,6 +94,8 @@ global:
   hostname: ""
   image: {}
   namespaceOverride: ""
+  security:
+    allowInsecureImages: true
   podAnnotations: {}
   useReleaseForNameLabel: false  # Set the name label to the release name for Marketplace
 
@@ -147,6 +149,8 @@ postgresql:
   enabled: true
   metrics:
     enabled: false
+    image:
+      repository: bitnamilegacy/postgres-exporter
     resources:
       limits:
         cpu: 50m
@@ -175,6 +179,7 @@ postgresql:
             key: PGPOOL_POSTGRES_CUSTOM_USERS
     image:
       debug: true
+      repository: bitnamilegacy/pgpool
     numInitChildren: 100
     podAntiAffinityPreset: soft
     podLabels:
@@ -194,7 +199,8 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 17.5.0-debian-12-r10
+      repository: bitnamilegacy/postgresql-repmgr
+      tag: 17.6.0-debian-12-r2
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank
@@ -217,7 +223,15 @@ redis:
     password: ""  # Randomly generated if left blank
   enabled: true
   host: "{{ .Release.Name }}-redis"
+  image:
+    repository: bitnamilegacy/redis
+  kubectl:
+    image:
+      repository: rancher/kubectl
+      tag: v1.33.4
   metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
     resources:
       limits:
         cpu: 100m
@@ -247,6 +261,8 @@ redis:
         memory: 1000Mi
   sentinel:
     enabled: true
+    image:
+      repository: bitnamilegacy/redis-sentinel
     masterSet: mirror
     persistence:
       enabled: true

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -23,7 +23,7 @@ fi
 
 annotation="com.googleapis.cloudmarketplace.product.service.name=services/hedera-mirror-node-mirror-node-public.cloudpartnerservices.goog"
 bats_tag="1.11.1"
-postgresql_tag="17.5.0-debian-12-r10"
+postgresql_tag="17.6.0-debian-12-r2"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"


### PR DESCRIPTION
**Description**:

* Bump minio, postgresql-repmgr, and redis Helm charts
* Switch most bitnami images to bitnamilegacy
* Switch kubectl to rancher

**Related issue(s)**:

Fixes #11869

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
