### PR TITLE
Fix changelog generation

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -113,16 +113,10 @@ jobs:
 
       - name: Create Release Notes
         if: ${{ steps.version_parser.outputs.prerelease == '' }}
-        uses: steven-sheehy/github-changelog-generator@587a63ffdd931b656ca33566d55fe76179e2046b
+        uses: steven-sheehy/github-changelog-generator@b4174ba12a75add137b35a1e28907d1ac0511f92
         with:
           config-file: .github/release-notes.yml
           milestone: ${{ steps.version_parser.outputs.release }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Output Release Notes
-        if: ${{ steps.version_parser.outputs.prerelease == '' }}
-        continue-on-error: true
-        run: cat changelog.md
 
       - name: Commit and Tag
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1


### PR DESCRIPTION
**Description**:

Another attempt at fixing the changelog generation after it failed again in [0.137.0](https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/17309494162)

* Add additional debug statements to the github-changelog-generator image
* Fix permission issue with `GITHUB_TOKEN` causing GitHub details to not be retrieved
* Remove printing of changelog.md since the debug statements now do it

**Related issue(s)**:

**Notes for reviewer**:

Working test run: https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/17311481127/job/49146371303

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
