### PR TITLE
HIP-1056 Ignore ethereum transaction callDataId when callData is inlined

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
@@ -78,7 +78,8 @@ final class EthereumTransactionHandler extends AbstractTransactionHandler {
 
         byte[] callData = ethereumTransaction.getCallData();
         var callDataId = ethereumTransaction.getCallDataId();
-        if (callDataId != null) {
+        if (ArrayUtils.isEmpty(callData) && !EntityId.isEmpty(callDataId)) {
+            // call data file (callDataId) is ignored by consensus node if there's call data in ethereum data
             callData = contractBytecodeService.get(callDataId);
             if (callData == null) {
                 Utility.handleRecoverableError(


### PR DESCRIPTION
**Description**:

This PR fixes the bug that `callDataId` is prioritized over non-empty inlined callData

- Use non-empty inlined callData over data from valid callDataId

**Related issue(s)**:

Fixes #12254 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
