### PR TITLE
Fix `NullPointerException` on `resetThrottlesUnconditionally()`

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/state/MirrorNodeState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/MirrorNodeState.java
@@ -306,7 +306,7 @@ public class MirrorNodeState implements MerkleNodeState {
             @Nonnull final String serviceName,
             @Nonnull final String stateKey,
             @Nonnull final SingletonState<V> singleton) {
-        final var state = new FunctionWritableSingletonState<>(serviceName, stateKey, singleton, singleton::set);
+        final var state = new FunctionWritableSingletonState<>(serviceName, stateKey, singleton);
         listeners.forEach(listener -> {
             if (listener.stateTypes().contains(SINGLETON)) {
                 registerSingletonListener(serviceName, state, listener);

--- a/web3/src/main/java/org/hiero/mirror/web3/state/core/FunctionWritableSingletonState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/core/FunctionWritableSingletonState.java
@@ -5,14 +5,11 @@ package org.hiero.mirror.web3.state.core;
 import com.swirlds.state.spi.WritableSingletonStateBase;
 import jakarta.annotation.Nonnull;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class FunctionWritableSingletonState<S> extends WritableSingletonStateBase<S> {
 
     private final Supplier<S> backingStoreAccessor;
-
-    private final Consumer<S> backingStoreMutator;
 
     /**
      * Creates a new instance.
@@ -21,16 +18,13 @@ public class FunctionWritableSingletonState<S> extends WritableSingletonStateBas
      * @param stateKey The state key for this instance.
      * @param backingStoreAccessor A {@link Supplier} that provides access to the value in the
      *     backing store.
-     * @param backingStoreMutator A {@link Consumer} for mutating the value in the backing store.
      */
     public FunctionWritableSingletonState(
             @Nonnull final String serviceName,
             @Nonnull final String stateKey,
-            @Nonnull final Supplier<S> backingStoreAccessor,
-            @Nonnull final Consumer<S> backingStoreMutator) {
+            @Nonnull final Supplier<S> backingStoreAccessor) {
         super(serviceName, stateKey);
         this.backingStoreAccessor = Objects.requireNonNull(backingStoreAccessor);
-        this.backingStoreMutator = Objects.requireNonNull(backingStoreMutator);
     }
 
     @Override
@@ -40,11 +34,11 @@ public class FunctionWritableSingletonState<S> extends WritableSingletonStateBas
 
     @Override
     protected void putIntoDataSource(@Nonnull S value) {
-        backingStoreMutator.accept(value);
+        // No-op as we don't persist updates in web3.
     }
 
     @Override
     protected void removeFromDataSource() {
-        backingStoreMutator.accept(null);
+        // No-op as we don't persist updates in web3.
     }
 }


### PR DESCRIPTION
**Description**:
As a result of the last hedera-app bump to 0.65.1 in #12001 new singleton states were added:
- `FunctionReadableSingletonState`
- `FunctionWritableSingletonState`

For the writable one the implementation of `putIntoDataSource()` and `removeFromDataSource()` needs to be removed as this introduces a regression and we don't persist any changes in the DB anyway. 

Fixes #12055