### PR TITLE
Enable Java network stake by default

### DIFF
--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -46,9 +46,6 @@ envFrom: []
 
 fullnameOverride: ""
 
-routes:
-  networkStake: false
-
 gateway:
   gcp:
     backendPolicy:
@@ -321,6 +318,9 @@ resources:
     memory: 1024Mi
 
 revisionHistoryLimit: 3
+
+routes:
+  networkStake: true
 
 securityContext:
   allowPrivilegeEscalation: false

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -200,7 +200,7 @@ postgresql:
     image:
       debug: true
       repository: bitnamilegacy/postgresql-repmgr
-      tag: 17.6.0-debian-12-r2
+      tag: 17.6.0-debian-12-r5
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank

--- a/charts/marketplace/gcp/BUILDING.md
+++ b/charts/marketplace/gcp/BUILDING.md
@@ -43,13 +43,15 @@ the [Dockerfile](Dockerfile).
 
 Additionally, GCP Marketplace restricts applications to images pulled from the Marketplace registry. Since the Mirror
 Node uses some third party images like PostgreSQL, we need to re-publish these images to our staging registry and keep
-them up to date. To republish postgresql-repmgr, run the following steps manually whenever it needs to change:
+them up to date. The image must be published as an OCI image for the required marketplace annotations to be attached.
+To republish postgresql-repmgr, run the following steps manually whenever it needs to change:
 
 ```shell
-export PG_VERSION=16.6.0-debian-12-r3
+export PG_VERSION=17.6.0-debian-12-r5
 git clone https://github.com/bitnami/containers.git
-cd containers/postgresql-repmgr/16/debian-12
+cd containers/bitnami/postgresql-repmgr/17/debian-12
 docker buildx build . -t gcr.io/mirror-node-public/hedera-mirror-node/postgresql-repmgr:${PG_VERSION} --push --provenance false --platform linux/amd64 --annotation "manifest,manifest-descriptor:com.googleapis.cloudmarketplace.product.service.name=services/hedera-mirror-node-mirror-node-public.cloudpartnerservices.goog"
+docker manifest inspect gcr.io/mirror-node-public/hedera-mirror-node/postgresql-repmgr:${PG_VERSION} | grep "vnd.oci.image"
 sed "s/postgresql_tag=.*/postgresql_tag=\"${PG_VERSION}\"/" release.sh
 ```
 

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -23,7 +23,7 @@ fi
 
 annotation="com.googleapis.cloudmarketplace.product.service.name=services/hedera-mirror-node-mirror-node-public.cloudpartnerservices.goog"
 bats_tag="1.11.1"
-postgresql_tag="17.6.0-debian-12-r2"
+postgresql_tag="17.6.0-debian-12-r5"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,8 +215,7 @@ configs:
         # rest-java host
         location ~ "^/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/(allowances/nfts|airdrops)" { proxy_pass http://rest_java_host$$request_uri; }
         location ~ "^/api/v1/topics/(\d+\.){0,2}\d+$" { proxy_pass http://rest_java_host$$request_uri; }
-        # Future route for /network/stake
-        # location = /api/v1/network/stake { proxy_pass http://rest_java_host$$request_uri; }
+        location = /api/v1/network/stake { proxy_pass http://rest_java_host$$request_uri; }
 
         # rest host
         location /api/v1/ { proxy_pass http://rest_host$$request_uri; }

--- a/docs/checklist/feature.md
+++ b/docs/checklist/feature.md
@@ -19,11 +19,10 @@ aims to document the required changes associated with any new feature.
 ## Importer
 
 - [ ] V1 migration
-- [ ] `V2.0.0__create_tables.sql`
-- [ ] `V2.0.1__distribution.sql`
-- [ ] `V2.0.3__index_init.sql`
+- [ ] V2 migration
 - [ ] Repository
   - [ ] `RetentionRepository` if insert-only
+- [ ] `BlockItemTransformer`
 - [ ] `EntityListener`
 - [ ] `CompositeEntityListener`
 - [ ] `SqlEntityListener`
@@ -79,13 +78,7 @@ Acceptance and performance tests should be updated whenever there's an API chang
 
 - [ ] [Configuration Properties](/docs/configuration.md)
 - [ ] [Database Indexes Table](/docs/database/README.md#indexes)
+- [ ] [ERD SQL](/docs/database/erd.sql)
+- [ ] [Regenerate](/docs/database/README.md#entity-relationship-diagram-erd) the [ERD diagram](/docs/database/erd.drawio)
 - [ ] [HAPI Compatibility Matrix](/docs/importer/README.md#hapi-compatibility)
 - [ ] [REST Database Table](/docs/rest/README.md#database)
-
-## ETL
-
-The separate [hedera-etl](https://github.com/blockchain-etl/hedera-etl) project should have its BigQuery schema
-definition updated whenever there's a HAPI change.
-
-- [ ] `transaction-types.csv` updated
-- [ ] `transactions-schema.json` updated

--- a/docs/checklist/release.md
+++ b/docs/checklist/release.md
@@ -5,10 +5,8 @@ This checklist verifies a release is rolled out successfully.
 ## Preparation
 
 - [ ] Milestone created
-- [ ] Milestone field populated on
-      relevant [issues](https://github.com/hiero-ledger/hiero-mirror-node/issues?q=is%3Aclosed+no%3Amilestone+sort%3Aupdated-desc)
-- [ ] Nothing open
-      for [milestone](https://github.com/hiero-ledger/hiero-mirror-node/issues?q=is%3Aopen+sort%3Aupdated-desc+milestone%3A0.130.0)
+- [ ] Milestone field populated on relevant [issues](https://github.com/hiero-ledger/hiero-mirror-node/issues?q=is%3Aclosed+no%3Amilestone+sort%3Aupdated-desc)
+- [ ] Nothing open for [milestone](https://github.com/hiero-ledger/hiero-mirror-node/issues?q=is%3Aopen+sort%3Aupdated-desc+milestone%3A0.139.0)
 - [ ] GitHub checks for branch are passing
 - [ ] No pre-release or snapshot dependencies present in build files
 - [ ] Verify HAPI protobuf dependency doesn't contain any unsupported fields or messages
@@ -78,6 +76,7 @@ These preprod environments are automatically deployed for any GA release. Ensure
 
 - [ ] Dev
 - [ ] Integration Docker
+- [ ] Staging Council
 - [ ] Staging Large
 - [ ] Staging Small
 

--- a/docs/checklist/rest-conversion.md
+++ b/docs/checklist/rest-conversion.md
@@ -35,8 +35,9 @@ regressions are introduced.
 - [ ] New `routes.<apiName>` property added to `charts/hedera-mirror-rest-java/values.yaml` and defaulted to `false`
 - [ ] New route added to ingress conditional on routes property
 - [ ] New route added to gateway conditional on routes property
-- [ ] After rollout, manually enable in environments for a short period of time and watch metrics
-- [ ] Permanently enable in previewnet and testnet for a release
+- [ ] Enable route in integration environment before tagging and test it
+- [ ] Enable route in previewnet and watch metrics/logs
+- [ ] Enable route in both testnet clusters for a release and watch metrics/logs
 
 ## Phase Two
 


### PR DESCRIPTION
**Description**:

* Add staging-council to release checklist
* Bump postgresql-repmgr to 17.6.0-debian-12-r5
* Enable Java network stake route by default in chart and docker compose
* Fix instructions for manually publishing postgres image to GCP Marketplace
* Update feature checklist with latest items
* Update REST Java conversion checklist with phase one changes

**Related issue(s)**:

Fixes #11993

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
