### PR TITLE
Upgrade components in acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -157,7 +157,7 @@ jobs:
           echo "Solo cluster setup completed successfully!"
 
       - name: Run acceptance tests
-        run: stdbuf -oL helm test "${HELM_RELEASE_NAME}" -n "${SOLO_NAMESPACE}" --logs --filter name="${HELM_RELEASE_NAME}-mirror-acceptance" --timeout 20m | tee output_log.txt
+        run: helm test "${HELM_RELEASE_NAME}" -n "${SOLO_NAMESPACE}" --logs --filter name="${HELM_RELEASE_NAME}-mirror-acceptance" --timeout 20m | tee output_log.txt
 
       - name: Parse acceptance tests logs and set k6 environment variables
         if: ${{ matrix.stream-type != 'BLOCK' }}


### PR DESCRIPTION
**Description**:

This PR upgrades components in acceptance test workflow

- block node v0.20.1, consensus node v0.67.0, mirror node v0.141.0-rc1, nodejs v22, solo v0.46.1
- migrate solo cli commands
- use new helm release name `mirror-1` to run acceptance test
- use new block node service name `block-node-1`

**Related issue(s)**:

Fixes #12152 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
