### PR TITLE
Properly set creator for ScheduleCreate transactions if there is top level EthereumTransaction

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
@@ -62,11 +62,7 @@ public class RecordItem implements StreamItem {
     private final long consensusTimestamp;
 
     private final boolean blockstream;
-
-    @Setter
-    @NonFinal
-    private RecordItem parent;
-
+    private final RecordItem parent;
     private final EntityId payerAccountId;
     private final RecordItem previous;
     private final SignatureMap signatureMap;

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandler.java
@@ -2,6 +2,7 @@
 
 package org.hiero.mirror.importer.parser.record.transactionhandler;
 
+import com.hederahashgraph.api.proto.java.AccountID;
 import jakarta.inject.Named;
 import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
@@ -53,7 +54,7 @@ class ScheduleCreateTransactionHandler extends AbstractEntityCrudTransactionHand
         var body = recordItem.getTransactionBody().getScheduleCreate();
         long consensusTimestamp = recordItem.getConsensusTimestamp();
 
-        EntityId creatorAccount = recordItem.getPayerAccountId();
+        var creatorAccount = recordItem.getPayerAccountId();
 
         var parentRecordItem = recordItem.getParent();
         if (parentRecordItem != null && parentRecordItem.getEthereumTransaction() != null) {
@@ -62,7 +63,7 @@ class ScheduleCreateTransactionHandler extends AbstractEntityCrudTransactionHand
                     ? transactionRecord.getContractCreateResult()
                     : transactionRecord.getContractCallResult();
 
-            if (functionResult.getSenderId().getAccountNum() > 0) {
+            if (!AccountID.getDefaultInstance().equals(functionResult.getSenderId())) {
                 creatorAccount = EntityId.of(functionResult.getSenderId());
             }
         }


### PR DESCRIPTION
**Description**:
This PR properly sets the creator field for ScheduleCreate transactions to be the sender of the Ethereum transaction in case there is a top level Ethereum transaction.

**Related issue(s)**:

Fixes #12089

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
