### PR TITLE
HIP-1056 Fix initcode from file not including constructorParameters

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/service/ContractInitcodeServiceImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/service/ContractInitcodeServiceImpl.java
@@ -2,6 +2,7 @@
 
 package org.hiero.mirror.importer.service;
 
+import com.google.common.primitives.Bytes;
 import com.hedera.services.stream.proto.ContractBytecode;
 import jakarta.inject.Named;
 import lombok.RequiredArgsConstructor;
@@ -9,15 +10,18 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.transaction.RecordItem;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.util.Utility;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Named
+@NullMarked
 @RequiredArgsConstructor
 public final class ContractInitcodeServiceImpl implements ContractInitcodeService {
 
     private final ContractBytecodeService contractBytecodeService;
 
     @Override
-    public byte[] get(ContractBytecode contractBytecode, RecordItem recordItem) {
+    public byte @Nullable [] get(@Nullable ContractBytecode contractBytecode, RecordItem recordItem) {
         if (!recordItem.getTransactionBody().hasContractCreateInstance()) {
             return null;
         }
@@ -26,14 +30,18 @@ public final class ContractInitcodeServiceImpl implements ContractInitcodeServic
         if (contractCreate.hasInitcode()) {
             return DomainUtils.toBytes(contractCreate.getInitcode());
         } else if (contractCreate.hasFileID() && recordItem.isBlockstream()) {
-            var fileId = EntityId.of(contractCreate.getFileID());
-            byte[] initcode = contractBytecodeService.get(fileId);
+            final var fileId = EntityId.of(contractCreate.getFileID());
+            final byte[] initcode = contractBytecodeService.get(fileId);
             if (initcode == null) {
                 Utility.handleRecoverableError(
                         "Failed to get initcode from file {} at {}", fileId, recordItem.getConsensusTimestamp());
+                return null;
             }
 
-            return initcode;
+            final var constructorParameters = contractCreate.getConstructorParameters();
+            return constructorParameters.isEmpty()
+                    ? initcode
+                    : Bytes.concat(initcode, DomainUtils.toBytes(constructorParameters));
         }
 
         if (contractBytecode != null) {


### PR DESCRIPTION
**Description**:

This PR fixes the incorrect contract initcode bug when bytecode is from a file

- Concat the bytecode from the file and the constructorParameters from body as initcode

**Related issue(s)**:

Fixes #12308

**Notes for reviewer**:

consensus node logic for reference: https://github.com/hiero-ledger/hiero-consensus-node/blob/6833ec1707f75433576c917b8df5c90d74706984/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java#L413C19-L430

**Checklist**

- [] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
