### PR TITLE
Re-enable mainnet-na post upgrade

### DIFF
--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
         HIERO_MIRROR_IMPORTER_RECONCILIATION_ENABLED: "false"
         HIERO_MIRROR_IMPORTER_START_DATE: "1970-01-01T00:00:00.000000000Z"
     monitor:
-      enabled: false
+      enabled: true
       env:
         HIERO_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "true"
         HIERO_MIRROR_MONITOR_NETWORK: "MAINNET"
@@ -117,7 +117,7 @@ spec:
               acceptance:
                 network: MAINNET
       cucumberTags: "@critical"
-      enabled: false
+      enabled: true
     web3:
       env:
         HIERO_MIRROR_WEB3_EVM_NETWORK: MAINNET


### PR DESCRIPTION
**Description**:

This PR re-enables mainnet-na post upgrade:

- enable acceptance tests
- enable java monitor

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

There are some hiccups during the preparation.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
