### PR TITLE
HIP-1056 Get intermediate topic message from trace data

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
@@ -61,6 +61,7 @@ public class RecordItem implements StreamItem {
     @ToString.Include
     private final long consensusTimestamp;
 
+    private final boolean blockstream;
     private final RecordItem parent;
     private final EntityId payerAccountId;
     private final RecordItem previous;

--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/StateChangeContext.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/StateChangeContext.java
@@ -150,19 +150,7 @@ public final class StateChangeContext {
     }
 
     public Optional<TopicMessage> getTopicMessage(@Nonnull TopicID topicId) {
-        return Optional.ofNullable(topicState.remove(topicId)).map(topicMessage -> {
-            if (topicMessage.getSequenceNumber() > 1) {
-                // running hash is lost for any earlier message, set it to an empty bytearray
-                // since null is not allowed
-                topicState.put(
-                        topicId,
-                        TopicMessage.builder()
-                                .runningHash(DomainUtils.EMPTY_BYTE_ARRAY)
-                                .sequenceNumber(topicMessage.getSequenceNumber() - 1)
-                                .build());
-            }
-            return topicMessage;
-        });
+        return Optional.ofNullable(topicState.remove(topicId));
     }
 
     /**

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
@@ -384,20 +384,13 @@ final class StateChangeContextTest {
         var context = new StateChangeContext(List.of(stateChanges));
         var topicIds = List.of(context.getNewTopicId(), context.getNewTopicId(), context.getNewTopicId());
         var topic1Message = context.getTopicMessage(topicId1);
-        var topic2Messages = List.of(
-                context.getTopicMessage(topicId2),
-                context.getTopicMessage(topicId2),
-                context.getTopicMessage(topicId2));
+        var topic2Messages = List.of(context.getTopicMessage(topicId2), context.getTopicMessage(topicId2));
 
         // then
         var expectedTopic2Messages = List.of(
                 Optional.of(TopicMessage.builder()
                         .runningHash(DomainUtils.toBytes(topic2RunningHash))
                         .sequenceNumber(2L)
-                        .build()),
-                Optional.of(TopicMessage.builder()
-                        .runningHash(DomainUtils.EMPTY_BYTE_ARRAY)
-                        .sequenceNumber(1L)
                         .build()),
                 Optional.<TopicMessage>empty());
         assertThat(topicIds).containsExactly(Optional.of(topicId2), Optional.of(topicId1), Optional.empty());

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockFileTransformer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockFileTransformer.java
@@ -84,6 +84,7 @@ public class BlockFileTransformer implements StreamFileTransformer<RecordFile, B
         for (int index = blockTransactions.size() - 1; index >= 0; index--) {
             var blockTransaction = blockTransactions.get(index);
             var builder = RecordItem.builder()
+                    .blockstream(true)
                     .hapiVersion(hapiVersion)
                     .signatureMap(blockTransaction.getSignedTransaction().getSigMap())
                     .transaction(blockTransaction.getTransaction())

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/ConsensusSubmitMessageTransformer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/ConsensusSubmitMessageTransformer.java
@@ -18,18 +18,20 @@ final class ConsensusSubmitMessageTransformer extends AbstractBlockTransactionTr
             return;
         }
 
-        var recordBuilder = blockTransactionTransformation.recordItemBuilder().transactionRecordBuilder();
-        var topicMessage = blockTransaction
-                .getStateChangeContext()
-                .getTopicMessage(blockTransactionTransformation
-                        .getTransactionBody()
-                        .getConsensusSubmitMessage()
-                        .getTopicID())
-                .orElseThrow();
-        recordBuilder
+        var receiptBuilder = blockTransactionTransformation
+                .recordItemBuilder()
+                .transactionRecordBuilder()
                 .getReceiptBuilder()
+                .setTopicRunningHashVersion(DEFAULT_RUNNING_HASH_VERSION);
+
+        var topicMessage = blockTransaction.getTopicMessage();
+        if (topicMessage == null) {
+            log.warn("Missing topic message runningHash and sequence at {}", blockTransaction.getConsensusTimestamp());
+            return;
+        }
+
+        receiptBuilder
                 .setTopicRunningHash(DomainUtils.fromBytes(topicMessage.getRunningHash()))
-                .setTopicRunningHashVersion(DEFAULT_RUNNING_HASH_VERSION)
                 .setTopicSequenceNumber(topicMessage.getSequenceNumber());
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
@@ -7,6 +7,7 @@ import static org.hiero.mirror.importer.util.Utility.DEFAULT_RUNNING_HASH_VERSIO
 
 import com.hederahashgraph.api.proto.java.ConsensusMessageChunkInfo;
 import jakarta.inject.Named;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.topic.TopicMessage;
@@ -16,9 +17,10 @@ import org.hiero.mirror.common.domain.transaction.TransactionType;
 import org.hiero.mirror.importer.parser.record.entity.EntityListener;
 import org.hiero.mirror.importer.parser.record.entity.EntityProperties;
 
+@CustomLog
 @Named
 @RequiredArgsConstructor
-class ConsensusSubmitMessageTransactionHandler extends AbstractTransactionHandler {
+final class ConsensusSubmitMessageTransactionHandler extends AbstractTransactionHandler {
 
     private final EntityListener entityListener;
     private final EntityProperties entityProperties;
@@ -56,6 +58,13 @@ class ConsensusSubmitMessageTransactionHandler extends AbstractTransactionHandle
         var transactionBody = recordItem.getTransactionBody().getConsensusSubmitMessage();
         var transactionRecord = recordItem.getTransactionRecord();
         var receipt = transactionRecord.getReceipt();
+        if (recordItem.isBlockstream() && receipt.getTopicRunningHash().isEmpty()) {
+            log.warn(
+                    "Skip topic message from blockstream due to missing runningHash at {}",
+                    recordItem.getConsensusTimestamp());
+            return;
+        }
+
         var topicMessage = new TopicMessage();
 
         // Only persist the value if it is not the default

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/AbstractTransformerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/AbstractTransformerTest.java
@@ -92,6 +92,6 @@ abstract class AbstractTransformerTest extends ImporterIntegrationTest {
     protected void finalize(RecordItemBuilder.Builder<?> builder) {
         builder.contractTransactionPredicate(null)
                 .entityTransactionPredicate(null)
-                .recordItem(r -> r.hapiVersion(HAPI_VERSION));
+                .recordItem(r -> r.blockstream(true).hapiVersion(HAPI_VERSION));
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/ConsensusTransformerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/ConsensusTransformerTest.java
@@ -4,14 +4,23 @@ package org.hiero.mirror.importer.downloader.block.transformer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.hapi.block.stream.output.protoc.MapChangeKey;
+import com.hedera.hapi.block.stream.output.protoc.MapChangeValue;
+import com.hedera.hapi.block.stream.output.protoc.MapUpdateChange;
+import com.hedera.hapi.block.stream.output.protoc.StateChange;
+import com.hedera.hapi.block.stream.output.protoc.StateChanges;
+import com.hedera.hapi.block.stream.output.protoc.StateIdentifier;
+import com.hedera.hapi.block.stream.trace.protoc.SubmitMessageTraceData;
+import com.hedera.hapi.block.stream.trace.protoc.TraceData;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.Topic;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class ConsensusTransformerTest extends AbstractTransformerTest {
+final class ConsensusTransformerTest extends AbstractTransformerTest {
 
     @Test
     void consensusCreateTopicTransform() {
@@ -69,6 +78,110 @@ class ConsensusTransformerTest extends AbstractTransformerTest {
                 .build();
         var blockTransaction = blockTransactionBuilder
                 .consensusSubmitMessage(expectedRecordItem)
+                .build();
+        var blockFile = blockFileBuilder.items(List.of(blockTransaction)).build();
+
+        // when
+        var recordFile = blockFileTransformer.transform(blockFile);
+
+        // then
+        assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expectedRecordItem));
+    }
+
+    @Test
+    void consensusSubmitMessageBatchTransform() {
+        // given
+        var runningHash2 = recordItemBuilder.bytes(48);
+        var topicId = recordItemBuilder.topicId();
+        var stateChanges = StateChanges.newBuilder()
+                .addStateChanges(StateChange.newBuilder()
+                        .setStateId(StateIdentifier.STATE_ID_TOPICS_VALUE)
+                        .setMapUpdate(MapUpdateChange.newBuilder()
+                                .setKey(MapChangeKey.newBuilder().setTopicIdKey(topicId))
+                                .setValue(MapChangeValue.newBuilder()
+                                        .setTopicValue(Topic.newBuilder()
+                                                .setRunningHash(runningHash2)
+                                                .setSequenceNumber(10L)
+                                                .setTopicId(topicId)))))
+                .build();
+        var atomicBachRecordItem =
+                recordItemBuilder.atomicBatch().customize(this::finalize).build();
+        var atomicBatchBlockTransaction = blockTransactionBuilder
+                .atomicBatch(atomicBachRecordItem)
+                .stateChanges(s -> s.add(stateChanges))
+                .build();
+        var parentConsensusTimestamp =
+                atomicBachRecordItem.getTransactionRecord().getConsensusTimestamp();
+
+        // consensus submit message 1
+        var consensusSubmitMessageRecordItem1 = recordItemBuilder
+                .consensusSubmitMessage()
+                .clearIncrementer()
+                .record(r -> r.setParentConsensusTimestamp(parentConsensusTimestamp))
+                .receipt(r -> r.setTopicSequenceNumber(9))
+                .recordItem(r -> r.transactionIndex(1))
+                .transactionBody(b -> b.setTopicID(topicId))
+                .customize(this::finalize)
+                .build();
+        var runningHash1 = consensusSubmitMessageRecordItem1
+                .getTransactionRecord()
+                .getReceipt()
+                .getTopicRunningHash();
+        var consensusSubmitMessageBlockTransaction1 = blockTransactionBuilder
+                .consensusSubmitMessage(consensusSubmitMessageRecordItem1)
+                .previous(atomicBatchBlockTransaction)
+                .stateChanges(List::clear)
+                .traceData(t -> t.add(TraceData.newBuilder()
+                        .setSubmitMessageTraceData(SubmitMessageTraceData.newBuilder()
+                                .setRunningHash(runningHash1)
+                                .setSequenceNumber(9))
+                        .build()))
+                .build();
+
+        // consensus submit message 2
+        var consensusSubmitMessageRecordItem2 = recordItemBuilder
+                .consensusSubmitMessage()
+                .clearIncrementer()
+                .record(r -> r.setParentConsensusTimestamp(parentConsensusTimestamp))
+                .receipt(r -> r.setTopicRunningHash(runningHash2).setTopicSequenceNumber(10))
+                .recordItem(r -> r.transactionIndex(2))
+                .transactionBody(b -> b.setTopicID(topicId))
+                .customize(this::finalize)
+                .build();
+        var consensusSubmitMessageBlockTransaction2 = blockTransactionBuilder
+                .consensusSubmitMessage(consensusSubmitMessageRecordItem2)
+                .previous(consensusSubmitMessageBlockTransaction1)
+                .stateChanges(List::clear)
+                .build();
+
+        var blockFile = blockFileBuilder
+                .items(List.of(
+                        atomicBatchBlockTransaction,
+                        consensusSubmitMessageBlockTransaction1,
+                        consensusSubmitMessageBlockTransaction2))
+                .build();
+
+        // when
+        var recordFile = blockFileTransformer.transform(blockFile);
+
+        // then
+        var expected =
+                List.of(atomicBachRecordItem, consensusSubmitMessageRecordItem1, consensusSubmitMessageRecordItem2);
+        assertRecordFile(recordFile, blockFile, items -> assertRecordItems(items, expected));
+    }
+
+    @Test
+    void consensusSubmitMessageTransformNoStateChangesNoTraceData() {
+        // given
+        var expectedRecordItem = recordItemBuilder
+                .consensusSubmitMessage()
+                .clearIncrementer()
+                .receipt(r -> r.clearTopicRunningHash().clearTopicSequenceNumber())
+                .customize(this::finalize)
+                .build();
+        var blockTransaction = blockTransactionBuilder
+                .consensusSubmitMessage(expectedRecordItem)
+                .stateChanges(List::clear)
                 .build();
         var blockFile = blockFileBuilder.items(List.of(blockTransaction)).build();
 

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -1470,6 +1470,9 @@ public class RecordItemBuilder {
 
     public class Builder<T extends GeneratedMessage.Builder<T>> {
 
+        private static final BiConsumer<TransactionBody.Builder, TransactionRecord.Builder> NOOP_INCREMENTER =
+                (b, r) -> {};
+
         private final TransactionType type;
         private final T transactionBody;
         private final SignatureMap.Builder signatureMap;
@@ -1481,7 +1484,7 @@ public class RecordItemBuilder {
 
         private Predicate<EntityId> entityTransactionPredicate = persistProperties::shouldPersistEntityTransaction;
         private Predicate<EntityId> contractTransactionPredicate = e -> persistProperties.isContractTransaction();
-        private BiConsumer<TransactionBody.Builder, TransactionRecord.Builder> incrementer = (b, r) -> {};
+        private BiConsumer<TransactionBody.Builder, TransactionRecord.Builder> incrementer = NOOP_INCREMENTER;
         private boolean useTransactionBodyBytesAndSigMap;
 
         private Builder(TransactionType type, T transactionBody) {
@@ -1556,6 +1559,11 @@ public class RecordItemBuilder {
 
         public Builder<T> entityTransactionPredicate(Predicate<EntityId> entityTransactionPredicate) {
             this.entityTransactionPredicate = entityTransactionPredicate;
+            return this;
+        }
+
+        public Builder<T> clearIncrementer() {
+            this.incrementer = NOOP_INCREMENTER;
             return this;
         }
 


### PR DESCRIPTION
**Description**:

This PR supports getting intermediate topic message info from trace data

- Get topic message info from `SubmitMessageTraceData` and fall back to statechanges
- Remove topic sequence number inference logic in `StateChangeContext`
- Skip creating `TopicMessage` in `ConsensusSubmitMessageTransactionHandler` if no running hash available

**Related issue(s)**:

Fixes #11700 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
