### PR TITLE
Re-enable testnet-eu for public traffic post upgrade

### DIFF
--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
         HIERO_MIRROR_IMPORTER_PARSER_RECORD_SIDECAR_ENABLED: "true"
         HIERO_MIRROR_IMPORTER_START_DATE: "1970-01-01T00:00:00.000000000Z"
     monitor:
-      enabled: false
+      enabled: true
       env:
         HIERO_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "true"
         HIERO_MIRROR_MONITOR_NETWORK: "TESTNET"
@@ -101,4 +101,4 @@ spec:
           size: 180Gi
     test:
       cucumberTags: "@acceptance and not @call and not @estimateprecompile"
-      enabled: false
+      enabled: true


### PR DESCRIPTION
**Description**:

This PR re-enables testnet-eu for public traffic after the upgrade:

- Enable acceptance test
- Enable java monitor

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
