### PR TITLE
Prevent `null` singleton values

### DIFF
--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -93,6 +93,7 @@ jobs:
             "com/hedera/hapi/node/state/schedule/Schedule.java"
             "com/swirlds/state/spi/ReadableKVStateBase.java"
             "com/swirlds/state/spi/WritableKVStateBase.java"
+            "com/swirlds/state/spi/WritableSingletonStateBase.java"
             "com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java"
             "com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java"
             "com/hedera/node/app/service/contract/impl/state/RootProxyWorldUpdater.java"

--- a/web3/src/main/java/com/swirlds/state/spi/WritableSingletonStateBase.java
+++ b/web3/src/main/java/com/swirlds/state/spi/WritableSingletonStateBase.java
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.swirlds.state.spi;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A convenient base class for mutable singletons.
+ * Copy of the class from hedera-app. The difference is that the get() method is modified not to return null values.
+ * @param <T> The type
+ */
+public abstract class WritableSingletonStateBase<T> extends ReadableSingletonStateBase<T>
+        implements WritableSingletonState<T> {
+
+    /**
+     * A sentinel value to represent null in the backing store.
+     */
+    private static final Object NULL_VALUE = new Object();
+
+    /** Modified value buffered in this mutable state */
+    private Object value;
+
+    /** A list of listeners to be notified of changes to the state */
+    private final List<SingletonChangeListener<T>> listeners = new ArrayList<>();
+
+    /**
+     * Creates a new instance.
+     *
+     * @param stateId The state ID for this instance
+     * @param label The state label
+     */
+    public WritableSingletonStateBase(final int stateId, final String label) {
+        super(stateId, label);
+    }
+
+    /**
+     * Register a listener to be notified of changes to the state on {@link #commit()}. We do not support unregistering
+     * a listener, as the lifecycle of a {@link WritableSingletonState} is scoped to the set of mutations made to a
+     * state in a round; and there is no case where an application would only want to be notified of a subset of those
+     * changes.
+     *
+     * @param listener the listener to register
+     */
+    public void registerListener(@NonNull final SingletonChangeListener<T> listener) {
+        requireNonNull(listener);
+        listeners.add(listener);
+    }
+
+    @Override
+    public T get() {
+        // If there is a modification, then we've already done a "put" or "remove"
+        // and should return based on the modification
+        if (isModified()) {
+            // The change from the copied class is here - preventing null values
+            // as they cause NullPointerExceptions in some various places in the code.
+            final var currentValue = currentValue();
+            return currentValue != null ? currentValue : super.get();
+        } else {
+            return super.get();
+        }
+    }
+
+    @Override
+    public void put(T value) {
+        this.value = value == null ? NULL_VALUE : value;
+    }
+
+    @Override
+    public boolean isModified() {
+        return value != null;
+    }
+
+    /**
+     * Flushes all changes into the underlying data store. This method should <strong>ONLY</strong>
+     * be called by the code that created the {@link WritableSingletonStateBase} instance or owns
+     * it. Don't cast and commit unless you own the instance!
+     */
+    public void commit() {
+        if (isModified()) {
+            if (currentValue() != null) {
+                putIntoDataSource(currentValue());
+                //noinspection DataFlowIssue
+                listeners.forEach(l -> l.singletonUpdateChange(currentValue()));
+            } else {
+                removeFromDataSource();
+            }
+        }
+        reset();
+    }
+
+    @SuppressWarnings("unchecked")
+    private T currentValue() {
+        return value == NULL_VALUE ? null : (T) value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Clears the "modified" and cached value, in addition to the super implementation
+     */
+    @Override
+    public void reset() {
+        this.value = null;
+        super.reset();
+    }
+
+    /**
+     * Puts the given value into the underlying data source.
+     *
+     * @param value value to put
+     */
+    protected abstract void putIntoDataSource(@NonNull T value);
+
+    /**
+     * Removes the value related to this singleton from the underlying data source.
+     */
+    protected abstract void removeFromDataSource();
+}


### PR DESCRIPTION
**Description**:
In `hedera-app` bump from 0.64.3 to 0.65.0 the `WritableSingletonStateBase` class was changed to abstract. Also, its get method was modified so that the current singleton value is returned even if it is `null`, which was not allowed in the previous release. Also, with this `hedera-app` bump the `NullPointerException` issues started to appear. This PR returns the previous behaviour - return the modified value only if it is not `null`, delegate to the super implementation (our custom singleton states that return non-null values in `get()`) if `null`.

Fixes #12400
Fixes #12055 