### PR TITLE
Workaround chart workflow failure

### DIFF
--- a/charts/hedera-mirror/ci/v1-values.yaml
+++ b/charts/hedera-mirror/ci/v1-values.yaml
@@ -22,6 +22,7 @@ rest:
   monitor:
     config:
       contract:
+        call: false  # Temporary until #12049
         logs: false
       freshness: false
       interval: 5

--- a/charts/hedera-mirror/ci/v2-values.yaml
+++ b/charts/hedera-mirror/ci/v2-values.yaml
@@ -27,6 +27,7 @@ rest:
   monitor:
     config:
       contract:
+        call: false  # Temporary until #12049
         logs: false
       freshness: false
       interval: 5

--- a/docs/checklist/rest-conversion.md
+++ b/docs/checklist/rest-conversion.md
@@ -45,6 +45,7 @@ Phase two enables the new route by default so that it rolls out to mainnet for t
 until we're confident there are no regressions.
 
 - [ ] Enable route by default in Ingress and Gateway
+- [ ] Update JavaScript monitor to use REST Java URL for route
 - [ ] Remove temporary enablement in previewnet and testnet so that default is used
 
 ## Phase Three


### PR DESCRIPTION
**Description**:

* Workaround chart workflow failure by disabling contract call test in REST monitor

**Related issue(s)**:

**Notes for reviewer**:

Change is temporary until we disable need for 0.0.801 in contract call via #12049

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
