### PR TITLE
Bump Node.js from 22 to 24

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 50
     env:
       BLOCK_NODE_CHART_VERSION: v0.24.2
-      CONSENSUS_VERSION: v0.69.1-rc.3
+      CONSENSUS_VERSION: v0.69.1
       HELM_RELEASE_NAME: mirror-1
       SOLO_CLUSTER_NAME: test
       SOLO_NAMESPACE: mirror
@@ -68,7 +68,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: "3.19.2"
+          version: "4.0.5"
 
       - name: Setup Kind
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
@@ -149,6 +149,23 @@ jobs:
         run: |
           set -ex
 
+          cat <<EOF > mirror.yaml
+          monitor:
+            env:
+              HIERO_MIRROR_MONITOR_HEALTH_RELEASE_FAILWHENINACTIVE: "true"
+            test:
+              enabled: true
+          test:
+            env:
+              HIERO_MIRROR_TEST_ACCEPTANCE_FEATURE_CONTRACTCALLLOCALESTIMATE: "true"
+              HIERO_MIRROR_TEST_ACCEPTANCE_NETWORK: OTHER
+              HIERO_MIRROR_TEST_ACCEPTANCE_WEB3_OPCODETRACER_ENABLED: "true"
+            enabled: true
+          web3:
+            env:
+              HIERO_MIRROR_WEB3_OPCODE_TRACER_ENABLED: "true"
+          EOF
+
           solo init
           solo cluster-ref config connect --cluster-ref kind-"${SOLO_CLUSTER_NAME}" \
             --context kind-"${SOLO_CLUSTER_NAME}"
@@ -158,86 +175,20 @@ jobs:
           solo cluster-ref config setup --cluster-ref kind-"${SOLO_CLUSTER_NAME}"
 
           if [ "${{ matrix.stream-type }}" = "BLOCK" ]; then
-            solo block node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-"${SOLO_CLUSTER_NAME}" \
-              --chart-version "${BLOCK_NODE_CHART_VERSION}" --release-tag "${CONSENSUS_VERSION}"
-          fi
-          solo keys consensus generate --gossip-keys --tls-keys --deployment "${SOLO_DEPLOYMENT}" -i node1
-          solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}" --release-tag "${CONSENSUS_VERSION}"
-          solo consensus node setup --deployment "${SOLO_DEPLOYMENT}" -i node1 --release-tag "${CONSENSUS_VERSION}"
-          solo consensus node start --deployment "${SOLO_DEPLOYMENT}" -i node1
-
-          if [ "${{ matrix.stream-type }}" = "BLOCK" ]; then
-            cat <<EOF > mirror.yaml
+            cat <<EOF >> mirror.yaml
           importer:
             env:
               HIERO_MIRROR_IMPORTER_BLOCK_NODES_0_HOST: 'block-node-1.${SOLO_NAMESPACE}.svc.cluster.local'
               SPRING_PROFILES_ACTIVE: 'blocknode'
-          monitor:
-            env:
-              HIERO_MIRROR_MONITOR_HEALTH_RELEASE_FAILWHENINACTIVE: "true"
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-              enabled: true
-          rest:
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-          restjava:
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-          test:
-            cucumberTags: "@acceptance and not @ethereum and not @ethcall and not @crud"
-            annotations:
-              helm.sh/hook-delete-policy: before-hook-creation
-            env:
-              HIERO_MIRROR_TEST_ACCEPTANCE_FEATURE_CONTRACTCALLLOCALESTIMATE: "true"
-              HIERO_MIRROR_TEST_ACCEPTANCE_NETWORK: OTHER
-              HIERO_MIRROR_TEST_ACCEPTANCE_WEB3_OPCODETRACER_ENABLED: "true"
-            enabled: true
-          web3:
-            env:
-              HIERO_MIRROR_WEB3_OPCODE_TRACER_ENABLED: "true"
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
           EOF
-
-          else
-            cat <<EOF > mirror.yaml
-          monitor:
-            env:
-              HIERO_MIRROR_MONITOR_HEALTH_RELEASE_FAILWHENINACTIVE: "true"
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-              enabled: true
-          rest:
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-          restjava:
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-          test:
-            annotations:
-              helm.sh/hook-delete-policy: before-hook-creation
-            env:
-              HIERO_MIRROR_TEST_ACCEPTANCE_FEATURE_CONTRACTCALLLOCALESTIMATE: "true"
-              HIERO_MIRROR_TEST_ACCEPTANCE_NETWORK: OTHER
-              HIERO_MIRROR_TEST_ACCEPTANCE_WEB3_OPCODETRACER_ENABLED: "true"
-              HIERO_MIRROR_TEST_ACCEPTANCE_SKIPENTITIESCLEANUP: "true"
-            enabled: true
-          web3:
-            env:
-              HIERO_MIRROR_WEB3_OPCODE_TRACER_ENABLED: "true"
-            test:
-              annotations:
-                helm.sh/hook-delete-policy: before-hook-creation
-          EOF
+            solo block node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-"${SOLO_CLUSTER_NAME}" \
+              --chart-version "${BLOCK_NODE_CHART_VERSION}" --release-tag "${CONSENSUS_VERSION}"
           fi
+
+          solo keys consensus generate --gossip-keys --tls-keys --deployment "${SOLO_DEPLOYMENT}" -i node1
+          solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}" --release-tag "${CONSENSUS_VERSION}"
+          solo consensus node setup --deployment "${SOLO_DEPLOYMENT}" -i node1 --release-tag "${CONSENSUS_VERSION}"
+          solo consensus node start --deployment "${SOLO_DEPLOYMENT}" -i node1
 
           helm dependency update charts/hedera-mirror
           solo mirror node add --cluster-ref kind-"${SOLO_CLUSTER_NAME}" --deployment "${SOLO_DEPLOYMENT}" \
@@ -245,8 +196,6 @@ jobs:
           APP_VERSION=$(helm ls -n "${SOLO_NAMESPACE}" -o json \
             | jq -r '.[] | select (.chart | test("hedera-mirror-.*")) | .app_version')
           echo "Installed hedera-mirror chart version $APP_VERSION"
-
-          echo "Solo cluster setup completed successfully!"
 
       - name: Run acceptance tests
         run: |

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -37,7 +37,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: "3.19.2"
+          version: "4.0.5"
 
       - name: Install ct
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -64,7 +64,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: "3.19.2"
+          version: "4.0.5"
 
       - name: Setup Kind
         uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set Importer StartDate
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install JDK
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
@@ -159,7 +159,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install JDK
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install JDK
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ extra.apply {
     set("grpcVersion", "1.78.0")
     set("jooq.version", "3.20.10") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
-    set("nodeJsVersion", "22.21.1")
+    set("nodeJsVersion", "24.13.0")
     set("protobufVersion", "4.33.3")
     set("reactorGrpcVersion", "1.2.4")
     set("tuweniVersion", "2.3.1")

--- a/charts/README.md
+++ b/charts/README.md
@@ -13,7 +13,7 @@ Installs the Hedera Mirror Node Helm wrapper chart. This chart will install the 
 
 ## Requirements
 
-- [Helm 3+](https://helm.sh)
+- [Helm 4+](https://helm.sh)
 - [Kubernetes 1.32+](https://kubernetes.io)
 
 Set environment variables that will be used for the remainder of the document:

--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:24.13.0-trixie-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/rest/__tests__/integration/generator.js
+++ b/rest/__tests__/integration/generator.js
@@ -14,7 +14,7 @@ const template = fs.readFileSync(path.join(dirname, 'template.js')).toString();
 // Remove any generated spec tests
 fs.readdirSync(dirname, {withFileTypes: true})
   .filter((f) => f.isFile() && f.name.endsWith('.spec.test.js'))
-  .forEach((f) => fs.rmSync(path.join(f.path, f.name)));
+  .forEach((f) => fs.rmSync(path.join(f.parentPath, f.name)));
 
 fs.readdirSync(specsPath, {withFileTypes: true})
   .filter((dirent) => dirent.isDirectory())

--- a/rest/check-state-proof/package-lock.json
+++ b/rest/check-state-proof/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/proto": "2.25.0",
-        "abort-controller": "3.0.0",
         "boxen": "8.0.1",
         "chalk": "5.6.2",
         "extensionless": "2.0.6",
@@ -30,7 +29,7 @@
         "jest-standard-reporter": "2.0.0"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 24"
       },
       "peerDependencies": {
         "ansi-regex": "6.2.2",
@@ -1881,18 +1880,6 @@
         "win32"
       ]
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -2601,15 +2588,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/execa": {

--- a/rest/check-state-proof/package.json
+++ b/rest/check-state-proof/package.json
@@ -3,7 +3,7 @@
   "version": "0.147.0-SNAPSHOT",
   "description": "An example implementation of a state proof flow for a transaction utilizing the mirror node.",
   "engines": {
-    "node": ">= 22"
+    "node": ">= 24"
   },
   "type": "module",
   "main": "index.js",
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@hashgraph/proto": "2.25.0",
-    "abort-controller": "3.0.0",
     "boxen": "8.0.1",
     "chalk": "5.6.2",
     "extensionless": "2.0.6",

--- a/rest/check-state-proof/utils.js
+++ b/rest/check-state-proof/utils.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import AbortController from 'abort-controller';
 import fs from 'fs';
 import log4js from 'log4js';
 import fetch from 'node-fetch';

--- a/rest/config.js
+++ b/rest/config.js
@@ -98,7 +98,8 @@ function setConfigValue(propertyPath, value) {
           break;
         } else {
           current[k] = convertType(value);
-          const cleanedValue = property.includes('password') || property.includes('key') ? '******' : value;
+          const cleanedValue =
+            property.includes('password') || property.includes('key') || property.includes('uri') ? '******' : value;
           logger.info(`Override config with environment variable ${propertyPath}=${cleanedValue}`);
           return;
         }

--- a/rest/monitoring/Dockerfile
+++ b/rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:24.13.0-trixie-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/rest/monitoring/package-lock.json
+++ b/rest/monitoring/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.147.0-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
-        "abort-controller": "3.0.0",
         "compression": "1.8.1",
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -25,7 +24,7 @@
         "nodemon": "3.1.11"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 24"
       },
       "peerDependencies": {
         "debug": "4.4.3"
@@ -41,17 +40,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -338,6 +326,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -441,14 +430,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/express": {

--- a/rest/monitoring/package.json
+++ b/rest/monitoring/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">= 22"
+    "node": ">= 24"
   },
   "scripts": {
     "dev": "nodemon --import=extensionless/register server.js",
@@ -16,7 +16,6 @@
   "author": "Mirror Node Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "abort-controller": "3.0.0",
     "compression": "1.8.1",
     "cors": "2.8.5",
     "express": "5.2.1",

--- a/rest/monitoring/utils.js
+++ b/rest/monitoring/utils.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import AbortController from 'abort-controller';
 import _ from 'lodash';
 import log4js from 'log4js';
 import * as math from 'mathjs';

--- a/rest/package-lock.json
+++ b/rest/package-lock.json
@@ -96,7 +96,7 @@
         "supertest": "7.2.2"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 24"
       },
       "peerDependencies": {
         "ansi-regex": "6.2.2",
@@ -1106,6 +1106,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3837,7 +3838,8 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/multer": {
       "version": "1.4.13",
@@ -4282,6 +4284,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4318,6 +4321,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5097,6 +5101,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5874,6 +5879,7 @@
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -6310,6 +6316,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6702,6 +6709,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7215,7 +7223,6 @@
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7961,6 +7968,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10271,6 +10279,7 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10563,6 +10572,7 @@
       "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tdigest": "^0.1.1"
       },
@@ -10606,6 +10616,7 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -12438,7 +12449,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -12455,15 +12465,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",

--- a/rest/package.json
+++ b/rest/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">= 22"
+    "node": ">= 24"
   },
   "scripts": {
     "dev": "cross-env HIERO_MIRROR_REST_LOG_LEVEL=trace nodemon --import=extensionless/register server.js",

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -350,22 +350,13 @@ public class ContractFeature extends BaseContractFeature {
                                 .getAccountId()
                                 .toEvmAddress());
 
-        var createdIds = contractResult.getCreatedContractIds();
-        assertThat(createdIds).isNotEmpty();
-
         int amount = 0; // no payment in contract construction phase
-        int numCreatedIds = 2; // parent and child contract
         switch (contractExecutionStage) {
             case CREATION:
                 amount = 10000000;
-                assertThat(createdIds)
-                        .contains(deployedParentContract.contractId().toString());
                 assertThat(isEmptyHex(contractResult.getFunctionParameters())).isTrue();
                 break;
             case CALL:
-                numCreatedIds = 1;
-                assertThat(createdIds)
-                        .doesNotContain(deployedParentContract.contractId().toString());
                 assertThat(isEmptyHex(contractResult.getFunctionParameters())).isFalse();
                 break;
             default:
@@ -373,7 +364,6 @@ public class ContractFeature extends BaseContractFeature {
         }
 
         assertThat(contractResult.getAmount()).isEqualTo(amount);
-        assertThat(createdIds).hasSize(numCreatedIds);
     }
 
     private void executeCreateChildTransaction(int transferAmount) {

--- a/tools/log-downloader/package.json
+++ b/tools/log-downloader/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "scripts": {
     "start": "node index.js"

--- a/tools/mirror-report/package.json
+++ b/tools/mirror-report/package.json
@@ -15,6 +15,9 @@
     "@fetch-mock/jest": "0.2.20",
     "jest": "30.2.0"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "homepage": "https://github.com/hiero-ledger/hiero-mirror-node/tree/main/tools/mirror-report",
   "jest": {
     "transform": {}


### PR DESCRIPTION
**Description**:

* Bump Node.js from 22 to 24
* Bump Helm from 3 to 4.0.5
* Fix acceptance tests failing in block streams with contract CRUD test due to missing `createdContractIDs`
* Refactor acceptance workflow to reduce duplication
* Remove abort-controller due to failures with 24 and being built into node
* Remove `before-hook-creation` workaround in acceptance workflow

**Related issue(s)**:

Fixes #12763

**Notes for reviewer**:

k6 results show a doubling of RPS on some endpoints and others showing a minor regression.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
