### PR TITLE
Fix race condition in parallel test execution

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -37,12 +37,14 @@ import org.hiero.mirror.test.e2e.acceptance.client.Cleanable;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.OrderComparator;
 import org.springframework.http.HttpStatus;
 
 @CustomLog
 @Data
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class AccountFeature extends AbstractFeature {
 
     public static final int DEFAULT_LIMIT = 25;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/BlockFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/BlockFeature.java
@@ -9,10 +9,12 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.props.Order;
+import org.springframework.context.annotation.Scope;
 import org.springframework.util.CollectionUtils;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class BlockFeature {
 
     private final MirrorNodeClient mirrorClient;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -63,12 +63,14 @@ import org.hiero.mirror.test.e2e.acceptance.client.TokenClient;
 import org.hiero.mirror.test.e2e.acceptance.config.Web3Properties;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.util.TestUtil;
+import org.springframework.context.annotation.Scope;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.client.HttpClientErrorException;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class CallFeature extends AbstractFeature {
 
     private static final String HEX_REGEX = "^[0-9a-fA-F]+$";

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -36,12 +36,14 @@ import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.config.Web3Properties;
 import org.hiero.mirror.test.e2e.acceptance.util.ModelBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class ContractFeature extends BaseContractFeature {
     private static final String GET_ACCOUNT_BALANCE_SELECTOR = "6896fabf";
     private static final String GET_SENDER_SELECTOR = "5e01eb5a";

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -38,9 +38,11 @@ import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.client.TokenClient;
 import org.hiero.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
+import org.springframework.context.annotation.Scope;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class ERCContractFeature extends AbstractFeature {
 
     private final AccountClient accountClient;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -27,9 +27,11 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hiero.mirror.test.e2e.acceptance.client.ContractClient.NodeNameEnum;
 import org.hiero.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
+import org.springframework.context.annotation.Scope;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class EquivalenceFeature extends AbstractFeature {
 
     private static final String OBTAINER_SAME_CONTRACT_ID_EXCEPTION = "OBTAINER_SAME_CONTRACT_ID";

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -85,10 +85,12 @@ import org.hiero.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.util.ModelBuilder;
 import org.hiero.mirror.test.e2e.acceptance.util.TestUtil;
+import org.springframework.context.annotation.Scope;
 import org.springframework.web.client.HttpClientErrorException;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class EstimateFeature extends AbstractEstimateFeature {
 
     private static final String HEX_DIGITS = "0123456789abcdef";

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -165,9 +165,11 @@ import org.hiero.mirror.test.e2e.acceptance.config.Web3Properties;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import org.hiero.mirror.test.e2e.acceptance.util.TestUtil;
+import org.springframework.context.annotation.Scope;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
     private static final long FIRST_NFT_SERIAL_NUMBER = 1;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -34,11 +34,13 @@ import org.hiero.mirror.test.e2e.acceptance.client.EthereumClient;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.config.Web3Properties;
 import org.hiero.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
+import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.web3j.crypto.transaction.type.TransactionType;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class EthereumFeature extends AbstractEstimateFeature {
 
     protected final EthereumClient ethereumClient;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/FileFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/FileFeature.java
@@ -18,10 +18,12 @@ import org.hiero.mirror.rest.model.TransactionDetail;
 import org.hiero.mirror.test.e2e.acceptance.client.FileClient;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
+import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class FileFeature {
     private static final String ORIGINAL_FILE_CONTENTS = "Mirror Node v1";
     private static final String UPDATE_BASE_FILE_CONTENTS = "Mirror Node v2,";

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -71,9 +71,11 @@ import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.props.Order;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import org.hiero.mirror.test.e2e.acceptance.util.ContractCallResponseWrapper;
+import org.springframework.context.annotation.Scope;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class HistoricalFeature extends AbstractEstimateFeature {
     private static final long CUSTOM_FIXED_FEE_AMOUNT = 10L;
 

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/NetworkFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/NetworkFeature.java
@@ -19,10 +19,12 @@ import org.hiero.mirror.rest.model.NetworkFee;
 import org.hiero.mirror.rest.model.NetworkFeesResponse;
 import org.hiero.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import org.hiero.mirror.test.e2e.acceptance.props.Order;
+import org.springframework.context.annotation.Scope;
 
 @CustomLog
 @Data
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class NetworkFeature {
 
     private final MirrorNodeClient mirrorClient;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -67,12 +67,14 @@ import org.hiero.mirror.test.e2e.acceptance.config.Web3Properties;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import org.hiero.mirror.test.e2e.acceptance.util.ContractCallResponseWrapper;
+import org.springframework.context.annotation.Scope;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.client.HttpClientErrorException;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class PrecompileContractFeature extends AbstractFeature {
     private static final long FIRST_NFT_SERIAL_NUMBER = 1;
     private static final BigInteger DEFAULT_SERIAL_NUMBER = BigInteger.ONE;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -37,10 +37,12 @@ import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.props.Order;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import org.springframework.boot.convert.DurationStyle;
+import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class ScheduleFeature extends AbstractFeature {
 
     private static final int DEFAULT_TINY_HBAR = 1_000;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -70,11 +70,13 @@ import org.hiero.mirror.test.e2e.acceptance.client.TokenClient.TokenResponse;
 import org.hiero.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
+import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.CollectionUtils;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class TokenFeature extends AbstractFeature {
 
     private final AcceptanceTestProperties properties;

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -51,11 +51,13 @@ import org.hiero.mirror.test.e2e.acceptance.client.TopicClient;
 import org.hiero.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import org.hiero.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import org.hiero.mirror.test.e2e.acceptance.util.FeatureInputHandler;
+import org.springframework.context.annotation.Scope;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 
 @CustomLog
 @RequiredArgsConstructor
+@Scope("cucumber-glue")
 public class TopicFeature extends AbstractFeature {
 
     private static final long FIXED_FEE_AMOUNT = 10;


### PR DESCRIPTION
**Description**:

Fix race condition in parallel Cucumber test execution causing intermittent token airdrop test failures

* Add @Scope("cucumber-glue") annotation to all 16 feature step definition classes
* Ensure each Cucumber scenario gets its own isolated instance
* Prevent instance variable state sharing between concurrent test executions

**Related issue(s)**:

Fixes #12262

**Notes for reviewer**:

This fixes issue #12262 where token airdrop tests were failing due to race conditions.

The root cause was that Cucumber-Spring step definition classes are singleton beans by default, meaning all parallel test scenarios share the same instance. This caused instance variables (like `tokenId`, `networkTransactionResponse`, etc.) to be overwritten by concurrent tests.

**Solution**: Added `@Scope("cucumber-glue")` annotation to all 16 feature classes to ensure each Cucumber scenario gets its own isolated instance, preventing state sharing between parallel test executions.

The following feature classes were updated:
- AccountFeature
- BlockFeature
- CallFeature
- ContractFeature
- ERCContractFeature
- EquivalenceFeature
- EstimateFeature
- EstimatePrecompileFeature
- EthereumFeature
- FileFeature
- HistoricalFeature
- NetworkFeature
- PrecompileContractFeature
- ScheduleFeature
- TokenFeature
- TopicFeature

This change ensures proper test isolation when `cucumber.execution.parallel.enabled=true` is configured, which is the case in this project's `junit-platform.properties`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)