### PR TITLE
Revert sync interval to 1m0s in standalone staging clusters

### DIFF
--- a/clusters/staging-council/flux-system/gotk-sync.yaml
+++ b/clusters/staging-council/flux-system/gotk-sync.yaml
@@ -19,7 +19,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 1m0s
   path: ./clusters/staging-council
   prune: true
   sourceRef:

--- a/clusters/staging-lg/flux-system/gotk-sync.yaml
+++ b/clusters/staging-lg/flux-system/gotk-sync.yaml
@@ -19,7 +19,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 1m0s
   path: ./clusters/staging-lg
   prune: true
   sourceRef:

--- a/clusters/staging-sm/flux-system/gotk-sync.yaml
+++ b/clusters/staging-sm/flux-system/gotk-sync.yaml
@@ -19,7 +19,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 10m0s
+  interval: 1m0s
   path: ./clusters/staging-sm
   prune: true
   sourceRef:


### PR DESCRIPTION
**Description**:

This PR reverts the sync interval to 1m0s in standalone staging clusters. The changes are side effect of rotating github token through `flux bootstrap github`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
