### PR TITLE
Fix snyk false positive

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,6 @@ patch: {}
 exclude:
   global:
     - monitor/src/main/java/org/hiero/mirror/monitor/OperatorProperties.java
+    - rest/constants.js
     - rest/tokens.js
     - rest/middleware/responseCacheHandler.js


### PR DESCRIPTION
**Description**:

Fix snyk `ACCOUNT_PUBLICKEY: 'account.publickey',` false positive in constants.js

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
