### PR TITLE
Avoid cache stampede on latest record file cache expiry

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/operations/MirrorBlockHashOperation.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/operations/MirrorBlockHashOperation.java
@@ -10,10 +10,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.web3.common.ContractCallContext;
 import org.hiero.mirror.web3.evm.config.ModularizedOperation;
-import org.hiero.mirror.web3.exception.BlockNumberNotFoundException;
 import org.hiero.mirror.web3.repository.RecordFileRepository;
-import org.hiero.mirror.web3.service.RecordFileServiceImpl;
-import org.hiero.mirror.web3.viewmodel.BlockType;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.BlockValues;
@@ -63,10 +60,7 @@ class MirrorBlockHashOperation extends BlockHashOperation implements Modularized
         if (currentBlockNumber <= 0 || soughtBlock > currentBlockNumber) {
             frame.pushStackItem(Bytes32.ZERO);
         } else if (currentBlockNumber == soughtBlock) {
-            final var latestBlock = ContractCallContext.get()
-                    .resolveRecordFile(() -> new RecordFileServiceImpl(recordFileRepository)
-                            .findByBlockType(BlockType.LATEST)
-                            .orElseThrow(BlockNumberNotFoundException::new));
+            final var latestBlock = ContractCallContext.get().getRecordFile();
             final var blockHash = getBlockHash(latestBlock);
             frame.pushStackItem(blockHash);
         } else {

--- a/web3/src/main/java/org/hiero/mirror/web3/service/ContractCallService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/ContractCallService.java
@@ -23,6 +23,7 @@ import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.hiero.mirror.web3.service.model.CallServiceParameters;
 import org.hiero.mirror.web3.throttle.ThrottleManager;
 import org.hiero.mirror.web3.throttle.ThrottleProperties;
+import org.hiero.mirror.web3.utils.Suppliers;
 import org.hiero.mirror.web3.viewmodel.BlockType;
 
 @Named
@@ -94,10 +95,10 @@ public abstract class ContractCallService {
             CallServiceParameters params, ContractCallContext ctx) throws MirrorEvmTransactionException {
         ctx.setCallServiceParameters(params);
 
-        if (params.getBlock() != BlockType.LATEST) {
-            ctx.setRecordFile(recordFileService
+        if (params.isModularized() || params.getBlock() != BlockType.LATEST) {
+            ctx.setBlockSupplier(Suppliers.memoize(() -> recordFileService
                     .findByBlockType(params.getBlock())
-                    .orElseThrow(BlockNumberNotFoundException::new));
+                    .orElseThrow(BlockNumberNotFoundException::new)));
         }
 
         return doProcessCall(params, params.getGas(), false);

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockInfoSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/BlockInfoSingleton.java
@@ -9,10 +9,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import jakarta.inject.Named;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.web3.common.ContractCallContext;
-import org.hiero.mirror.web3.exception.BlockNumberNotFoundException;
-import org.hiero.mirror.web3.service.RecordFileService;
 import org.hiero.mirror.web3.state.Utils;
-import org.hiero.mirror.web3.viewmodel.BlockType;
 
 @Named
 @RequiredArgsConstructor
@@ -23,14 +20,9 @@ public class BlockInfoSingleton implements SingletonState<BlockInfo> {
         return BLOCKS_STATE_ID;
     }
 
-    private final RecordFileService recordFileService;
-
     @Override
     public BlockInfo get() {
-        final var recordFile = ContractCallContext.get().resolveRecordFile(() -> recordFileService
-                .findByBlockType(BlockType.LATEST)
-                .orElseThrow(BlockNumberNotFoundException::new));
-
+        final var recordFile = ContractCallContext.get().getRecordFile();
         final var startTimestamp = Utils.convertToTimestamp(recordFile.getConsensusStart());
         final var endTimestamp = Utils.convertToTimestamp(recordFile.getConsensusEnd());
 

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/RunningHashesSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/RunningHashesSingleton.java
@@ -7,17 +7,10 @@ import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import jakarta.inject.Named;
-import lombok.AllArgsConstructor;
 import org.hiero.mirror.web3.common.ContractCallContext;
-import org.hiero.mirror.web3.exception.BlockNumberNotFoundException;
-import org.hiero.mirror.web3.service.RecordFileService;
-import org.hiero.mirror.web3.viewmodel.BlockType;
 
 @Named
-@AllArgsConstructor
 public class RunningHashesSingleton implements SingletonState<RunningHashes> {
-
-    private RecordFileService recordFileService;
 
     @Override
     public Integer getId() {
@@ -26,12 +19,10 @@ public class RunningHashesSingleton implements SingletonState<RunningHashes> {
 
     @Override
     public RunningHashes get() {
-        final var recordFile = ContractCallContext.get().resolveRecordFile(() -> recordFileService
-                .findByBlockType(BlockType.LATEST)
-                .orElseThrow(BlockNumberNotFoundException::new));
+        final var recordFile = ContractCallContext.get().getRecordFile();
         return RunningHashes.newBuilder()
-                .runningHash(Bytes.EMPTY)
                 .nMinus1RunningHash(Bytes.EMPTY)
+                .runningHash(Bytes.EMPTY)
                 .nMinus2RunningHash(Bytes.EMPTY)
                 .nMinus3RunningHash(Bytes.fromHex(recordFile.getHash())) // Used by prevrandao
                 .build();

--- a/web3/src/test/java/org/hiero/mirror/web3/common/ContractCallContextTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/common/ContractCallContextTest.java
@@ -24,7 +24,7 @@ class ContractCallContextTest {
     @Test
     void testReset() {
         var context = ContractCallContext.get();
-        context.setRecordFile(RecordFile.builder().consensusEnd(123L).build());
+        context.setBlockSupplier(() -> RecordFile.builder().consensusEnd(123L).build());
         context.reset();
     }
 

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/operations/MirrorBlockHashOperationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/operations/MirrorBlockHashOperationTest.java
@@ -99,7 +99,7 @@ class MirrorBlockHashOperationTest {
     void current() {
         // Given
         var recordFile = domainBuilder.recordFile().get();
-        ContractCallContext.get().setRecordFile(recordFile);
+        ContractCallContext.get().setBlockSupplier(() -> recordFile);
         var blockValues = new SimpleBlockValues();
         blockValues.setNumber(recordFile.getIndex());
         given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(recordFile.getIndex()));

--- a/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockInfoSingletonTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/singleton/BlockInfoSingletonTest.java
@@ -12,28 +12,19 @@ import org.hiero.mirror.common.domain.DomainBuilder;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.web3.ContextExtension;
 import org.hiero.mirror.web3.common.ContractCallContext;
-import org.hiero.mirror.web3.service.RecordFileService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith({ContextExtension.class, MockitoExtension.class})
+@ExtendWith(ContextExtension.class)
 class BlockInfoSingletonTest {
 
+    private final BlockInfoSingleton blockInfoSingleton = new BlockInfoSingleton();
     private final DomainBuilder domainBuilder = new DomainBuilder();
     private final RecordFile recordFile = domainBuilder.recordFile().get();
 
-    @Mock
-    private RecordFileService recordFileService;
-
-    @InjectMocks
-    private BlockInfoSingleton blockInfoSingleton;
-
     @Test
     void get() {
-        ContractCallContext.get().setRecordFile(recordFile);
+        ContractCallContext.get().setBlockSupplier(() -> recordFile);
         assertThat(blockInfoSingleton.get())
                 .isEqualTo(BlockInfo.newBuilder()
                         .blockHashes(Bytes.EMPTY)
@@ -52,7 +43,7 @@ class BlockInfoSingletonTest {
 
     @Test
     void set() {
-        ContractCallContext.get().setRecordFile(recordFile);
+        ContractCallContext.get().setBlockSupplier(() -> recordFile);
         blockInfoSingleton.set(BlockInfo.DEFAULT);
         assertThat(blockInfoSingleton.get()).isNotEqualTo(BlockInfo.DEFAULT);
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/state/singleton/RunningHashesSingletonTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/singleton/RunningHashesSingletonTest.java
@@ -9,29 +9,18 @@ import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.hiero.mirror.common.domain.DomainBuilder;
 import org.hiero.mirror.web3.common.ContractCallContext;
-import org.hiero.mirror.web3.service.RecordFileService;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class RunningHashesSingletonTest {
 
     private final DomainBuilder domainBuilder = new DomainBuilder();
-
-    @Mock
-    private RecordFileService recordFileService;
-
-    @InjectMocks
-    private RunningHashesSingleton runningHashesSingleton;
+    private final RunningHashesSingleton runningHashesSingleton = new RunningHashesSingleton();
 
     @Test
     void get() {
         ContractCallContext.run(context -> {
             var recordFile = domainBuilder.recordFile().get();
-            context.setRecordFile(recordFile);
+            context.setBlockSupplier(() -> recordFile);
             assertThat(runningHashesSingleton.get())
                     .returns(Bytes.EMPTY, RunningHashes::runningHash)
                     .returns(Bytes.EMPTY, RunningHashes::nMinus1RunningHash)
@@ -50,7 +39,7 @@ class RunningHashesSingletonTest {
     void set() {
         ContractCallContext.run(context -> {
             var recordFile = domainBuilder.recordFile().get();
-            context.setRecordFile(recordFile);
+            context.setBlockSupplier(() -> recordFile);
             runningHashesSingleton.set(RunningHashes.DEFAULT);
             assertThat(runningHashesSingleton.get()).isNotEqualTo(RunningHashes.DEFAULT);
             return null;


### PR DESCRIPTION
**Description**:
This PR should reduce the impact from the cache stampede that happens on latest record file cache expiry resulting in hundreds of thousands of unnecessary db calls on daily basis. The latest record file now is queried when is actually needed instead of early in the ContractCallService.callContract() .
 
**Related issue(s)**:

Fixes #12477 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
