### PR TITLE
Rollback to citus 12 in staging

### DIFF
--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -97,6 +97,13 @@ spec:
         enabled: true
       coordinator:
         enableMetricsExporter: true
+      extensions: # remove when deploying 148
+        - name: citus
+          version: "12.1-1"
+        - name: btree_gist
+          version: stable
+        - name: pg_trgm
+          version: "1.6"
       worker:
         config:
           shared_buffers: "20GB"
@@ -137,7 +144,7 @@ spec:
               acceptance:
                 network: MAINNET
       cucumberTags: "@critical"
-      enabled: true
+      enabled: false # enable when deploying 148
     web3:
       env:
         HIERO_MIRROR_WEB3_EVM_NETWORK: MAINNET


### PR DESCRIPTION
**Description**:

This PR rolls back to citus 12 in staging just in case we need to run k6 tests with the previous citus version. It also disables acceptance test.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Just want to get needed approvals. Will close the PR if the test result stabilizes.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
