### PR TITLE
Fix "Unhandled failure for input" error

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -2,10 +2,10 @@
 
 package org.hiero.mirror.web3.service;
 
+import static com.hedera.node.app.hapi.utils.keys.KeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 import static org.hiero.mirror.web3.convert.BytesDecoder.maybeDecodeSolidityErrorStringToReadableMessage;
 import static org.hiero.mirror.web3.state.Utils.DEFAULT_KEY;
-import static org.hiero.mirror.web3.state.Utils.HOLLOW_ACCOUNT_KEY;
 import static org.hiero.mirror.web3.state.Utils.isMirror;
 import static org.hiero.mirror.web3.validation.HexValidator.HEX_PREFIX;
 
@@ -227,7 +227,7 @@ public class TransactionExecutionService {
             throwPayerAccountNotFoundException(SENDER_NOT_FOUND);
         } else if (account.smartContract()) {
             throwPayerAccountNotFoundException(SENDER_IS_SMART_CONTRACT);
-        } else if (!account.hasKey() || account.key().equals(HOLLOW_ACCOUNT_KEY)) {
+        } else if (!account.hasKey() || account.key().equals(IMMUTABILITY_SENTINEL_KEY)) {
             // If the account is hollow, complete it in the state as a workaround
             // as this happens in HandleWorkflow in hedera-app but calling the
             // transaction executor directly skips this account completion and

--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -4,6 +4,8 @@ package org.hiero.mirror.web3.service;
 
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 import static org.hiero.mirror.web3.convert.BytesDecoder.maybeDecodeSolidityErrorStringToReadableMessage;
+import static org.hiero.mirror.web3.state.Utils.DEFAULT_KEY;
+import static org.hiero.mirror.web3.state.Utils.HOLLOW_ACCOUNT_KEY;
 import static org.hiero.mirror.web3.state.Utils.isMirror;
 import static org.hiero.mirror.web3.validation.HexValidator.HEX_PREFIX;
 
@@ -73,7 +75,7 @@ public class TransactionExecutionService {
         final var executor = transactionExecutorFactory.get();
 
         TransactionBody transactionBody;
-        HederaEvmTransactionProcessingResult result = null;
+        HederaEvmTransactionProcessingResult result;
         if (isContractCreate) {
             transactionBody = buildContractCreateTransactionBody(params, estimatedGas, maxLifetime);
         } else {
@@ -225,6 +227,15 @@ public class TransactionExecutionService {
             throwPayerAccountNotFoundException(SENDER_NOT_FOUND);
         } else if (account.smartContract()) {
             throwPayerAccountNotFoundException(SENDER_IS_SMART_CONTRACT);
+        } else if (!account.hasKey() || account.key().equals(HOLLOW_ACCOUNT_KEY)) {
+            // If the account is hollow, complete it in the state as a workaround
+            // as this happens in HandleWorkflow in hedera-app but calling the
+            // transaction executor directly skips this account completion and
+            // this results in failed transactions that would otherwise succeed
+            // against the consensus node.
+            final var writableAccountCache = ContractCallContext.get().getWriteCacheState(AccountReadableKVState.KEY);
+            final var completedAccount = account.copyBuilder().key(DEFAULT_KEY).build();
+            writableAccountCache.put(account.accountId(), completedAccount);
         }
 
         return accountIDNum;

--- a/web3/src/main/java/org/hiero/mirror/web3/state/Utils.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/Utils.java
@@ -23,15 +23,13 @@ public class Utils {
     public static final Key DEFAULT_KEY = Key.newBuilder()
             .keyList(KeyList.newBuilder()
                     .keys(Key.newBuilder()
-                            .ecdsaSecp256k1(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {
+                            .ecdsaSecp256k1(Bytes.wrap(new byte[] {
                                 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                0, 0, 0, 0
+                                0, 0, 0, 0,
                             }))
                             .build())
                     .build())
             .build();
-    public static final Key HOLLOW_ACCOUNT_KEY =
-            Key.newBuilder().keyList(KeyList.DEFAULT).build();
 
     public static Key parseKey(final byte[] keyBytes) {
         try {

--- a/web3/src/main/java/org/hiero/mirror/web3/state/Utils.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/Utils.java
@@ -20,6 +20,18 @@ public class Utils {
     public static final int EVM_ADDRESS_LEN = 20;
     public static final Key EMPTY_KEY_LIST =
             Key.newBuilder().keyList(KeyList.DEFAULT).build();
+    public static final Key DEFAULT_KEY = Key.newBuilder()
+            .keyList(KeyList.newBuilder()
+                    .keys(Key.newBuilder()
+                            .ecdsaSecp256k1(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {
+                                2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0
+                            }))
+                            .build())
+                    .build())
+            .build();
+    public static final Key HOLLOW_ACCOUNT_KEY =
+            Key.newBuilder().keyList(KeyList.DEFAULT).build();
 
     public static Key parseKey(final byte[] keyBytes) {
         try {

--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -734,6 +734,13 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .persist();
     }
 
+    protected Entity hollowAccountPersist() {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.key(null).maxAutomaticTokenAssociations(10).receiverSigRequired(false))
+                .persist();
+    }
+
     protected String getAddressFromEntity(final Entity entity) {
         return EvmTokenUtils.toAddress(entity.toEntityId()).toHexString();
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -16,7 +16,6 @@ import jakarta.annotation.Resource;
 import java.math.BigInteger;
 import java.util.List;
 import lombok.SneakyThrows;
-import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.token.FallbackFee;
 import org.hiero.mirror.common.domain.token.FixedFee;
@@ -754,13 +753,6 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
         final var result = testWeb3jService.getTransactionResult();
         // Then
         assertThat(result).isEqualTo("0x");
-    }
-
-    private Entity hollowAccountPersist() {
-        return domainBuilder
-                .entity()
-                .customize(e -> e.key(null).maxAutomaticTokenAssociations(10).receiverSigRequired(false))
-                .persist();
     }
 
     @SneakyThrows


### PR DESCRIPTION
**Description**:
In some rare cases when the sender of a transaction is a hollow account and we have an inner child transaction that makes a transfer from this account to another account, the first one needs to be completed. However, by calling the `TransactionExecutor` directly in the MN, we bypass the account completion (which happens in the `HandleWorkflow` on the consensus node). This PR modifies the sender hollow account in the state by setting a default key for it and this way "completing" it, so that the transaction execution can proceed as expected. After this change the transaction passed against MN and CN will be successful in both cases. 

Fixes #11963 