### PR TITLE
Fix parser skipping past transactions in blockstream

### DIFF
--- a/importer/src/main/resources/application.yml
+++ b/importer/src/main/resources/application.yml
@@ -135,7 +135,6 @@ hiero:
       downloader:
         record:
           enabled: false
-      startDate: 1970-01-01T00:00:00Z
 spring:
   config:
     activate:


### PR DESCRIPTION
**Description**:

This PR fixes the bug that parser may skip past transactions in blockstream

- conditionally set startDate to EPOCH instead of NOW for blockstream 

**Related issue(s)**:

Fixes #11125 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
