### PR TITLE
Fix NullPointerException when dummy system accounts are accessed in partial mirror node environments.

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AbstractAliasedAccountReadableKVState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AbstractAliasedAccountReadableKVState.java
@@ -108,6 +108,18 @@ public abstract class AbstractAliasedAccountReadableKVState<K, V> extends Abstra
                 .build();
     }
 
+    /**
+     * Returns the default key for accounts that don't have a key set.
+     * In hedera.app there isn't a case in which an account does not have a key set in the state - it is
+     * either valid, or it is an empty KeyList. This key is added in the account state in the mirror node
+     * for consistency as well as to prevent potential NullPointerException.
+     *
+     * @return EMPTY_KEY_LIST as the default key for accounts without keys
+     */
+    protected Key getDefaultKey() {
+        return EMPTY_KEY_LIST;
+    }
+
     private Key getKey(final Entity entity, final boolean isSmartContract) {
         final var key = parseKey(entity.getKey());
         if (key == null) {
@@ -120,10 +132,7 @@ public abstract class AbstractAliasedAccountReadableKVState<K, V> extends Abstra
                                 .build())
                         .build();
             } else {
-                // In hedera.app there isn't a case in which an account does not have a key set in the state - it is
-                // either valid, or it is an empty KeyList as the one below. This key is added in the account state in
-                // the mirror node for consistency as well as to prevent from potential NullPointerException.
-                return EMPTY_KEY_LIST;
+                return getDefaultKey();
             }
         }
         return key;

--- a/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVState.java
@@ -5,7 +5,6 @@ package org.hiero.mirror.web3.state.keyvalue;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_STATE_ID;
 import static org.hiero.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static org.hiero.mirror.common.domain.entity.EntityType.CONTRACT;
-import static org.hiero.mirror.web3.state.Utils.EMPTY_KEY_LIST;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
@@ -104,7 +103,7 @@ public class AccountReadableKVState extends AbstractAliasedAccountReadableKVStat
             return AccountDetector.isStrictSystem(accountNum) && accountNum != 0
                     ? Optional.of(Account.newBuilder()
                             .accountId(accountID)
-                            .key(EMPTY_KEY_LIST)
+                            .key(getDefaultKey())
                             .build())
                     : Optional.empty();
         }

--- a/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateTest.java
@@ -652,22 +652,22 @@ class AccountReadableKVStateTest {
 
     @Test
     void returnsDummyAccountForSystemAccountWhenNotFound() {
-        final var systemKey = new AccountID(0, 0, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 50L));
-        when(commonEntityAccessor.get(systemKey, Optional.empty())).thenReturn(Optional.empty());
+        final var systemAccount = new AccountID(0, 0, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 50L));
+        when(commonEntityAccessor.get(systemAccount, Optional.empty())).thenReturn(Optional.empty());
 
-        assertThat(accountReadableKVState.readFromDataSource(systemKey)).satisfies(account -> assertThat(account)
+        assertThat(accountReadableKVState.readFromDataSource(systemAccount)).satisfies(account -> assertThat(account)
                 .isNotNull()
-                .returns(systemKey, Account::accountId)
+                .returns(systemAccount, Account::accountId)
                 .returns(0L, Account::tinybarBalance)
                 .returns(EMPTY_KEY_LIST, Account::key));
     }
 
     @Test
     void dummySystemAccountDoesNotThrowNPEOnKeyOrThrow() {
-        final var systemKey = new AccountID(0, 0, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 50L));
-        when(commonEntityAccessor.get(systemKey, Optional.empty())).thenReturn(Optional.empty());
+        final var systemAccount = new AccountID(0, 0, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 50L));
+        when(commonEntityAccessor.get(systemAccount, Optional.empty())).thenReturn(Optional.empty());
 
-        final var account = accountReadableKVState.readFromDataSource(systemKey);
+        final var account = accountReadableKVState.readFromDataSource(systemAccount);
         assertThat(account).isNotNull();
         assertThat(account.keyOrThrow()).isNotNull().isEqualTo(EMPTY_KEY_LIST);
     }


### PR DESCRIPTION
**Description**:
Dummy system accounts were created without keys, causing NPE when Hedera's PreHandle workflow called `account.keyOrThrow()` on preprod with partial data.

 * Add `EMPTY_KEY_LIST` to dummy system account creation in `getDummySystemAccountIfApplicable()`
 * Add test to verify `keyOrThrow()` does not throw `NullPointerException` on dummy accounts
 * Enhance existing test to verify dummy accounts have proper key field set


**Related issue(s)**:

Fixes #12534 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
