### PR TITLE
Add missing imports in traffic replay k6 test

### DIFF
--- a/tools/k6/src/web3/test/traffic-replay/trafficReplay.js
+++ b/tools/k6/src/web3/test/traffic-replay/trafficReplay.js
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import http from 'k6/http';
+import check from 'k6';
+
 import {getOptionsWithScenario} from '../../../lib/common.js';
 
 const BASE_URL = __ENV.BASE_URL;


### PR DESCRIPTION
**Description**:
This PR adds the missing imports in order to run the k6 traffic replay tests successfully. It seems that these imports were deleted by `spotless` on commit.