### PR TITLE
Disable problematic web3 tests on Windows

### DIFF
--- a/web3/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/web3/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -15,6 +15,8 @@ import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class AccountTest {
     private static final byte[] mockCreate2Addr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
@@ -110,6 +112,7 @@ class AccountTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void canonicalAddressIsEVMAddressIfCorrectAlias() {
         // default truffle address #0
         subject.setAlias(ByteString.copyFrom(
@@ -120,6 +123,7 @@ class AccountTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void invalidCanonicalAddresses() {
         Address untranslatedAddress = Address.wrap(Bytes.fromHexString("0000000000000000000000000000000000003039"));
 

--- a/web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -59,6 +59,8 @@ import org.hiero.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -159,6 +161,7 @@ class AutoCreationLogicTest {
             53, -1
             52, 0
             """)
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void hollowAccountWithHbarChangeWorks(int hapiMinorVersion, int expectedMaxAutoAssociations) {
         final var jKey = mapKey(Key.parseFrom(ECDSA_PUBLIC_KEY));
         final var evmAddressAlias =

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -16,11 +16,14 @@ import org.hiero.mirror.web3.evm.store.Store.OnMissing;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
 class AccountAccessorImplTest {
 
     private static final String HEX = "0x00000000000000000000000000000000000004e4";

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -29,6 +29,8 @@ import org.hiero.mirror.web3.evm.utils.EvmTokenUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -158,6 +160,7 @@ class MirrorEvmContractAliasesTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void publicKeyCouldNotBeParsed() throws InvalidProtocolBufferException, InvalidKeyException {
         final byte[] ecdsaPublicKey =
                 Hex.decode("3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
@@ -17,12 +17,15 @@ import org.hiero.mirror.web3.service.AbstractContractCallServiceTest;
 import org.hiero.mirror.web3.web3j.generated.SelfDestructContract;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.shaded.org.bouncycastle.util.encoders.Hex;
 
 @RequiredArgsConstructor
 class SelfDestructOperationTest extends AbstractContractCallServiceTest {
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void testSuccessfulExecute() throws Exception {
         final var senderPublicKey = ByteString.copyFrom(
                 Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -33,6 +33,8 @@ import org.hiero.mirror.web3.web3j.generated.DynamicEthCalls.TokenTransferList;
 import org.hiero.mirror.web3.web3j.generated.DynamicEthCalls.TransferList;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -470,6 +472,7 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
                             FUNGIBLE_COMMON,        1,      0
                             NON_FUNGIBLE_UNIQUE,    0,      1
                             """)
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void approveTokenTransferFromGetAllowanceGetBalance(
             final TokenTypeEnum tokenType, final long amount, final long serialNumber) {
         // Given

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -35,6 +35,8 @@ import org.hiero.mirror.web3.web3j.generated.EvmCodes;
 import org.hiero.mirror.web3.web3j.generated.EvmCodes.G1Point;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.web3j.abi.FunctionReturnDecoder;
@@ -241,6 +243,7 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void selfDestructCall() throws Exception {
         // Given
         final var senderEntityId = domainBuilder.entityId();

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallIsAuthorizedTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallIsAuthorizedTest.java
@@ -13,6 +13,8 @@ import java.security.KeyPairGenerator;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.web3j.generated.HRC632Contract;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.web3j.crypto.Keys;
@@ -23,6 +25,7 @@ class ContractCallIsAuthorizedTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void isAuthorizedRawECDSA(boolean longZeroAddressAllowed) throws Exception {
         // Given
 
@@ -59,6 +62,7 @@ class ContractCallIsAuthorizedTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void isAuthorizedRawECDSADifferentHash(boolean longZeroAddressAllowed) throws Exception {
         // Given
         // Generate new key pair
@@ -88,6 +92,7 @@ class ContractCallIsAuthorizedTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void isAuthorizedRawECDSAInvalidSignedValue(boolean longZeroAddressAllowed) throws Exception {
         // Given
         // Generate new key pair
@@ -130,6 +135,7 @@ class ContractCallIsAuthorizedTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void isAuthorizedRawECDSAInvalidSignatureLength(boolean longZeroAddressAllowed) throws Exception {
         // Given
         final byte[] invalidSignature = new byte[64];
@@ -251,6 +257,7 @@ class ContractCallIsAuthorizedTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void isAuthorizedRawECDSAKeyWighLongZero(boolean longZeroAddressAllowed) throws Exception {
         // Given
         // Generate new key pair

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallNestedCallsTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallNestedCallsTest.java
@@ -27,6 +27,8 @@ import org.hiero.mirror.web3.web3j.generated.NestedCalls.KeyValue;
 import org.hiero.mirror.web3.web3j.generated.NestedCalls.TokenKey;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -439,6 +441,7 @@ class ContractCallNestedCallsTest extends AbstractContractCallServiceOpcodeTrace
 
     @Test
     @SuppressWarnings("deprecation")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void nestedDeployTwoContracts() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(NestedCalls::deploy);

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceDeployerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceDeployerTest.java
@@ -6,10 +6,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.hiero.mirror.web3.web3j.generated.TestContractDeployer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class ContractCallServiceDeployerTest extends AbstractContractCallServiceTest {
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void testDeployMultipleContracts() throws Exception {
         final var contract = testWeb3jService.deploy(TestContractDeployer::deploy);
         final var result = contract.send_deployTestContracts().send();

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -66,6 +66,8 @@ import org.hiero.mirror.web3.web3j.generated.ModificationPrecompileTestContract.
 import org.hiero.mirror.web3.web3j.generated.ModificationPrecompileTestContract.TransferList;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -973,6 +975,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void create2ContractAndTransferFromIt() throws Exception {
         // Given
         final var receiver = accountEntityWithEvmAddressPersist();

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
@@ -67,6 +67,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -721,6 +723,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
      * accountId will result in hollow account creation.
      */
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void hollowAccountCreationWorks() {
         // Given
         final var value = 10L;

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallSignScheduleTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ScheduleTests/ContractCallSignScheduleTest.java
@@ -25,6 +25,8 @@ import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.web3j.generated.HRC755Contract;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Keys;
 import org.web3j.utils.Numeric;
@@ -32,6 +34,7 @@ import org.web3j.utils.Numeric;
 class ContractCallSignScheduleTest extends AbstractContractCallScheduleTest {
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void signScheduleWithEcdsaKey() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
@@ -110,6 +113,7 @@ class ContractCallSignScheduleTest extends AbstractContractCallScheduleTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void signScheduleWithEcdsaKeyWhichAlreadySignedFails() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
@@ -148,6 +152,7 @@ class ContractCallSignScheduleTest extends AbstractContractCallScheduleTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void signScheduleWithEcdsaKeyAndAlreadyExistingPayerEdSignature() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
@@ -285,6 +290,7 @@ class ContractCallSignScheduleTest extends AbstractContractCallScheduleTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     void signScheduleWithEcdsaKeyFailsWhenEd25519Expected() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(HRC755Contract::deploy);
@@ -337,6 +343,7 @@ class ContractCallSignScheduleTest extends AbstractContractCallScheduleTest {
         return new Keccak.Digest256().digest(getMessageBytes(scheduleEntity));
     }
 
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Native secp256k1 DLL not available on Windows")
     private byte[] getSignatureMapBytesEcdsa(final byte[] messageHash, final ECKeyPair keyPair) {
         final var signedMessage = signMessageECDSA(messageHash, Numeric.toBytesPadded(keyPair.getPrivateKey(), 32));
         var publicKeyBytestring = convertToCompressedPublicKey(keyPair.getPublicKey());


### PR DESCRIPTION
**Description**:
Skip web3 tests that are throwing error on windows

Add support for Windows execution of `./gradlew :web3:test`
Annotate problematic tests with `@DisabledOnOs`

**Related issue(s)**:

Fixes #12102 

**Notes for reviewer**:
Outcome of `./gradlew :web3:test` on Windows: `Test Results: SUCCESS (3701 tests, 3665 passed, 0 failed, 36 skipped)`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
