### PR TITLE
Fix gRPC cancel propagation

### DIFF
--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -91,6 +91,8 @@ gateway:
             service: com.hedera.mirror.api.proto.NetworkService
         - method:
             service: grpc.reflection.v1alpha.ServerReflection
+        - method:
+            service: grpc.reflection.v1.ServerReflection
   target:
     group: ""
     kind: Service
@@ -136,6 +138,7 @@ ingress:
         - "/com.hedera.mirror.api.proto.ConsensusService"
         - "/com.hedera.mirror.api.proto.NetworkService"
         - "/grpc.reflection.v1alpha.ServerReflection"
+        - "/grpc.reflection.v1.ServerReflection"
   tls:
     enabled: false
     secretName: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,6 +229,7 @@ configs:
         location = /com.hedera.mirror.api.proto.ConsensusService/subscribeTopic { grpc_read_timeout 600s; grpc_pass grpc://grpc_host; }
         location /com.hedera.mirror.api.proto. { grpc_pass grpc://grpc_host; }
         location /grpc.reflection.v1alpha.ServerReflection { grpc_pass grpc://grpc_host; }
+        location /grpc.reflection.v1.ServerReflection { grpc_pass grpc://grpc_host; }
 
         # graphql host
         location = /graphql/alpha { proxy_pass http://$$graphql_host$$request_uri; }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,7 +406,6 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hiero.mirror.grpc.retriever.enabled`                      | true             | Whether to retrieve historical massages or not                                                            |
 | `hiero.mirror.grpc.retriever.maxPageSize`                  | 1000             | The maximum number of messages the retriever can return in a single call to the database                  |
 | `hiero.mirror.grpc.retriever.pollingFrequency`             | 2s               | How often to poll for historical messages. Can accept duration units like `50ms`, `10s` etc               |
-| `hiero.mirror.grpc.retriever.threadMultiplier`             | 4                | Multiplied by the CPU count to calculate the number of retriever threads                                  |
 | `hiero.mirror.grpc.retriever.timeout`                      | 60s              | How long to wait between emission of messages before returning an error                                   |
 | `hiero.mirror.grpc.retriever.unthrottled.maxPageSize`      | 5000             | The maximum number of messages the retriever can return in a single call to the database when unthrottled |
 | `hiero.mirror.grpc.retriever.unthrottled.maxPolls`         | 12               | The max number of polls when unthrottled                                                                  |

--- a/grpc/src/main/java/org/hiero/mirror/grpc/controller/ConsensusController.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/controller/ConsensusController.java
@@ -9,6 +9,7 @@ import com.hedera.mirror.api.proto.ConsensusTopicResponse;
 import com.hederahashgraph.api.proto.java.ConsensusMessageChunkInfo;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.util.Objects;
 import lombok.CustomLog;
@@ -31,7 +32,7 @@ import reactor.core.publisher.Mono;
 @GrpcService
 @CustomLog
 @RequiredArgsConstructor
-public class ConsensusController extends ConsensusServiceGrpc.ConsensusServiceImplBase {
+final class ConsensusController extends ConsensusServiceGrpc.ConsensusServiceImplBase {
 
     // Blockstreams no longer contain runningHashVersion, default to the latest version
     static final int DEFAULT_RUNNING_HASH_VERSION = 3;
@@ -40,15 +41,19 @@ public class ConsensusController extends ConsensusServiceGrpc.ConsensusServiceIm
 
     @Override
     public void subscribeTopic(ConsensusTopicQuery request, StreamObserver<ConsensusTopicResponse> responseObserver) {
-        Mono.fromCallable(() -> toFilter(request))
+        final var disposable = Mono.fromCallable(() -> toFilter(request))
                 .flatMapMany(topicMessageService::subscribeTopic)
                 .map(this::toResponse)
                 .onErrorMap(ProtoUtil::toStatusRuntimeException)
                 .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+
+        if (responseObserver instanceof ServerCallStreamObserver serverCallStreamObserver) {
+            serverCallStreamObserver.setOnCancelHandler(disposable::dispose);
+        }
     }
 
     private TopicMessageFilter toFilter(ConsensusTopicQuery query) {
-        var filter = TopicMessageFilter.builder().limit(query.getLimit());
+        final var filter = TopicMessageFilter.builder().limit(query.getLimit());
 
         if (query.hasTopicID()) {
             filter.topicId(EntityId.of(query.getTopicID()));
@@ -77,7 +82,7 @@ public class ConsensusController extends ConsensusServiceGrpc.ConsensusServiceIm
 
     // Consider caching this conversion for multiple subscribers to the same topic if the need arises.
     private ConsensusTopicResponse toResponse(TopicMessage t) {
-        var consensusTopicResponseBuilder = ConsensusTopicResponse.newBuilder()
+        final var consensusTopicResponseBuilder = ConsensusTopicResponse.newBuilder()
                 .setConsensusTimestamp(ProtoUtil.toTimestamp(t.getConsensusTimestamp()))
                 .setMessage(ProtoUtil.toByteString(t.getMessage()))
                 .setRunningHash(ProtoUtil.toByteString(t.getRunningHash()))

--- a/grpc/src/main/java/org/hiero/mirror/grpc/controller/NetworkController.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/controller/NetworkController.java
@@ -7,6 +7,7 @@ import com.hedera.mirror.api.proto.AddressBookQuery;
 import com.hedera.mirror.api.proto.NetworkServiceGrpc;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -24,21 +25,25 @@ import reactor.core.publisher.Mono;
 @GrpcService
 @CustomLog
 @RequiredArgsConstructor
-public class NetworkController extends NetworkServiceGrpc.NetworkServiceImplBase {
+final class NetworkController extends NetworkServiceGrpc.NetworkServiceImplBase {
 
     private final NetworkService networkService;
 
     @Override
-    public void getNodes(AddressBookQuery request, StreamObserver<NodeAddress> responseObserver) {
-        Mono.fromCallable(() -> toFilter(request))
+    public void getNodes(final AddressBookQuery request, final StreamObserver<NodeAddress> responseObserver) {
+        final var disposable = Mono.fromCallable(() -> toFilter(request))
                 .flatMapMany(networkService::getNodes)
                 .map(this::toNodeAddress)
                 .onErrorMap(ProtoUtil::toStatusRuntimeException)
                 .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+
+        if (responseObserver instanceof ServerCallStreamObserver serverCallStreamObserver) {
+            serverCallStreamObserver.setOnCancelHandler(disposable::dispose);
+        }
     }
 
-    private AddressBookFilter toFilter(AddressBookQuery query) {
-        var filter = AddressBookFilter.builder().limit(query.getLimit());
+    private AddressBookFilter toFilter(final AddressBookQuery query) {
+        final var filter = AddressBookFilter.builder().limit(query.getLimit());
 
         if (query.hasFileId()) {
             filter.fileId(EntityId.of(query.getFileId()));
@@ -48,8 +53,8 @@ public class NetworkController extends NetworkServiceGrpc.NetworkServiceImplBase
     }
 
     @SuppressWarnings("deprecation")
-    private NodeAddress toNodeAddress(AddressBookEntry addressBookEntry) {
-        var nodeAddress = NodeAddress.newBuilder()
+    private NodeAddress toNodeAddress(final AddressBookEntry addressBookEntry) {
+        final var nodeAddress = NodeAddress.newBuilder()
                 .setNodeAccountId(addressBookEntry.getNodeAccountId().toAccountID())
                 .setNodeId(addressBookEntry.getNodeId());
 
@@ -73,8 +78,8 @@ public class NetworkController extends NetworkServiceGrpc.NetworkServiceImplBase
             nodeAddress.setStake(addressBookEntry.getStake());
         }
 
-        for (var s : addressBookEntry.getServiceEndpoints()) {
-            var serviceEndpoint = ServiceEndpoint.newBuilder()
+        for (final var s : addressBookEntry.getServiceEndpoints()) {
+            final var serviceEndpoint = ServiceEndpoint.newBuilder()
                     .setDomainName(s.getDomainName())
                     .setIpAddressV4(toIpAddressV4(s.getIpAddressV4()))
                     .setPort(s.getPort())
@@ -85,7 +90,7 @@ public class NetworkController extends NetworkServiceGrpc.NetworkServiceImplBase
         return nodeAddress.build();
     }
 
-    private ByteString toIpAddressV4(String ipAddress) {
+    private ByteString toIpAddressV4(final String ipAddress) {
         try {
             if (StringUtils.isBlank(ipAddress)) {
                 return ByteString.EMPTY;

--- a/grpc/src/main/java/org/hiero/mirror/grpc/listener/PollingTopicListener.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/listener/PollingTopicListener.java
@@ -28,8 +28,7 @@ public class PollingTopicListener implements TopicListener {
     private final ListenerProperties listenerProperties;
     private final ObservationRegistry observationRegistry;
     private final TopicMessageRepository topicMessageRepository;
-    private final Scheduler scheduler =
-            Schedulers.newParallel("poll", 4 * Runtime.getRuntime().availableProcessors(), true);
+    private final Scheduler scheduler = Schedulers.boundedElastic();
 
     @Override
     public Flux<TopicMessage> listen(TopicMessageFilter filter) {

--- a/grpc/src/main/java/org/hiero/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -34,7 +34,7 @@ public class SharedPollingTopicListener extends SharedTopicListener {
         super(listenerProperties);
         this.topicMessageRepository = topicMessageRepository;
 
-        Scheduler scheduler = Schedulers.newSingle("shared-poll", true);
+        Scheduler scheduler = Schedulers.boundedElastic();
         Duration interval = listenerProperties.getInterval();
         PollingContext context = new PollingContext();
 

--- a/grpc/src/main/java/org/hiero/mirror/grpc/retriever/PollingTopicMessageRetriever.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/retriever/PollingTopicMessageRetriever.java
@@ -38,9 +38,7 @@ public class PollingTopicMessageRetriever implements TopicMessageRetriever {
         this.observationRegistry = observationRegistry;
         this.retrieverProperties = retrieverProperties;
         this.topicMessageRepository = topicMessageRepository;
-        int threadCount =
-                retrieverProperties.getThreadMultiplier() * Runtime.getRuntime().availableProcessors();
-        scheduler = Schedulers.newParallel("retriever", threadCount, true);
+        scheduler = Schedulers.boundedElastic();
     }
 
     @Override

--- a/grpc/src/main/java/org/hiero/mirror/grpc/retriever/RetrieverProperties.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/retriever/RetrieverProperties.java
@@ -24,9 +24,6 @@ public class RetrieverProperties {
     @NotNull
     private Duration pollingFrequency = Duration.ofSeconds(2L);
 
-    @Min(1)
-    private int threadMultiplier = 4;
-
     @NotNull
     private Duration timeout = Duration.ofSeconds(60L);
 

--- a/grpc/src/main/java/org/hiero/mirror/grpc/service/NetworkServiceImpl.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/service/NetworkServiceImpl.java
@@ -70,7 +70,7 @@ public class NetworkServiceImpl implements NetworkService {
                 .repeatWhen(Repeat.onlyIf(c -> !context.isComplete())
                         .randomBackoff(addressBookProperties.getMinPageDelay(), addressBookProperties.getMaxPageDelay())
                         .jitter(Jitter.random())
-                        .withBackoffScheduler(Schedulers.parallel()))
+                        .withBackoffScheduler(Schedulers.boundedElastic()))
                 .take(filter.getLimit() > 0 ? filter.getLimit() : Long.MAX_VALUE)
                 .doOnNext(context::onNext)
                 .doOnSubscribe(s -> log.info("Querying for address book: {}", filter))


### PR DESCRIPTION
**Description**:

* Change all schedulers to virtual thread compatible scheduler
* Fix gRPC reflection API via ingress and gateway API
* Register cancel handler on subscription
* Remove now unused `hiero.mirror.grpc.retriever.threadMultiplier` property

**Related issue(s)**:

Fixes #12848

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
