### PR TITLE
Fix release Gradle task not compatible with config cache (0.146)

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Gradle Release
-        run: ./gradlew release -Pversion=${{ env.VERSION }}
+        run: ./gradlew release --newVersion=${{ env.VERSION }}
 
       - name: Close the Milestone
         if: ${{ steps.version_parser.outputs.prerelease == '' }}
@@ -189,7 +189,7 @@ jobs:
           git reset --hard $RELEASE_BRANCH
 
       - name: Gradle Release for Next Minor Snapshot
-        run: ./gradlew release -Pversion=${{ env.NEXT_VERSION_SNAPSHOT }}
+        run: ./gradlew release --newVersion=${{ env.NEXT_VERSION_SNAPSHOT }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import com.github.gradle.node.npm.task.NpmSetupTask
 import java.nio.file.Paths
+import task.Release
 
 description = "Hedera Mirror Node imports data from consensus nodes and serves it via an API"
 
@@ -254,37 +255,12 @@ spotless {
     }
 }
 
-fun replaceVersion(files: String, match: String) {
-    ant.withGroovyBuilder {
-        "replaceregexp"("match" to match, "replace" to project.version, "flags" to "gm") {
-            "fileset"(
-                "dir" to rootProject.projectDir,
-                "includes" to files,
-                "excludes" to "**/node_modules/",
-            )
-        }
-    }
-}
-
 tasks.nodeSetup { onlyIf { !this.nodeDir.get().asFile.exists() } }
 
-tasks.register("release") {
+tasks.register<Release>("release") {
     description = "Replaces release version in files."
     group = "release"
-    doLast {
-        replaceVersion("charts/**/Chart.yaml", "(?<=^(appVersion|version): ).+")
-        replaceVersion("docker-compose.yml", "(?<=gcr.io/mirrornode/hedera-mirror-.+:).+")
-        replaceVersion("gradle.properties", "(?<=^version=).+")
-        replaceVersion(
-            "rest/**/package*.json",
-            "(?<=\"@hiero-ledger/(check-state-proof|mirror-rest|mirror-monitor)\",\\s{3,7}\"version\": \")[^\"]+",
-        )
-        replaceVersion("rest/**/openapi.yml", "(?<=^  version: ).+")
-        replaceVersion(
-            "tools/log-downloader/package*.json",
-            "(?<=\"@hiero-ledger/mirror-log-downloader\",\\s{3,7}\"version\": \")[^\"]+",
-        )
-    }
+    directory = layout.settingsDirectory
 }
 
 tasks.spotlessApply { dependsOn(tasks.nodeSetup) }

--- a/buildSrc/src/main/kotlin/task/release.kt
+++ b/buildSrc/src/main/kotlin/task/release.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.kotlin.dsl.withGroovyBuilder
+
+abstract class Release : DefaultTask() {
+    @get:InputDirectory abstract val directory: DirectoryProperty
+
+    @get:Input
+    @get:Option(description = "The new version to replace in source files", option = "newVersion")
+    abstract val newVersion: Property<String>
+
+    @TaskAction
+    fun action() {
+        replaceVersion("charts/**/Chart.yaml", "(?<=^(appVersion|version): ).+")
+        replaceVersion("docker-compose.yml", "(?<=gcr.io/mirrornode/hedera-mirror-.+:).+")
+        replaceVersion("gradle.properties", "(?<=^version=).+")
+        replaceVersion(
+            "rest/**/package*.json",
+            "(?<=\"@hiero-ledger/(check-state-proof|mirror-rest|mirror-monitor)\",\\s{3,7}\"version\": \")[^\"]+",
+        )
+        replaceVersion("rest/**/openapi.yml", "(?<=^  version: ).+")
+        replaceVersion(
+            "tools/log-downloader/package*.json",
+            "(?<=\"@hiero-ledger/mirror-log-downloader\",\\s{3,7}\"version\": \")[^\"]+",
+        )
+    }
+
+    fun replaceVersion(files: String, match: String) {
+        ant.withGroovyBuilder {
+            "replaceregexp"("match" to match, "replace" to newVersion.get(), "flags" to "gm") {
+                "fileset"(
+                    "dir" to directory.get().asFile.absolutePath,
+                    "includes" to files,
+                    "excludes" to "**/node_modules/",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**:

Fix release Gradle task not compatible with config cache (#12728)

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
