### PR TITLE
Upgrade performance and mainnet-staging to v0.146.0-rc1

### DIFF
--- a/clusters/mainnet-staging-na/common/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.145.0-rc1'
+      version: '0.146.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.145.0-rc1'
+      version: '0.146.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
@@ -24,6 +24,12 @@ spec:
       - paths: [""]
         target:
           kind: (MutatingWebhookConfiguration|SGConfig|ValidatingWebhookConfiguration)
+      - paths:
+          - /spec/coordinator/pods/persistentVolume/size
+          - /spec/shards/pods/persistentVolume/size
+          - /spec/shards/overrides
+        target:
+          kind: SGShardedCluster
   install:
     crds: CreateReplace
   interval: 90s
@@ -95,19 +101,6 @@ spec:
         config:
           shared_buffers: "20GB"
         enableMetricsExporter: true
-        overrides:
-          - index: 0
-            pods:
-              persistentVolume:
-                size: 14000Gi
-          - index: 1
-            pods:
-              persistentVolume:
-                size: 15000Gi
-          - index: 2
-            pods:
-              persistentVolume:
-                size: 550Gi
         pgbouncer:
           users:
             mirror_web3:

--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.145.0-rc1'
+      version: '0.146.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -14,11 +14,18 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.145.0-rc1'
+      version: '0.146.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
+    ignore:
+      - paths:
+          - /spec/coordinator/pods/persistentVolume/size
+          - /spec/shards/pods/persistentVolume/size
+          - /spec/shards/overrides
+        target:
+          kind: SGShardedCluster
     mode: warn
   install:
     crds: CreateReplace


### PR DESCRIPTION
**Description**:

* Add ignore paths for auto-grow disk to drift detection
* Remove Stackgres worker overrides in mainnet-staging and use auto-grow
* Upgrade mainnet-staging to v0.146.0-rc1
* Upgrade performance to v0.146.0-rc1

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
