### PR TITLE
Change ContractExecutionParameters.sender to be Address #11870

### DIFF
--- a/web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -7,7 +7,6 @@ import static org.hiero.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmMutableWorldState;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import java.time.Instant;
 import java.util.Map;
@@ -82,7 +81,7 @@ public class HederaEvmTxProcessor {
      */
     @SuppressWarnings("java:S107")
     public HederaEvmTransactionProcessingResult execute(
-            final HederaEvmAccount sender,
+            final Address sender,
             final Address receiver,
             final long gasPrice,
             final boolean isEstimate,
@@ -100,7 +99,6 @@ public class HederaEvmTxProcessor {
         final var valueAsWei = Wei.of(value);
         final var updater = worldState.updater();
         final var stackedUpdater = updater.updater();
-        final var senderEvmAddress = sender.canonicalAddress();
         final var precompileContext = new PrecompileContext();
         precompileContext.setEstimate(isEstimate);
 
@@ -108,9 +106,9 @@ public class HederaEvmTxProcessor {
                 .maxStackSize(MAX_STACK_SIZE)
                 .worldUpdater(stackedUpdater)
                 .initialGas(gasAvailable)
-                .originator(senderEvmAddress)
+                .originator(sender)
                 .gasPrice(Wei.of(gasPrice))
-                .sender(senderEvmAddress)
+                .sender(sender)
                 .value(valueAsWei)
                 .apparentValue(valueAsWei)
                 .blockValues(blockValues)

--- a/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
@@ -6,7 +6,6 @@ import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType
 import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static org.hiero.mirror.web3.utils.Constants.MODULARIZED_HEADER;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.CustomLog;
@@ -59,7 +58,6 @@ class ContractController {
     private ContractExecutionParameters constructServiceParameters(
             ContractCallRequest request, final String isModularizedHeader) {
         final var fromAddress = request.getFrom() != null ? Address.fromHexString(request.getFrom()) : Address.ZERO;
-        final var sender = new HederaEvmAccount(fromAddress);
 
         Address receiver;
 
@@ -103,7 +101,7 @@ class ContractController {
                 .isModularized(isModularized)
                 .isStatic(isStaticCall)
                 .receiver(receiver)
-                .sender(sender)
+                .sender(fromAddress)
                 .value(request.getValue())
                 .build();
     }

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -81,15 +81,13 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         final long gasPrice = gasPriceTinyBarsGiven(Instant.now());
 
         store.wrap();
-        if (store.getAccount(params.getSender().canonicalAddress(), OnMissing.DONT_THROW)
-                .isEmptyAccount()) {
+        if (store.getAccount(params.getSender(), OnMissing.DONT_THROW).isEmptyAccount()) {
 
             final Account senderAccount;
-            if (isMirror(params.getSender().canonicalAddress())) {
-                senderAccount = Account.getDummySenderAccount(params.getSender().canonicalAddress());
+            if (isMirror(params.getSender())) {
+                senderAccount = Account.getDummySenderAccount(params.getSender());
             } else {
-                senderAccount = Account.getDummySenderAccountWithAlias(
-                        params.getSender().canonicalAddress());
+                senderAccount = Account.getDummySenderAccountWithAlias(params.getSender());
             }
 
             store.updateAccount(senderAccount);

--- a/web3/src/main/java/org/hiero/mirror/web3/service/OpcodeServiceImpl.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/OpcodeServiceImpl.java
@@ -8,7 +8,6 @@ import static org.hiero.mirror.common.util.DomainUtils.EVM_ADDRESS_LENGTH;
 import static org.hiero.mirror.common.util.DomainUtils.convertToNanosMax;
 import static org.hiero.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import java.math.BigInteger;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -171,7 +170,7 @@ public class OpcodeServiceImpl implements OpcodeService {
                 .gas(getGasLimit(ethTransaction, contractResult))
                 .isModularized(isModularized)
                 .receiver(getReceiverAddress(ethTransaction, contractResult, transactionType))
-                .sender(new HederaEvmAccount(getSenderAddress(contractResult)))
+                .sender(getSenderAddress(contractResult))
                 .value(getValue(ethTransaction, contractResult).longValue())
                 .build();
     }

--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -214,10 +214,10 @@ public class TransactionExecutionService {
 
     private AccountID getSenderAccountID(final CallServiceParameters params) {
         // Set a default account to keep the sender parameter optional.
-        if (params.getSender().canonicalAddress().isZero() && params.getValue() == 0L) {
+        if (params.getSender().isZero() && params.getValue() == 0L) {
             return EntityIdUtils.toAccountId(systemEntity.treasuryAccount());
         }
-        final var senderAddress = params.getSender().canonicalAddress();
+        final var senderAddress = params.getSender();
         final var accountIDNum = getSenderAccountIDAsNum(senderAddress);
 
         final var account = accountReadableKVState.get(accountIDNum);

--- a/web3/src/main/java/org/hiero/mirror/web3/service/model/CallServiceParameters.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/model/CallServiceParameters.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.web3.service.model;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import org.apache.tuweni.bytes.Bytes;
 import org.hiero.mirror.web3.evm.contracts.execution.traceability.TracerType;
 import org.hiero.mirror.web3.viewmodel.BlockType;
@@ -19,7 +18,7 @@ public interface CallServiceParameters {
 
     Address getReceiver();
 
-    HederaEvmAccount getSender();
+    Address getSender();
 
     TracerType getTracerType();
 

--- a/web3/src/main/java/org/hiero/mirror/web3/service/model/ContractDebugParameters.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/model/ContractDebugParameters.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.web3.service.model;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -46,7 +45,7 @@ public class ContractDebugParameters implements CallServiceParameters {
     Address receiver;
 
     @NotNull
-    HederaEvmAccount sender;
+    Address sender;
 
     @NotNull
     TracerType tracerType = TracerType.OPCODE;

--- a/web3/src/main/java/org/hiero/mirror/web3/service/model/ContractExecutionParameters.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/model/ContractExecutionParameters.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.web3.service.model;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import lombok.Builder;
 import lombok.Value;
 import org.apache.tuweni.bytes.Bytes;
@@ -21,7 +20,7 @@ public class ContractExecutionParameters implements CallServiceParameters {
     private final boolean isModularized;
     private final boolean isStatic;
     private final Address receiver;
-    private final HederaEvmAccount sender;
+    private final Address sender;
     private final TracerType tracerType = TracerType.OPERATION;
     private final long value;
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/controller/OpcodesControllerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/controller/OpcodesControllerTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSortedMap;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hederahashgraph.api.proto.java.Key;
 import io.github.bucket4j.Bucket;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -302,7 +301,7 @@ class OpcodesControllerTest {
 
         expectedCallServiceParameters.set(ContractDebugParameters.builder()
                 .consensusTimestamp(consensusTimestamp)
-                .sender(new HederaEvmAccount(senderAddress))
+                .sender(senderAddress)
                 .receiver(contractAddress)
                 .gas(provider.hasEthTransaction() ? ethTransaction.getGasLimit() : contractResult.getGasLimit())
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
@@ -468,8 +467,7 @@ class OpcodesControllerTest {
             }
 
             expectedCallServiceParameters.set(expectedCallServiceParameters.get().toBuilder()
-                    .sender(new HederaEvmAccount(
-                            entityAddress(providerEnum.getSenderEntity().get())))
+                    .sender(entityAddress(providerEnum.getSenderEntity().get()))
                     .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                     .build());
 

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -81,7 +81,7 @@ class MirrorEvmTxProcessorTest {
     private static final int MAX_STACK_SIZE = 1024;
     private static final String EVM_ADDRESS = "0x6b175474e89094c44da98b954eedeac495271d0f";
     private static final String FUNCTION_HASH = "0x8070450f";
-    private final HederaEvmAccount sender = new HederaEvmAccount(Address.ALTBN128_ADD);
+    private final Address sender = Address.ALTBN128_ADD;
     private final HederaEvmAccount receiver = new HederaEvmAccount(Address.ALTBN128_MUL);
     private final Address receiverAddress = receiver.canonicalAddress();
     private final Address nativePrecompileAddress = Address.SHA256;
@@ -200,8 +200,7 @@ class MirrorEvmTxProcessorTest {
         when(evmProperties.getSemanticEvmVersion()).thenReturn(EVM_VERSION_0_34);
         given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         given(pricesAndFeesProvider.currentGasPrice(any(), any())).willReturn(10L);
-        given(store.getAccount(sender.canonicalAddress(), OnMissing.DONT_THROW))
-                .willReturn(Account.getDummySenderAccount(sender.canonicalAddress()));
+        given(store.getAccount(sender, OnMissing.DONT_THROW)).willReturn(Account.getDummySenderAccount(sender));
 
         final var params = ContractExecutionParameters.builder()
                 .sender(sender)
@@ -227,10 +226,10 @@ class MirrorEvmTxProcessorTest {
         when(evmProperties.getSemanticEvmVersion()).thenReturn(EVM_VERSION);
         given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         given(pricesAndFeesProvider.currentGasPrice(any(), any())).willReturn(10L);
-        given(store.getAccount(sender.canonicalAddress(), OnMissing.DONT_THROW)).willReturn(Account.getEmptyAccount());
+        given(store.getAccount(sender, OnMissing.DONT_THROW)).willReturn(Account.getEmptyAccount());
 
         final var params = ContractExecutionParameters.builder()
-                .sender(senderWithAlias)
+                .sender(senderWithAlias.canonicalAddress())
                 .receiver(receiver.canonicalAddress())
                 .gas(33_333L)
                 .value(1234L)
@@ -253,9 +252,9 @@ class MirrorEvmTxProcessorTest {
         final MessageFrame.Builder protoFrame = MessageFrame.builder()
                 .worldUpdater(updater)
                 .initialGas(1L)
-                .originator(sender.canonicalAddress())
+                .originator(sender)
                 .gasPrice(Wei.ZERO)
-                .sender(sender.canonicalAddress())
+                .sender(sender)
                 .value(Wei.ONE)
                 .apparentValue(Wei.ONE)
                 .blockValues(hederaBlockValues)
@@ -279,9 +278,9 @@ class MirrorEvmTxProcessorTest {
                 .maxStackSize(MAX_STACK_SIZE)
                 .worldUpdater(mock(WorldUpdater.class))
                 .initialGas(GAS_LIMIT)
-                .originator(sender.canonicalAddress())
+                .originator(sender)
                 .gasPrice(Wei.ZERO)
-                .sender(sender.canonicalAddress())
+                .sender(sender)
                 .value(oneWei)
                 .apparentValue(oneWei)
                 .blockValues(mock(BlockValues.class))
@@ -293,7 +292,7 @@ class MirrorEvmTxProcessorTest {
                 commonInitialFrame, receiver.canonicalAddress(), Bytes.EMPTY, 0L);
 
         // expect:
-        assertThat(sender.canonicalAddress()).isEqualTo(buildMessageFrame.getSenderAddress());
+        assertThat(sender).isEqualTo(buildMessageFrame.getSenderAddress());
         assertThat(oneWei).isEqualTo(buildMessageFrame.getApparentValue());
     }
 
@@ -311,9 +310,9 @@ class MirrorEvmTxProcessorTest {
                 .maxStackSize(MAX_STACK_SIZE)
                 .worldUpdater(mock(WorldUpdater.class))
                 .initialGas(GAS_LIMIT)
-                .originator(sender.canonicalAddress())
+                .originator(sender)
                 .gasPrice(Wei.ZERO)
-                .sender(sender.canonicalAddress())
+                .sender(sender)
                 .value(Wei.ZERO)
                 .apparentValue(Wei.ZERO)
                 .blockValues(mock(BlockValues.class))
@@ -325,7 +324,7 @@ class MirrorEvmTxProcessorTest {
         final MessageFrame buildMessageFrame = mirrorEvmTxProcessor.buildInitialFrame(
                 commonInitialFrame, nativePrecompileAddress, validPrecompilePayload, 0L);
 
-        assertThat(sender.canonicalAddress()).isEqualTo(buildMessageFrame.getSenderAddress());
+        assertThat(sender).isEqualTo(buildMessageFrame.getSenderAddress());
         assertThat(buildMessageFrame.getApparentValue()).isEqualTo(Wei.ZERO);
         assertThat(nativePrecompileAddress).isEqualTo(buildMessageFrame.getRecipientAddress());
     }
@@ -345,9 +344,9 @@ class MirrorEvmTxProcessorTest {
                 .maxStackSize(MAX_STACK_SIZE)
                 .worldUpdater(mock(WorldUpdater.class))
                 .initialGas(GAS_LIMIT)
-                .originator(sender.canonicalAddress())
+                .originator(sender)
                 .gasPrice(Wei.ZERO)
-                .sender(sender.canonicalAddress())
+                .sender(sender)
                 .value(Wei.ZERO)
                 .apparentValue(Wei.ZERO)
                 .blockValues(mock(BlockValues.class))

--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.Key;
@@ -324,7 +323,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .isModularized(isModularized)
                 .isStatic(false)
                 .receiver(receiverAddress)
-                .sender(new HederaEvmAccount(senderAddress))
+                .sender(senderAddress)
                 .value(value)
                 .build();
     }
@@ -764,7 +763,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .gas(TRANSACTION_GAS_LIMIT)
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                 .receiver(functionProvider.contractAddress())
-                .sender(new HederaEvmAccount(functionProvider.sender()))
+                .sender(functionProvider.sender())
                 .value(functionProvider.value())
                 .build();
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallNativePrecompileTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallNativePrecompileTest.java
@@ -8,7 +8,6 @@ import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType
 import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_LIMIT;
 
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.hiero.mirror.common.domain.entity.Entity;
@@ -230,10 +229,9 @@ class ContractCallNativePrecompileTest extends Web3IntegrationTest {
     private ContractExecutionParameters serviceParametersForExecution(
             final Bytes callData, final Address contractAddress) {
         final var account = accountEntityWithEvmAddressPersist();
-        final HederaEvmAccount sender = new HederaEvmAccount(Address.wrap(Bytes.wrap(account.getEvmAddress())));
 
         return ContractExecutionParameters.builder()
-                .sender(sender)
+                .sender(Address.wrap(Bytes.wrap(account.getEvmAddress())))
                 .receiver(contractAddress)
                 .callData(callData)
                 .gas(TRANSACTION_GAS_LIMIT)

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
@@ -19,7 +19,6 @@ import static org.hiero.mirror.web3.web3j.generated.PrecompileTestContract.Heder
 import static org.hiero.mirror.web3.web3j.generated.PrecompileTestContract.TokenKey;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.store.contracts.precompile.codec.KeyValueWrapper.KeyValueType;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
@@ -1059,7 +1058,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                 .isStatic(false)
                 .receiver(Address.fromHexString(contract.getContractAddress()))
-                .sender(new HederaEvmAccount(testWeb3jService.getSender()))
+                .sender(testWeb3jService.getSender())
                 .value(value)
                 .build();
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
 import java.math.BigInteger;
@@ -1065,7 +1064,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                 .isStatic(false)
                 .receiver(receiverAddress)
-                .sender(new HederaEvmAccount(Address.ZERO))
+                .sender(Address.ZERO)
                 .value(0L)
                 .build();
     }
@@ -1084,7 +1083,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                 .isStatic(false)
                 .receiver(Address.fromHexString(contract.getContractAddress()))
-                .sender(new HederaEvmAccount(Address.ZERO))
+                .sender(Address.ZERO)
                 .value(0L)
                 .build();
     }
@@ -1114,7 +1113,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 .isModularized(mirrorNodeEvmProperties.isModularizedServices())
                 .isStatic(false)
                 .receiver(receiverAddress)
-                .sender(new HederaEvmAccount(senderAddress))
+                .sender(senderAddress)
                 .value(value)
                 .build();
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/TransactionExecutionServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/TransactionExecutionServiceTest.java
@@ -19,7 +19,6 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.node.app.workflows.standalone.TransactionExecutor;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -426,7 +425,7 @@ class TransactionExecutionServiceTest {
                 .isEstimate(false)
                 .isStatic(true)
                 .receiver(isContractCreate ? Address.ZERO : Address.fromHexString("0x1234"))
-                .sender(new HederaEvmAccount(senderAddress))
+                .sender(senderAddress)
                 .value(0)
                 .build();
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/web3j/TestWeb3jService.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/web3j/TestWeb3jService.java
@@ -11,7 +11,6 @@ import static org.hiero.mirror.web3.validation.HexValidator.HEX_PREFIX;
 import static org.web3j.crypto.TransactionUtils.generateTransactionHashHexEncoded;
 
 import com.google.common.collect.Range;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hederahashgraph.api.proto.java.Key.KeyCase;
 import io.reactivex.Flowable;
 import java.io.IOException;
@@ -283,9 +282,8 @@ public class TestWeb3jService implements Web3jService {
             final BlockType block,
             final long gasLimit,
             final Address sender) {
-        final var senderAccount = new HederaEvmAccount(sender);
         return ContractExecutionParameters.builder()
-                .sender(senderAccount)
+                .sender(sender)
                 .value(value)
                 .receiver(contractAddress)
                 .callData(callData)
@@ -301,7 +299,7 @@ public class TestWeb3jService implements Web3jService {
     protected ContractExecutionParameters serviceParametersForExecutionSingle(
             final Transaction transaction, final CallServiceParameters.CallType callType, final BlockType block) {
         return ContractExecutionParameters.builder()
-                .sender(new HederaEvmAccount(sender))
+                .sender(sender)
                 .value(value)
                 .receiver(Address.fromHexString(transaction.getTo()))
                 .callData(Bytes.fromHexString(transaction.getData()))
@@ -316,11 +314,10 @@ public class TestWeb3jService implements Web3jService {
 
     public ContractExecutionParameters serviceParametersForTopLevelContractCreate(
             final String contractInitCode, final CallServiceParameters.CallType callType, final Address senderAddress) {
-        final var senderEvmAccount = new HederaEvmAccount(senderAddress);
 
         final var callData = Bytes.wrap(Hex.decode(contractInitCode));
         return ContractExecutionParameters.builder()
-                .sender(senderEvmAccount)
+                .sender(senderAddress)
                 .callData(callData)
                 .receiver(Address.ZERO)
                 .gas(TRANSACTION_GAS_LIMIT)


### PR DESCRIPTION
Change ContractExecutionParameters.sender to be Address type to standardize contract execution behavior.

Update ContractExecutionParameters model
Update HederaEvmTxProcessor and MirrorEvmTxProcessorImpl to use Address
Update ContractController and relevant service classes
Update unit tests to reflect the new type

Related issue(s):
Fixes #11870

Notes for reviewer:
All affected services and tests updated to use Address type
Spotless and Gradle run successfully

Checklist
 Tested (unit and integration tests updated and passing)
