### PR TITLE
Fix release workflows by removing docker registry mirror

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -90,9 +90,6 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: network=host
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
           version: latest
 
       - name: Build and push images

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -91,9 +91,6 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: network=host
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
           version: latest
 
       - name: Build and push images


### PR DESCRIPTION
**Description**:

This PR applies the workaround to fix release workflows.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
