### PR TITLE
Add block by hash and schedules acceptance tests

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -27,6 +27,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.Durations;
 import org.hiero.mirror.rest.model.AccountBalanceTransactions;
 import org.hiero.mirror.rest.model.AccountInfo;
+import org.hiero.mirror.rest.model.Block;
 import org.hiero.mirror.rest.model.BlocksResponse;
 import org.hiero.mirror.rest.model.ContractActionsResponse;
 import org.hiero.mirror.rest.model.ContractCallRequest;
@@ -46,6 +47,7 @@ import org.hiero.mirror.rest.model.NftAllowancesResponse;
 import org.hiero.mirror.rest.model.NftTransactionHistory;
 import org.hiero.mirror.rest.model.Nfts;
 import org.hiero.mirror.rest.model.Schedule;
+import org.hiero.mirror.rest.model.SchedulesResponse;
 import org.hiero.mirror.rest.model.TokenAirdropsResponse;
 import org.hiero.mirror.rest.model.TokenAllowancesResponse;
 import org.hiero.mirror.rest.model.TokenBalancesResponse;
@@ -284,6 +286,11 @@ public class MirrorNodeClient {
         return callRestEndpoint("/blocks?order={order}&limit={limit}", BlocksResponse.class, order, limit);
     }
 
+    public Block getBlockByHash(String hash) {
+        log.debug("Get block hash by Mirror Node");
+        return callRestEndpoint("/blocks/{hash}", Block.class, hash);
+    }
+
     public List<NetworkNode> getNetworkNodes() {
         List<NetworkNode> nodes = new ArrayList<>();
         String next = "/network/nodes?limit=25";
@@ -332,6 +339,11 @@ public class MirrorNodeClient {
     public Schedule getScheduleInfo(String scheduleId) {
         log.debug("Verify schedule '{}' is returned by Mirror Node", scheduleId);
         return callRestEndpoint("/schedules/{scheduleId}", Schedule.class, scheduleId);
+    }
+
+    public SchedulesResponse getSchedules(Order order, long limit) {
+        log.debug("Get schedules data by Mirror Node");
+        return callRestEndpoint("/schedules?order={order}&limit={limit}", SchedulesResponse.class, order, limit);
     }
 
     public TokenBalancesResponse getTokenBalances(String tokenId) {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/BlockFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/BlockFeature.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.test.e2e.acceptance.steps;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.cucumber.java.en.When;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
+import org.hiero.mirror.test.e2e.acceptance.props.Order;
+import org.springframework.util.CollectionUtils;
+
+@CustomLog
+@RequiredArgsConstructor
+public class BlockFeature {
+
+    private final MirrorNodeClient mirrorClient;
+
+    @When("I verify block by hash")
+    public void verifyBlockByHash() {
+        final var blocks = mirrorClient.getBlocks(Order.ASC, 1);
+        if (CollectionUtils.isEmpty(blocks.getBlocks())) {
+            log.warn("Skipping block by hash verification since there are no blocks");
+            return;
+        }
+        final var firstBlock = blocks.getBlocks().getFirst();
+        final var blockHash = firstBlock.getHash();
+        final var blockResponse = mirrorClient.getBlockByHash(blockHash);
+
+        assertThat(blockResponse).isNotNull();
+        assertThat(blockResponse).isEqualTo(firstBlock);
+    }
+}

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -32,6 +32,7 @@ import org.hiero.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.client.ScheduleClient;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
+import org.hiero.mirror.test.e2e.acceptance.props.Order;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import org.springframework.boot.convert.DurationStyle;
 import org.springframework.http.HttpStatus;
@@ -166,6 +167,13 @@ public class ScheduleFeature extends AbstractFeature {
             String scheduleStatus, String expirationTimeInSeconds, String waitForExpiry) {
         verifyScheduleFromMirror(
                 ScheduleStatus.valueOf(scheduleStatus), expirationTimeInSeconds, Boolean.parseBoolean(waitForExpiry));
+    }
+
+    @Then("the mirror node REST API should list all schedules")
+    public void verifyListIncludesCreatedSchedule() {
+        final var schedulesResponse = mirrorClient.getSchedules(Order.ASC, 10);
+        assertNotNull(schedulesResponse);
+        assertThat(schedulesResponse.getSchedules()).isNotEmpty();
     }
 
     private void verifyScheduleFromMirror(

--- a/test/src/test/resources/features/block/block.feature
+++ b/test/src/test/resources/features/block/block.feature
@@ -1,0 +1,5 @@
+@block @fullsuite @acceptance
+Feature: Block Coverage Feature
+
+  Scenario Outline: Validate block
+    When I verify block by hash

--- a/test/src/test/resources/features/schedule/schedule.feature
+++ b/test/src/test/resources/features/schedule/schedule.feature
@@ -26,6 +26,7 @@ Feature: Schedule Base Coverage Feature
     And the mirror node REST API should return status <httpStatusCode> for the schedule transaction
     Then I wait until the schedule's expiration time
     And the mirror node REST API should verify the "EXECUTED" schedule entity with expiration time "25s" and wait for expiry "true"
+    Then the mirror node REST API should list all schedules
 
     Examples:
       | httpStatusCode |


### PR DESCRIPTION
**Description**:
Add acceptance tests for:

/api/v1/blocks/{hashOrNumber} - Specific block lookup
/api/v1/schedules - List all schedules

Fixes #11867

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
