### PR TITLE
Use node v22 LTS image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ extra.apply {
     set("grpcVersion", "1.76.0")
     set("jooq.version", "3.20.8") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
-    set("nodeJsVersion", "22.17.1")
+    set("nodeJsVersion", "22.21.1")
     set("protobufVersion", "4.33.1")
     set("reactorGrpcVersion", "1.2.4")
     set("tuweniVersion", "2.3.1")

--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bookworm-slim
+FROM node:22-bookworm-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup


### PR DESCRIPTION
**Description**:

This PR changes rest Dockerfile to use node v22 LTS image.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
