### PR TITLE
Fix update hook_type migration

### DIFF
--- a/importer/src/main/resources/db/migration/v1/V1.115.0__update_hook_type.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.115.0__update_hook_type.sql
@@ -1,9 +1,5 @@
 -- Update hook_type enum since all lambda references have been removed
-alter table if exists hook drop column if exists type;
-alter table if exists hook_history drop column if exists type;
-drop table if exists hook_temp;
-drop type if exists hook_type;
-
+drop type if exists hook_type cascade;
 create type hook_type as enum ('EVM');
 alter table if exists hook add column type hook_type not null default 'EVM';
 alter table if exists hook_history add column type hook_type not null default 'EVM';

--- a/importer/src/main/resources/db/migration/v2/R__02_temp_table_distribution.sql
+++ b/importer/src/main/resources/db/migration/v2/R__02_temp_table_distribution.sql
@@ -18,6 +18,7 @@ call create_distributed_table_safe('custom_fee_temp', 'entity_id', 'custom_fee')
 call create_distributed_table_safe('entity_stake_temp', 'id', 'entity_stake');
 call create_distributed_table_safe('entity_state_start', 'id', 'entity');
 call create_distributed_table_safe('entity_temp', 'id', 'entity');
+call create_distributed_table_safe('hook_temp', 'owner_id', 'entity');
 call create_distributed_table_safe('nft_allowance_temp', 'owner', 'nft_allowance');
 call create_distributed_table_safe('nft_temp', 'token_id', 'nft');
 call create_distributed_table_safe('schedule_temp', 'schedule_id', 'schedule');

--- a/importer/src/main/resources/db/migration/v2/V2.20.0__update_hook_type.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.20.0__update_hook_type.sql
@@ -1,11 +1,7 @@
 -- Update hook_type enum since all lambda references have been removed
 set local citus.multi_shard_modify_mode to 'sequential';
 
-alter table if exists hook drop column if exists type;
-alter table if exists hook_history drop column if exists type;
-drop table if exists hook_temp;
-drop type if exists hook_type;
-
+drop type if exists hook_type cascade;
 create type hook_type as enum ('EVM');
 alter table if exists hook add column type hook_type not null default 'EVM';
 alter table if exists hook_history add column type hook_type not null default 'EVM';


### PR DESCRIPTION
**Description**:

This PR fixes the migration failure:

- add cascade when dropping hook_type
- distribute hook_temp tables in V2

**Related issue(s)**:

Fixes #12811 

**Notes for reviewer**:

Verified it locally by running a upgrade from 0.146.0 to 0.147.0-SNAPSHOT with the patch.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
