### PR TITLE
Revert citus version to 12.1-1 in chart

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -380,7 +380,7 @@ stackgres:
   enabled: false
   extensions:
     - name: citus
-      version: "13.2.0"
+      version: "12.1-1"
     - name: btree_gist
       version: stable
     - name: pg_trgm


### PR DESCRIPTION
**Description**:

This PR reverts the default citus version to `12.1-1` in chart.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
