### PR TITLE
Bump redis image to 8.2.2 (0.140)

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -227,6 +227,20 @@ release:
 kubectl delete $(kubectl get pvc -o name)
 ```
 
+## Development
+
+The Helm charts use Bitnami for various chart components. Newer Bitnami images are no longer freely available, so we
+need to periodically build their images from source and publish them to our own registry. After building the images
+using the below steps, update the `values.yaml` to use the newly built images.
+
+```bash
+export REDIS_VERSION="8.2.2"
+git checkout https://github.com/bitnami/containers.git
+cd containers/bitnami/
+docker buildx build --platform linux/amd64,linux/arm64 -t gcr.io/mirrornode/redis:${REDIS_VERSION} --provenance false --push redis/8.2/debian-12
+docker buildx build --platform linux/amd64,linux/arm64 -t gcr.io/mirrornode/redis-sentinel:${REDIS_VERSION} --provenance false --push redis-sentinel/8.2/debian-12
+```
+
 ## Troubleshooting
 
 To troubleshoot a pod, you can view its log and describe the pod to see its status. See the
@@ -238,7 +252,9 @@ kubectl logs -f --tail=100 "${POD_NAME}"
 kubectl logs -f --prefix --tail=10 -l app.kubernetes.io/name=importer
 ```
 
-To change an application's properties, create a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-configmaps-from-files) and mount it into the container by specifying `volumes`
+To change an application's properties, create
+a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#create-configmaps-from-files)
+and mount it into the container by specifying `volumes`
 and `volumeMounts` in your custom values.yaml. Create the ConfigMap from a properties file:
 
 ```shell script

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -226,7 +226,9 @@ redis:
   enabled: true
   host: "{{ .Release.Name }}-redis"
   image:
-    repository: bitnamilegacy/redis
+    registry: gcr.io
+    repository: mirrornode/redis
+    tag: 8.2.2
   kubectl:
     image:
       repository: rancher/kubectl
@@ -264,7 +266,9 @@ redis:
   sentinel:
     enabled: true
     image:
-      repository: bitnamilegacy/redis-sentinel
+      registry: gcr.io
+      repository: mirrornode/redis-sentinel
+      tag: 8.2.2
     masterSet: mirror
     persistence:
       enabled: true


### PR DESCRIPTION
**Description**:

Cherry pick of #12149 to `release/0.140`.

* Add instructions on how to build the images for future updates
* Bump redis image to 8.2.2
* Bump redis-sentinel image to 8.2.2
* Change to store Bitnami redis images in gcr.io/mirrornode

**Related issue(s)**:

Fixes #12148

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
