### PR TITLE
Bump Spring Boot from 3.5.5 to 3.5.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,9 @@ extra.apply {
     set("grpcVersion", "1.75.0")
     set("jooq.version", "3.20.7") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
-    set("netty.version", "4.1.125.Final") // Temporary until next Spring Boot
     set("nodeJsVersion", "22.17.1")
     set("protobufVersion", "4.32.1")
     set("reactorGrpcVersion", "1.2.4")
-    set("spring-framework.version", "6.2.11") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("org.jooq:jooq-postgres-extensions:${jooqVersion}")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.15.0")
     implementation("org.owasp:dependency-check-gradle:12.1.3")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.5")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.6")
     implementation("org.testcontainers:postgresql:1.21.3")
     implementation("org.web3j:web3j-gradle-plugin:4.14.0")
 }


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 3.5.5 to 3.5.6
* Remove manual overrides for Netty and Spring Framework

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
