### PR TITLE
Remove previewnet restjava routes config

### DIFF
--- a/clusters/previewnet/previewnet-citus/helmrelease.yaml
+++ b/clusters/previewnet/previewnet-citus/helmrelease.yaml
@@ -63,8 +63,6 @@ spec:
       enabled: true
     restjava:
       enabled: true
-      routes:
-        networkStake: true
     stackgres:
       coordinator:
         persistentVolume:


### PR DESCRIPTION
**Description**:

This PR removes previewnet restjava routes config since networkStake is not enabled by default.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
