### PR TITLE
Remove remaining lambda references

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/ContractSlotId.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/ContractSlotId.java
@@ -10,8 +10,8 @@ import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Identifier for either contract storage or lambda (hook) storage. For regular contract storage: contractId is set,
- * hookId is null For lambda/hook storage: contractId is null, hookId is set
+ * Identifier for either contract storage or hook storage. For regular contract storage: contractId is set, hookId is
+ * null. For hook storage: contractId is null, hookId is set
  *
  * <p><strong>Note:</strong> Use the static factory method {@link #of(ContractID, HookId)} to create instances.
  * Direct construction is not allowed.

--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/ContractSlotKey.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/ContractSlotKey.java
@@ -8,8 +8,8 @@ import com.hederahashgraph.api.proto.java.HookId;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Unified key for both contract storage and lambda (hook) storage. For regular contract storage: contractId is set,
- * hookId is null For lambda/hook storage: contractId is null, hookId is set
+ * Unified key for both contract storage and hook storage. For regular contract storage: contractId is set, hookId is
+ * null. For hook storage: contractId is null, hookId is set
  */
 public record ContractSlotKey(ContractSlotId slotId, ByteString key) {
 

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
@@ -19,12 +19,12 @@ import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.co
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.convert;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getAccountId;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getContractId;
+import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getEvmHookSlotKey;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getFileId;
-import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getLambdaSlotKey;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getTokenId;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.getTopicId;
-import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.lambdaStorageMapDeleteChange;
-import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.lambdaStorageMapUpdateChange;
+import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.hookStorageMapDeleteChange;
+import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.hookStorageMapUpdateChange;
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.makeIdentical;
 
 import com.google.common.primitives.Bytes;
@@ -518,18 +518,18 @@ final class StateChangeContextTest {
     }
 
     @Test
-    void getLambdaStorageValueWritten() {
+    void getHookStorageValueWritten() {
         // given
-        var lambdaSlot1 = bytes(24);
-        var lambdaSlot1Padded = DomainUtils.fromBytes(Bytes.concat(new byte[8], DomainUtils.toBytes(lambdaSlot1)));
-        var lambdaSlot1Value = bytes(8);
-        var lambdaSlot2 = bytes(32);
-        var lambdaSlot2Value = bytes(12);
-        var lambdaSlotKey1 = getLambdaSlotKey(1L, lambdaSlot1Padded);
-        var lambdaSlotKey2 = getLambdaSlotKey(2L, lambdaSlot2);
+        var hookSlot1 = bytes(24);
+        var hookSlot1Padded = DomainUtils.fromBytes(Bytes.concat(new byte[8], DomainUtils.toBytes(hookSlot1)));
+        var hookSlot1Value = bytes(8);
+        var hookSlot2 = bytes(32);
+        var hookSlot2Value = bytes(12);
+        var hookSlotKey1 = getEvmHookSlotKey(1L, hookSlot1Padded);
+        var hookSlotKey2 = getEvmHookSlotKey(2L, hookSlot2);
         var stateChanges = StateChanges.newBuilder()
-                .addStateChanges(lambdaStorageMapUpdateChange(lambdaSlotKey1, lambdaSlot1Value))
-                .addStateChanges(lambdaStorageMapUpdateChange(lambdaSlotKey2, lambdaSlot2Value))
+                .addStateChanges(hookStorageMapUpdateChange(hookSlotKey1, hookSlot1Value))
+                .addStateChanges(hookStorageMapUpdateChange(hookSlotKey2, hookSlot2Value))
                 .addStateChanges(otherMapUpdateChange())
                 .build();
 
@@ -539,43 +539,42 @@ final class StateChangeContextTest {
         // then
         // Test retrieval with normalized key
         var normalizedSlotKey1 =
-                convert(lambdaSlotKey1.toBuilder().setKey(lambdaSlot1).build());
-        assertThat(context.getContractStorageValueWritten(normalizedSlotKey1))
-                .isEqualTo(BytesValue.of(lambdaSlot1Value));
+                convert(hookSlotKey1.toBuilder().setKey(hookSlot1).build());
+        assertThat(context.getContractStorageValueWritten(normalizedSlotKey1)).isEqualTo(BytesValue.of(hookSlot1Value));
         // Test retrieval with padded key (should normalize and find the value)
-        assertThat(context.getContractStorageValueWritten(convert(lambdaSlotKey2)))
-                .isEqualTo(BytesValue.of(lambdaSlot2Value));
+        assertThat(context.getContractStorageValueWritten(convert(hookSlotKey2)))
+                .isEqualTo(BytesValue.of(hookSlot2Value));
         // Test non-existent key
-        var nonExistentKey = getLambdaSlotKey(3L, bytes(32));
+        var nonExistentKey = getEvmHookSlotKey(3L, bytes(32));
         assertThat(context.getContractStorageValueWritten(convert(nonExistentKey)))
                 .isNull();
     }
 
     @Test
-    void getLambdaStorageValueWrittenWithEmptyContext() {
+    void getHookStorageValueWrittenWithEmptyContext() {
         // given
-        var lambdaSlotKey = getLambdaSlotKey(1L, bytes(32));
+        var hookSlotKey = getEvmHookSlotKey(1L, bytes(32));
 
         // when, then
-        assertThat(EMPTY_CONTEXT.getContractStorageValueWritten(convert(lambdaSlotKey)))
+        assertThat(EMPTY_CONTEXT.getContractStorageValueWritten(convert(hookSlotKey)))
                 .isNull();
     }
 
     @Test
-    void getLambdaStorageValueWrittenWithMapDelete() {
+    void getHookStorageValueWrittenWithMapDelete() {
         // given
-        var lambdaSlot1 = bytes(32);
-        var lambdaSlot1Value = bytes(8);
-        var lambdaSlot2 = bytes(32);
-        var lambdaSlot2Value = bytes(12);
-        var lambdaSlot3 = bytes(32);
-        var lambdaSlotKey1 = getLambdaSlotKey(1L, lambdaSlot1);
-        var lambdaSlotKey2 = getLambdaSlotKey(2L, lambdaSlot2);
-        var lambdaSlotKey3 = getLambdaSlotKey(3L, lambdaSlot3);
+        var hookSlot1 = bytes(32);
+        var hookSlot1Value = bytes(8);
+        var hookSlot2 = bytes(32);
+        var hookSlot2Value = bytes(12);
+        var hookSlot3 = bytes(32);
+        var hookSlotKey1 = getEvmHookSlotKey(1L, hookSlot1);
+        var hookSlotKey2 = getEvmHookSlotKey(2L, hookSlot2);
+        var hookSlotKey3 = getEvmHookSlotKey(3L, hookSlot3);
         var stateChanges = StateChanges.newBuilder()
-                .addStateChanges(lambdaStorageMapUpdateChange(lambdaSlotKey1, lambdaSlot1Value))
-                .addStateChanges(lambdaStorageMapUpdateChange(lambdaSlotKey2, lambdaSlot2Value))
-                .addStateChanges(lambdaStorageMapDeleteChange(lambdaSlotKey2))
+                .addStateChanges(hookStorageMapUpdateChange(hookSlotKey1, hookSlot1Value))
+                .addStateChanges(hookStorageMapUpdateChange(hookSlotKey2, hookSlot2Value))
+                .addStateChanges(hookStorageMapDeleteChange(hookSlotKey2))
                 .addStateChanges(otherMapUpdateChange())
                 .build();
 
@@ -584,13 +583,13 @@ final class StateChangeContextTest {
 
         // then
         // Test that updated value is present
-        assertThat(context.getContractStorageValueWritten(convert(lambdaSlotKey1)))
-                .isEqualTo(BytesValue.of(lambdaSlot1Value));
+        assertThat(context.getContractStorageValueWritten(convert(hookSlotKey1)))
+                .isEqualTo(BytesValue.of(hookSlot1Value));
         // Test that deleted slot has default BytesValue (empty)
-        assertThat(context.getContractStorageValueWritten(convert(lambdaSlotKey2)))
+        assertThat(context.getContractStorageValueWritten(convert(hookSlotKey2)))
                 .isEqualTo(BytesValue.getDefaultInstance());
         // Test non-existent key
-        assertThat(context.getContractStorageValueWritten(convert(lambdaSlotKey3)))
+        assertThat(context.getContractStorageValueWritten(convert(hookSlotKey3)))
                 .isNull();
     }
 }

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeTestUtils.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeTestUtils.java
@@ -2,7 +2,7 @@
 
 package org.hiero.mirror.common.domain.transaction;
 
-import static com.hedera.hapi.block.stream.output.protoc.StateIdentifier.STATE_ID_LAMBDA_STORAGE_VALUE;
+import static com.hedera.hapi.block.stream.output.protoc.StateIdentifier.STATE_ID_EVM_HOOK_STORAGE_VALUE;
 import static com.hedera.hapi.block.stream.output.protoc.StateIdentifier.STATE_ID_STORAGE_VALUE;
 
 import com.google.protobuf.ByteString;
@@ -11,7 +11,7 @@ import com.hedera.hapi.block.stream.output.protoc.MapChangeValue;
 import com.hedera.hapi.block.stream.output.protoc.MapDeleteChange;
 import com.hedera.hapi.block.stream.output.protoc.MapUpdateChange;
 import com.hedera.hapi.block.stream.output.protoc.StateChange;
-import com.hedera.hapi.node.state.hooks.legacy.LambdaSlotKey;
+import com.hedera.hapi.node.state.hooks.legacy.EvmHookSlotKey;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
@@ -84,27 +84,27 @@ public final class StateChangeTestUtils {
         return builder.build();
     }
 
-    public static StateChange lambdaStorageMapUpdateChange(LambdaSlotKey lambdaSlotKey, ByteString value) {
+    public static StateChange hookStorageMapUpdateChange(EvmHookSlotKey evmHookSlotKey, ByteString value) {
         return StateChange.newBuilder()
-                .setStateId(STATE_ID_LAMBDA_STORAGE_VALUE)
+                .setStateId(STATE_ID_EVM_HOOK_STORAGE_VALUE)
                 .setMapUpdate(MapUpdateChange.newBuilder()
-                        .setKey(MapChangeKey.newBuilder().setLambdaSlotKey(lambdaSlotKey))
+                        .setKey(MapChangeKey.newBuilder().setEvmHookSlotKey(evmHookSlotKey))
                         .setValue(MapChangeValue.newBuilder()
                                 .setSlotValueValue(com.hederahashgraph.api.proto.java.SlotValue.newBuilder()
                                         .setValue(value))))
                 .build();
     }
 
-    public static StateChange lambdaStorageMapDeleteChange(LambdaSlotKey lambdaSlotKey) {
+    public static StateChange hookStorageMapDeleteChange(EvmHookSlotKey evmHookSlotKey) {
         return StateChange.newBuilder()
-                .setStateId(STATE_ID_LAMBDA_STORAGE_VALUE)
+                .setStateId(STATE_ID_EVM_HOOK_STORAGE_VALUE)
                 .setMapDelete(MapDeleteChange.newBuilder()
-                        .setKey(MapChangeKey.newBuilder().setLambdaSlotKey(lambdaSlotKey)))
+                        .setKey(MapChangeKey.newBuilder().setEvmHookSlotKey(evmHookSlotKey)))
                 .build();
     }
 
-    public static LambdaSlotKey getLambdaSlotKey(long hookId, ByteString key) {
-        return LambdaSlotKey.newBuilder()
+    public static EvmHookSlotKey getEvmHookSlotKey(long hookId, ByteString key) {
+        return EvmHookSlotKey.newBuilder()
                 .setHookId(com.hederahashgraph.api.proto.java.HookId.newBuilder()
                         .setHookId(hookId)
                         .setEntityId(com.hederahashgraph.api.proto.java.HookEntityId.newBuilder()
@@ -113,9 +113,9 @@ public final class StateChangeTestUtils {
                 .build();
     }
 
-    public static ContractSlotKey convert(LambdaSlotKey lambdaSlotKey) {
-        var slotId = ContractSlotId.of(null, lambdaSlotKey.getHookId());
-        return new ContractSlotKey(slotId, lambdaSlotKey.getKey());
+    public static ContractSlotKey convert(EvmHookSlotKey evmHookSlotKey) {
+        var slotId = ContractSlotId.of(null, evmHookSlotKey.getHookId());
+        return new ContractSlotKey(slotId, evmHookSlotKey.getKey());
     }
 
     private static long nextId() {

--- a/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
@@ -291,16 +291,16 @@ final class DomainUtilsTest {
             00001234, 1234
             1234567890000000000000000000000000, 1234567890000000000000000000000000
             """)
-    void normalizeLambdaSlotKey(String input, String trimmed) {
+    void normalizeEvmHookSlotKey(String input, String trimmed) {
         var hookId = HookId.newBuilder()
                 .setHookId(1L)
                 .setEntityId(HookEntityId.newBuilder()
                         .setAccountId(AccountID.newBuilder().setAccountNum(1000)))
                 .build();
         var slotId = ContractSlotId.of(null, hookId);
-        var lambdaSlotKey = new ContractSlotKey(slotId, ByteString.fromHex(input));
+        var hookSlotKey = new ContractSlotKey(slotId, ByteString.fromHex(input));
         var expected = new ContractSlotKey(slotId, ByteString.fromHex(trimmed));
-        assertThat(DomainUtils.normalize(lambdaSlotKey)).isEqualTo(expected);
+        assertThat(DomainUtils.normalize(hookSlotKey)).isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR removes remaining lambda references.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

`main` is broken. This happened due to the fact no workflow was re-run for the lambda PR after the hook storage for blockstream PR was merged.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
