### PR TITLE
HIP-1056 Leave receipt.NewTotalSupply unset for TokenCreate transactions

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/TokenCreateTransformer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/TokenCreateTransformer.java
@@ -19,10 +19,6 @@ final class TokenCreateTransformer extends AbstractBlockTransactionTransformer {
                 .recordItemBuilder()
                 .transactionRecordBuilder()
                 .getReceiptBuilder();
-        receiptBuilder.setNewTotalSupply(blockTransactionTransformation
-                .getTransactionBody()
-                .getTokenCreation()
-                .getInitialSupply());
         blockTransaction
                 .getStateChangeContext()
                 .getNewTokenId()

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/TokenTransformerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/TokenTransformerTest.java
@@ -100,8 +100,12 @@ class TokenTransformerTest extends AbstractTransformerTest {
     @Test
     void tokenCreate() {
         // given
-        var expectedRecordItem =
-                recordItemBuilder.tokenCreate().customize(this::finalize).build();
+        var expectedRecordItem = recordItemBuilder
+                .tokenCreate()
+                .transactionBody(
+                        b -> b.setInitialSupply(domainBuilder.number()).setTokenType(TokenType.FUNGIBLE_COMMON))
+                .customize(this::finalize)
+                .build();
         var blockTransaction =
                 blockTransactionBuilder.tokenCreate(expectedRecordItem).build();
         var blockFile = blockFileBuilder.items(List.of(blockTransaction)).build();


### PR DESCRIPTION
**Description**:

This PR fixes the bug that `TokenCreateTransformer` sets NewTotalSupply in receipt.

**Related issue(s)**:

Fixes #12250 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
