### PR TITLE
Upgrade mainnet-na to v0.146.0

### DIFF
--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-v2.yaml
-      version: '0.145.2'
+      version: '0.146.0'
   driftDetection:
     mode: enabled
     ignore:

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.145.2'
+      version: '0.146.0'
   dependsOn:
     - name: mirror
       namespace: common
@@ -25,6 +25,12 @@ spec:
           - /spec/scripts
         target:
           kind: SGScript
+      - paths:
+          - /spec/coordinator/pods/persistentVolume/size
+          - /spec/shards/pods/persistentVolume/size
+          - /spec/shards/overrides
+        target:
+          kind: SGShardedCluster
   install:
     crds: CreateReplace
   interval: 90s
@@ -115,7 +121,5 @@ spec:
       env:
         HIERO_MIRROR_WEB3_EVM_NETWORK: MAINNET
         SPRING_DATASOURCE_HIKARI_MAXIMUMPOOLSIZE: "75"
-        HIERO_MIRROR_WEB3_MODULARIZED_ALLOWLONGZEROADDRESS: "false"
-        HIERO_MIRROR_WEB3_EVM_ALLOWLONGZEROADDRESS: "false"
       hpa:
         minReplicas: 5


### PR DESCRIPTION
**Description**:

* Ignore reconciliation of SGShardedCluster volume sizes for auto volume sizing
* Remove deleted `hiero.mirror.web3.evm.allowLongZeroAddress` properties
* Upgrade mainnet-na to v0.146.0

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
