### PR TITLE
Add ETag header to REST Java API response

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/config/RestJavaConfiguration.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/config/RestJavaConfiguration.java
@@ -5,16 +5,24 @@ package org.hiero.mirror.restjava.config;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.restjava.jooq.DomainRecordMapperProvider;
 import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 @RequiredArgsConstructor
 class RestJavaConfiguration {
 
     @Bean
-    public DefaultConfigurationCustomizer configurationCustomizer(
-            DomainRecordMapperProvider domainRecordMapperProvider) {
+    DefaultConfigurationCustomizer configurationCustomizer(DomainRecordMapperProvider domainRecordMapperProvider) {
         return c -> c.set(domainRecordMapperProvider).settings().withRenderSchema(false);
+    }
+
+    @Bean
+    FilterRegistrationBean<ShallowEtagHeaderFilter> etagFilter() {
+        final var filterRegistrationBean = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/api/*");
+        return filterRegistrationBean;
     }
 }


### PR DESCRIPTION
**Description**:

Add ETag header to REST Java API response

**Related issue(s)**:

Fixes #12085

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
