### PR TITLE
Remove duplicate `Web3Properties` bean

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/Web3Properties.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/Web3Properties.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.web3;
 
-import jakarta.inject.Named;
 import jakarta.validation.constraints.Positive;
 import java.time.Duration;
 import lombok.Data;
@@ -10,7 +9,6 @@ import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-@Named("web3Properties")
 @Data
 @ConfigurationProperties(prefix = "hiero.mirror.web3")
 @Validated


### PR DESCRIPTION
**Description**:
Heap dumps showed that there are two instances of `Web3Properties` bean and one of them is unneeded. The reason for this is that there is one bean registered from `org.hiero.mirror.common.CommonConfiguration` and another named one in the `Web3Properties` itself - they use different names, so they are both instantiated. The `@Named` annotation is removed and now there is only one bean registered from `org.hiero.mirror.common.CommonConfiguration`.

Fixes #12487 
