### PR TITLE
Add network stake k6 test case to rest-java

### DIFF
--- a/tools/k6/src/rest-java/libex/common.js
+++ b/tools/k6/src/rest-java/libex/common.js
@@ -26,7 +26,7 @@ class RestJavaTestScenarioBuilder extends TestScenarioBuilder {
     super();
     this.fallbackRequest((testParameters) => {
       // Fallback to a known account ID. Replace this with another API endpoint when one exists not requiring an entity ID.
-      const url = `${testParameters['BASE_URL_PREFIX']}/accounts/2/allowances/nfts`;
+      const url = `${testParameters['BASE_URL_PREFIX']}/accounts/0.0.2/allowances/nfts`;
       return http.get(url);
     });
   }

--- a/tools/k6/src/rest-java/libex/common.js
+++ b/tools/k6/src/rest-java/libex/common.js
@@ -26,7 +26,7 @@ class RestJavaTestScenarioBuilder extends TestScenarioBuilder {
     super();
     this.fallbackRequest((testParameters) => {
       // Fallback to a known account ID. Replace this with another API endpoint when one exists not requiring an entity ID.
-      const url = `${testParameters['BASE_URL_PREFIX']}/accounts/0.0.2/allowances/nfts`;
+      const url = `${testParameters['BASE_URL_PREFIX']}/accounts/2/allowances/nfts`;
       return http.get(url);
     });
   }

--- a/tools/k6/src/rest-java/test/index.js
+++ b/tools/k6/src/rest-java/test/index.js
@@ -7,6 +7,7 @@ import * as accountsNftAllowanceOwner from './accountsNftAllowanceOwner.js';
 import * as accountsNftAllowanceSpender from './accountsNftAllowanceSpender.js';
 import * as accountsPendingAirdrop from './accountsPendingAirdrop.js';
 import * as accountsOutstandingAirdrop from './accountsOutstandingAirdrop.js';
+import * as networkStake from './networkStake.js';
 import * as topicsId from './topicsId.js';
 import * as rampUp from './rampUp.js';
 
@@ -16,6 +17,7 @@ const tests = {
   accountsNftAllowanceSpender,
   accountsPendingAirdrop,
   accountsOutstandingAirdrop,
+  networkStake,
   topicsId,
   rampUp,
 };

--- a/tools/k6/src/rest-java/test/networkStake.js
+++ b/tools/k6/src/rest-java/test/networkStake.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import {isSuccess, RestJavaTestScenarioBuilder} from '../libex/common.js';
+
+const urlTag = '/network/stake';
+
+const {options, run, setup} = new RestJavaTestScenarioBuilder()
+  .name('networkStake') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL_PREFIX']}${urlTag}`;
+    return http.get(url);
+  })
+  .check('Network stake OK', isSuccess)
+  .build();
+
+export {options, run, setup};


### PR DESCRIPTION
**Description**:

This PR duplicates the network stake k6 test case for rest-java

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Wanted to a take a cleaner approach to move it to a common test case folder. It's easy for network stake mainly due to no test case parameter discovery involved. However it'll be more work when later we move other test cases over and it's not worth the effort for non-production code.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
