### PR TITLE
CORS Issue with REST Java API POST Endpoints

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/controller/GenericControllerAdvice.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/controller/GenericControllerAdvice.java
@@ -65,7 +65,7 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
 
     @Bean
     @SuppressWarnings("java:S5122") // Make sure that enabling CORS is safe here.
-    public WebMvcConfigurer corsConfigurer() {
+    WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/controller/ControllerTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/controller/ControllerTest.java
@@ -91,20 +91,37 @@ abstract class ControllerTest extends RestJavaIntegrationTest {
 
         protected abstract String getUrl();
 
+        /*
+         * This method allows subclasses to do any setup work like entity persistence and provide a default URI and
+         * parameters for the parent class to run its common set of tests.
+         */
+        protected RequestHeadersSpec<?> defaultRequest(RequestHeadersUriSpec<?> uriSpec) {
+            return uriSpec.uri("");
+        }
+
         @BeforeEach
         void setup() {
             var suffix = getUrl().replace("/api/v1/", "");
             restClient = restClientBuilder.baseUrl(baseUrl + suffix).build();
         }
+
+        @Test
+        void callSuccessfulCors() {
+            // When
+            var headers = defaultRequest(restClient.options())
+                    .header("Origin", "http://example.com")
+                    .header("Access-Control-Request-Method", "POST")
+                    .retrieve()
+                    .toBodilessEntity()
+                    .getHeaders();
+
+            // Then
+            assertThat(headers.getAccessControlAllowOrigin()).isEqualTo("*");
+            assertThat(headers.getFirst("Access-Control-Allow-Methods")).contains("GET", "HEAD", "POST");
+        }
     }
 
     protected abstract class EndpointTest extends RestTest {
-
-        /*
-         * This method allows subclasses to do any setup work like entity persistence and provide a default URI and
-         * parameters for the parent class to run its common set of tests.
-         */
-        protected abstract RequestHeadersSpec<?> defaultRequest(RequestHeadersUriSpec<?> uriSpec);
 
         @Test
         void etagHeader() {


### PR DESCRIPTION
**Description**:

Add CORS configuration to REST Java API to allow cross-origin requests from browsers.

* Add CORS configurer bean to GenericControllerAdvice
* Allow all origins for /api/** endpoints
* Align with TypeScript REST API and web3 module patterns


**Related issue(s)**:

Fixes #12629 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
