### PR TITLE
docs: document token expiry_timestamp encoding inconsistency

### DIFF
--- a/rest/api/v1/openapi.yml
+++ b/rest/api/v1/openapi.yml
@@ -3831,6 +3831,10 @@ components:
           example: true
           nullable: true
         expiry_timestamp:
+          description: >-
+            The token's expiration time in nanoseconds since the Unix epoch. Note that this encoding
+            differs from other entity expiry timestamps (e.g., accounts) which use a seconds.nanoseconds
+            string format. This inconsistency is a known issue retained for backwards compatibility.
           example: 1234567890100000
           format: int64
           nullable: true


### PR DESCRIPTION
## Description

Adds documentation to the OpenAPI spec clarifying that the token's `expiry_timestamp` field uses a different encoding than other entity timestamps.

### The Issue

The token's `expiry_timestamp` is encoded as an integer in nanoseconds (e.g., `1.7622556834341256e+18`), while other entities like accounts use the standard `seconds.nanoseconds` string format (e.g., `"1762116598.687071000"`).

This inconsistency was previously noted in #5779 but retained for backwards compatibility.

### Changes

Updated the OpenAPI spec (`rest/api/v1/openapi.yml`) to add a description to the token's `expiry_timestamp` field noting:
- The field is in nanoseconds since the Unix epoch
- This differs from other entity expiry timestamps which use seconds.nanoseconds string format
- This is a known issue retained for backwards compatibility

## Related Issues

- Related to historical issue #5779