### PR TITLE
Fix failed non-zero-realm importer test

### DIFF
--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -662,21 +662,23 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         var optionalSidecarRegex = streamType == StreamType.RECORD ? "(sidecar/)?" : "";
 
         String regex;
+        final long realm = fileCopier.isIgnoreNonZeroRealmShard() ? 0 : commonProperties.getRealm();
+        final long shard = fileCopier.isIgnoreNonZeroRealmShard() ? 0 : commonProperties.getShard();
         if (commonDownloaderProperties.getPathType() == PathType.ACCOUNT_ID) {
             regex = "^/%s%s/%s%d\\.%d\\.\\d+/%s[^/]+$"
                     .formatted(
                             optionalDatePrefix,
                             streamType.getPath(),
                             streamType.getNodePrefix(),
-                            commonProperties.getShard(),
-                            commonProperties.getRealm(),
+                            shard,
+                            realm,
                             optionalSidecarRegex);
         } else {
             regex = "^/%s%s/%d/\\d+/%s/%s[^/]+$"
                     .formatted(
                             optionalDatePrefix,
                             importerProperties.getNetwork(),
-                            commonProperties.getShard(),
+                            shard,
                             streamType.getNodeIdBasedSuffix(),
                             optionalSidecarRegex);
         }


### PR DESCRIPTION
**Description**:

This PR fixes the failed non-zero-realm importer test:

- Exclude account balance file downloader test from non-zero-realm check

**Related issue(s)**:

Fixes #12510 

**Notes for reviewer**:

Account balance files will never exist in non-zero-realm networks. The fix aligns the expected archive file path predicate with that expectation.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
