### PR TITLE
Show encoded ED25519 public key in /account/balance response (0.139)

### DIFF
--- a/rosetta/app/interfaces/account_repository.go
+++ b/rosetta/app/interfaces/account_repository.go
@@ -19,14 +19,15 @@ type AccountRepository interface {
 	// GetAccountId returns the `shard.realm.num` format of the account from its alias if exists
 	GetAccountId(ctx context.Context, accountId types.AccountId) (types.AccountId, *rTypes.Error)
 
-	// RetrieveBalanceAtBlock returns the hbar balance and token balances of the account at a given block (provided by
-	// consensusEnd timestamp).
+	// RetrieveBalanceAtBlock returns the hbar balance of the account at a given block (provided by consensusEnd
+	// timestamp).
 	// balance = balanceAtLatestBalanceSnapshot + balanceChangeBetweenSnapshotAndBlock
 	// if the account is deleted at T1 and T1 <= consensusEnd, the balance is calculated as
 	// balance = balanceAtLatestBalanceSnapshotBeforeT1 + balanceChangeBetweenSnapshotAndT1
 	RetrieveBalanceAtBlock(ctx context.Context, accountId types.AccountId, consensusEnd int64) (
 		types.AmountSlice,
 		string,
+		[]byte,
 		*rTypes.Error,
 	)
 }

--- a/rosetta/test/domain/entity_builder.go
+++ b/rosetta/test/domain/entity_builder.go
@@ -30,6 +30,11 @@ func (b *EntityBuilder) Historical(historical bool) *EntityBuilder {
 	return b
 }
 
+func (b *EntityBuilder) Key(key []byte) *EntityBuilder {
+	b.entity.Key = key
+	return b
+}
+
 func (b *EntityBuilder) ModifiedAfter(delta int64) *EntityBuilder {
 	b.entity.TimestampRange = getTimestampRangeWithLower(*b.entity.CreatedTimestamp + delta)
 	return b

--- a/rosetta/test/mocks/account_repository.go
+++ b/rosetta/test/mocks/account_repository.go
@@ -36,7 +36,7 @@ func (m *MockAccountRepository) RetrieveBalanceAtBlock(
 	ctx context.Context,
 	accountId types.AccountId,
 	consensusEnd int64,
-) (types.AmountSlice, string, *rTypes.Error) {
+) (types.AmountSlice, string, []byte, *rTypes.Error) {
 	args := m.Called()
-	return args.Get(0).(types.AmountSlice), args.Get(1).(string), args.Get(2).(*rTypes.Error)
+	return args.Get(0).(types.AmountSlice), args.Get(1).(string), args.Get(2).([]byte), args.Get(3).(*rTypes.Error)
 }

--- a/rosetta/test/utils/key.go
+++ b/rosetta/test/utils/key.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/thanhpk/randstr"
+	"google.golang.org/protobuf/proto"
+)
+
+func EcdsaSecp256k1PublicKey() *services.Key {
+	return &services.Key{Key: &services.Key_ECDSASecp256K1{ECDSASecp256K1: randstr.Bytes(33)}}
+}
+
+func Ed25519PublicKey() *services.Key {
+	return &services.Key{Key: &services.Key_Ed25519{Ed25519: randstr.Bytes(32)}}
+}
+
+func KeyListKey(keys []*services.Key) *services.Key {
+	return &services.Key{Key: &services.Key_KeyList{KeyList: &services.KeyList{Keys: keys}}}
+}
+
+func MustMarshal(m proto.Message) []byte {
+	bytes, err := proto.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes
+}


### PR DESCRIPTION
**Description**:

This PR cherry-picks the change to `release/0.139`.

- Show encoded ED25519 public key in /account/balance response

**Related issue(s)**:

Fixes #12020 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
