### PR TITLE
Revert citus version to 12.1-1 in chart (0.147)

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -380,7 +380,7 @@ stackgres:
   enabled: false
   extensions:
     - name: citus
-      version: "13.2.0"
+      version: "12.1-1"
     - name: btree_gist
       version: stable
     - name: pg_trgm


### PR DESCRIPTION
**Description**:

This PR cherry-picks the change to `release/0.147`

- revert citus version to 12.1-1 in default values file

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
