### PR TITLE
Add exchangerate path back to rest-java ingress

### DIFF
--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -134,6 +134,7 @@ ingress:
       paths:
         # the rest of /api/v1/* is still handled by the Node.js based REST API logic, except for these paths
         - path: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/(allowances/nfts|airdrops|hooks)'
+        - path: '/api/v1/network/exchangerate'
         - path: '/api/v1/network/fees$'
           condition: "{{ .Values.routes.fees }}"
         - path: '/api/v1/network/stake$'


### PR DESCRIPTION
**Description**:

This PR fixes the exchangerate REST API 404 issue

- Add exchangerate path back to rest-java ingress

**Related issue(s)**:

Fixes #12423 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
