### PR TITLE
Fix tagged commit detection in acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         stream-type:
           - RECORD
-          - BLOCK
+    #          - BLOCK # re-enable in PR for #12192
     timeout-minutes: 50
     env:
       BLOCK_NODE_CHART_VERSION: v0.23.2
@@ -92,9 +92,15 @@ jobs:
           set -ex
 
           TAG=$(sed -nE 's/^version: (.+)$/\1/p' charts/hedera-mirror/Chart.yaml)
-          [[ "$TAG" != *SNAPSHOT ]] && BASE="v$TAG" || BASE=""
-
-          git describe --exact-match HEAD 2>/dev/null | grep "$TAG" && TRIGGERED_BY_TAG=true || TRIGGERED_BY_TAG=false
+          BASE=""
+          TRIGGERED_BY_TAG=false
+          if [[ "$TAG" != *SNAPSHOT ]]; then
+            BASE="v$TAG"
+            # The dereferenced tag corresponds to the commit the annotated tag refers to
+            DEREFERENCED_TAG="v${TAG}^{}"
+            git ls-remote --tags origin "${DEREFERENCED_TAG}" | grep $(git rev-parse HEAD) && TRIGGERED_BY_TAG=true \
+              || true
+          fi
 
           echo "BASE=${BASE}" >> $GITHUB_ENV
           echo "TAG=${TAG}" >> $GITHUB_ENV
@@ -132,7 +138,7 @@ jobs:
             - 'web3/**'
 
       - name: Build images
-        if: env.TRIGGERED_BY_TAG != 'true' && steps.changeset.outputs != ''
+        if: env.TRIGGERED_BY_TAG != 'true' && steps.changeset.outputs.changes != '[]'
         run: |
           set -ex
           echo '${{ steps.changeset.outputs.changes }}' | jq -r '.[]' | while read module; do


### PR DESCRIPTION
**Description**:

This PR fixes tagged commit detection in acceptance test workflow:

- Use ls-remote --tags to check if it's a tagged commit
- Disable the workflow for blockstream

**Related issue(s)**:

Fixes #12524 

**Notes for reviewer**:

Tested the changes in a cloned repo

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
