### PR TITLE
Use default minimum payer balance in web3 calls for historical calls (0.143)

### DIFF
--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
                 .entity()
                 .customize(e -> {
                     e.type(EntityType.ACCOUNT)
-                            .balance(DEFAULT_ACCOUNT_BALANCE)
+                            .balance(getDefaultAccountBalance())
                             .createdTimestamp(timestampRange.lowerEndpoint())
                             .timestampRange(timestampRange);
                     customizer.accept(e);
@@ -399,5 +399,16 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
                             .timestampRange(timestampRange))
                     .persist();
         }
+    }
+
+    /**
+     * Returns the default account balance depending on override setting.
+     *
+     * @return the default account balance
+     */
+    private long getDefaultAccountBalance() {
+        return mirrorNodeEvmProperties.isOverridePayerBalanceValidation()
+                ? DEFAULT_SMALL_ACCOUNT_BALANCE
+                : DEFAULT_ACCOUNT_BALANCE;
     }
 }


### PR DESCRIPTION
**Description**:

Cherry pick of #12439 to release/0.143:

Currently we use a high value of default minimum balance for payers during eth_call and eth_estimateGas, so that a payer with low amount of hbars can still perform transaction simulations. This PR enhances this logic covering historical calls as well.

**Related issue(s)**:

Fixes #12440

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
