### PR TITLE
Enable Java exchange rate API by default

### DIFF
--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -323,7 +323,7 @@ resources:
 revisionHistoryLimit: 3
 
 routes:
-  exchangeRate: false
+  exchangeRate: true
 
 securityContext:
   allowPrivilegeEscalation: false

--- a/rest/monitoring/network_tests.js
+++ b/rest/monitoring/network_tests.js
@@ -200,7 +200,7 @@ const getNetworkSupply = async (server) => {
 const runTests = async (server, testResult) => {
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
-    runTest(getNetworkExchangeRate),
+    runTest(getNetworkExchangeRate, 'REST_JAVA'),
     runTest(getNetworkFees),
     runTest(getNetworkNodes),
     runTest(getNetworkStake, 'REST_JAVA'),


### PR DESCRIPTION
**Description**:

Enable Java exchange rate API by default

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
