### PR TITLE
Fix failure on empty data field

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/repository/upsert/EntityMetadataRegistry.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/repository/upsert/EntityMetadataRegistry.java
@@ -40,7 +40,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 @CustomLog
 @Named
 @RequiredArgsConstructor
-public class EntityMetadataRegistry {
+public final class EntityMetadataRegistry {
 
     private final DBProperties dbProperties;
     private final EntityManager entityManager;
@@ -123,7 +123,7 @@ public class EntityMetadataRegistry {
     private Map<String, InformationSchemaColumns> getColumnSchema(String tableName) {
         String sql =
                 """
-                select column_name, regexp_replace(column_default, '::.*', '') as column_default,
+                select distinct column_name, regexp_replace(column_default, '::.*', '') as column_default,
                 is_nullable = 'YES' as nullable from information_schema.columns
                 where table_name = ? and table_schema = ?
                 """;

--- a/importer/src/test/java/org/hiero/mirror/importer/ImporterIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/ImporterIntegrationTest.java
@@ -47,6 +47,7 @@ import org.hiero.mirror.common.tableusage.EndpointContext;
 import org.hiero.mirror.importer.config.DateRangeCalculator;
 import org.hiero.mirror.importer.config.Owner;
 import org.hiero.mirror.importer.converter.JsonbToListConverter;
+import org.hiero.mirror.importer.db.DBProperties;
 import org.hiero.mirror.importer.parser.record.entity.ParserContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,6 +94,9 @@ public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
 
     @Resource
     private DateRangeCalculator dateRangeCalculator;
+
+    @Resource
+    private DBProperties dbProperties;
 
     @Resource
     private ImporterProperties importerProperties;
@@ -192,7 +196,10 @@ public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
 
     protected Boolean tableExists(String name) {
         return jdbcOperations.queryForObject(
-                "select exists(select 1 from information_schema.tables where table_name = ?)", Boolean.class, name);
+                "select exists(select 1 from information_schema.tables where table_schema = ? and table_name = ?)",
+                Boolean.class,
+                dbProperties.getSchema(),
+                name);
     }
 
     private String getDefaultIdColumns(Class<?> entityClass) {

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -35,11 +35,6 @@ dependencies {
     testImplementation("io.cucumber:cucumber-junit-platform-engine")
     testImplementation("io.cucumber:cucumber-spring")
     testImplementation("io.grpc:grpc-okhttp")
-    testImplementation(
-        group = "io.netty",
-        name = "netty-resolver-dns-native-macos",
-        classifier = "osx-aarch_64",
-    )
     testImplementation("jakarta.inject:jakarta.inject-api")
     testImplementation("net.java.dev.jna:jna")
     testImplementation("org.apache.commons:commons-lang3")

--- a/web3/src/main/java/org/hiero/mirror/web3/validation/Hex.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/validation/Hex.java
@@ -24,7 +24,7 @@ public @interface Hex {
     /**
      * @return maxLength the element must be less than or equal to
      */
-    long maxLength() default Long.MAX_VALUE;
+    long maxLength() default 1048576L;
 
     /**
      * @return minLength the element must be greater than or equal to

--- a/web3/src/main/java/org/hiero/mirror/web3/validation/HexValidator.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/validation/HexValidator.java
@@ -9,18 +9,17 @@ import java.util.regex.Pattern;
 public class HexValidator implements ConstraintValidator<Hex, String> {
 
     public static final String MESSAGE = "invalid hexadecimal string";
-    private static final Pattern HEX_PATTERN = Pattern.compile("^(0x)?[0-9a-fA-F]+$");
     public static final String HEX_PREFIX = "0x";
 
-    private long maxLength;
-    private long minLength;
     private boolean allowEmpty;
+    private long minLength;
+    private Pattern pattern;
 
     @Override
     public void initialize(Hex hex) {
-        maxLength = hex.maxLength();
-        minLength = hex.minLength();
         allowEmpty = hex.allowEmpty();
+        minLength = hex.minLength();
+        pattern = Pattern.compile("^(0x)?[0-9a-fA-F]{%d,%d}$".formatted(minLength, hex.maxLength()));
     }
 
     @Override
@@ -29,12 +28,6 @@ public class HexValidator implements ConstraintValidator<Hex, String> {
             return true;
         }
 
-        if (!HEX_PATTERN.matcher(value).matches()) {
-            return false;
-        }
-
-        int prefixLength = value.startsWith(HEX_PREFIX) ? HEX_PREFIX.length() : 0;
-        int length = value.length() - prefixLength;
-        return length >= minLength && length <= maxLength;
+        return pattern.matcher(value).matches();
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -419,7 +420,8 @@ class ContractControllerTest {
         contractCall(request).andExpect(status().isOk());
     }
 
-    @NullAndEmptySource
+    @NullSource
+    @ValueSource(strings = {"", "0x"})
     @ParameterizedTest
     void callSuccessWithNullAndEmptyData(String data) throws Exception {
         final var request = request();

--- a/web3/src/test/java/org/hiero/mirror/web3/validation/HexValidatorTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/validation/HexValidatorTest.java
@@ -16,6 +16,7 @@ class HexValidatorTest {
     @ParameterizedTest
     @CsvSource({
         "0,0,''",
+        "0,40,0x",
         "1,3,0xa",
         "1,3,0xa1D",
         "1,3,a",
@@ -34,7 +35,6 @@ class HexValidatorTest {
     @ParameterizedTest
     @CsvSource({
         "0,0,1",
-        "0,0,0x",
         "1,3,''",
         "1,3,0xa1D4",
         "2,3,a",


### PR DESCRIPTION
**Description**:

* Fix failure on empty 0x data field
* Fix not specifying schema when querying table metadata
* Remove unnecessary `netty-resolver-dns-native-macos` dependency in test module

**Related issue(s)**:

Fixes #12084

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
