### PR TITLE
Persist updates to node account ID

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/node/AbstractNode.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/node/AbstractNode.java
@@ -17,6 +17,7 @@ import org.hiero.mirror.common.converter.ObjectToStringSerializer;
 import org.hiero.mirror.common.domain.History;
 import org.hiero.mirror.common.domain.UpsertColumn;
 import org.hiero.mirror.common.domain.Upsertable;
+import org.hiero.mirror.common.domain.entity.EntityId;
 
 @Data
 @MappedSuperclass
@@ -24,6 +25,8 @@ import org.hiero.mirror.common.domain.Upsertable;
 @SuperBuilder(toBuilder = true)
 @Upsertable(history = true)
 public abstract class AbstractNode implements History {
+
+    private EntityId accountId;
 
     @ToString.Exclude
     private byte[] adminKey;

--- a/common/src/test/java/org/hiero/mirror/common/domain/DomainBuilder.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/DomainBuilder.java
@@ -366,7 +366,7 @@ public class DomainBuilder {
                 .owner(id())
                 .payerAccountId(spender)
                 .spender(spender.getId())
-                .timestampRange(Range.atLeast(timestamp()));
+                .timestampRange(timestampRange());
         return new DomainWrapperImpl<>(builder, builder::build);
     }
 
@@ -399,7 +399,7 @@ public class DomainBuilder {
                 .fixedFees(List.of(fixedFee()))
                 .fractionalFees(List.of(fractionalFee()))
                 .royaltyFees(List.of(royaltyFee()))
-                .timestampRange(Range.atLeast(timestamp()))
+                .timestampRange(timestampRange())
                 .entityId(entityId().getId());
         return new DomainWrapperImpl<>(builder, builder::build);
     }
@@ -507,7 +507,7 @@ public class DomainBuilder {
                 .stakedNodeIdStart(-1L)
                 .stakedToMe(0L)
                 .stakeTotalStart(0L)
-                .timestampRange(Range.atLeast(timestamp()));
+                .timestampRange(timestampRange());
         return new DomainWrapperImpl<>(builder, builder::build);
     }
 
@@ -643,7 +643,7 @@ public class DomainBuilder {
                 .owner(entityId().getId())
                 .payerAccountId(entityId())
                 .spender(entityId().getId())
-                .timestampRange(Range.atLeast(timestamp()))
+                .timestampRange(timestampRange())
                 .tokenId(entityId().getId());
         return new DomainWrapperImpl<>(builder, builder::build);
     }
@@ -676,14 +676,14 @@ public class DomainBuilder {
         long timestamp = timestamp();
 
         var builder = Node.builder()
+                .accountId(entityId())
                 .adminKey(key())
                 .createdTimestamp(timestamp)
                 .declineReward(false)
                 .deleted(false)
                 .grpcProxyEndpoint(ServiceEndpoint.builder()
-                        .domainName("node1.hedera.com")
-                        .ipAddressV4("")
-                        .port(80)
+                        .ipAddressV4("127.0.0.1")
+                        .port(443)
                         .build())
                 .nodeId(number())
                 .timestampRange(Range.atLeast(timestamp));
@@ -694,14 +694,14 @@ public class DomainBuilder {
     public DomainWrapper<NodeHistory, NodeHistory.NodeHistoryBuilder<?, ?>> nodeHistory() {
         long timestamp = timestamp();
         var builder = NodeHistory.builder()
+                .accountId(entityId())
                 .adminKey(key())
                 .createdTimestamp(timestamp)
                 .declineReward(false)
                 .deleted(false)
                 .grpcProxyEndpoint(ServiceEndpoint.builder()
-                        .domainName("node1.hedera.com")
-                        .ipAddressV4("")
-                        .port(80)
+                        .ipAddressV4("127.0.0.1")
+                        .port(443)
                         .build())
                 .nodeId(number())
                 .timestampRange(Range.closedOpen(timestamp, timestamp + 10));
@@ -962,7 +962,7 @@ public class DomainBuilder {
                 .owner(id())
                 .payerAccountId(spender)
                 .spender(spender.getId())
-                .timestampRange(Range.atLeast(timestamp()))
+                .timestampRange(timestampRange())
                 .tokenId(id());
         return new DomainWrapperImpl<>(builder, builder::build);
     }
@@ -1247,6 +1247,10 @@ public class DomainBuilder {
 
     public long timestamp() {
         return timestampNoOffset() + timestampOffset;
+    }
+
+    public Range<Long> timestampRange() {
+        return Range.atLeast(timestamp());
     }
 
     private long tinybar() {

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -638,9 +638,22 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         previous.setTimestampUpper(current.getTimestampLower());
         current.setCreatedTimestamp(previous.getCreatedTimestamp());
 
+        if (current.getAccountId() == null) {
+            current.setAccountId(previous.getAccountId());
+        }
+
         if (current.getAdminKey() == null) {
             current.setAdminKey(previous.getAdminKey());
         }
+
+        if (current.getDeclineReward() == null) {
+            current.setDeclineReward(previous.getDeclineReward());
+        }
+
+        if (current.getGrpcProxyEndpoint() == null) {
+            current.setGrpcProxyEndpoint(previous.getGrpcProxyEndpoint());
+        }
+
         return current;
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeCreateTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeCreateTransactionHandler.java
@@ -8,13 +8,17 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.node.Node;
 import org.hiero.mirror.common.domain.transaction.RecordItem;
 import org.hiero.mirror.common.domain.transaction.TransactionType;
+import org.hiero.mirror.importer.domain.EntityIdService;
 import org.hiero.mirror.importer.parser.record.entity.EntityListener;
 
 @Named
 class NodeCreateTransactionHandler extends AbstractNodeTransactionHandler {
 
-    public NodeCreateTransactionHandler(EntityListener entityListener) {
+    private final EntityIdService entityIdService;
+
+    public NodeCreateTransactionHandler(EntityListener entityListener, EntityIdService entityIdService) {
         super(entityListener);
+        this.entityIdService = entityIdService;
     }
 
     @Override
@@ -38,8 +42,10 @@ class NodeCreateTransactionHandler extends AbstractNodeTransactionHandler {
                 ? toServiceEndpoint(consensusTimestamp, nodeCreate.getGrpcProxyEndpoint())
                 : null;
         var key = nodeCreate.hasAdminKey() ? nodeCreate.getAdminKey().toByteArray() : null;
+        final var accountId = entityIdService.lookup(nodeCreate.getAccountId()).orElse(EntityId.EMPTY);
 
         return Node.builder()
+                .accountId(accountId)
                 .adminKey(key)
                 .createdTimestamp(consensusTimestamp)
                 .declineReward(nodeCreate.getDeclineReward())

--- a/importer/src/main/resources/db/migration/v1/V1.112.0__node_account_id.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.112.0__node_account_id.sql
@@ -1,0 +1,2 @@
+alter table if exists node add column if not exists account_id bigint null;
+alter table if exists node_history add column if not exists account_id bigint null;

--- a/importer/src/main/resources/db/migration/v2/V2.17.0__node_account_id.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.17.0__node_account_id.sql
@@ -1,0 +1,2 @@
+alter table if exists node add column if not exists account_id bigint null;
+alter table if exists node_history add column if not exists account_id bigint null;


### PR DESCRIPTION
**Description**:

* Fix not coalescing decline reward and grpc proxy endpoint for consecutive updates to same node in a single record file
* Persist updates to node account ID on node create and update transactions

**Related issue(s)**:

Fixes #12094

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
