### PR TITLE
Re-enable mainnet-eu post upgrade

### DIFF
--- a/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
         HIERO_MIRROR_IMPORTER_RECONCILIATION_ENABLED: "false"
         HIERO_MIRROR_IMPORTER_START_DATE: "1970-01-01T00:00:00.000000000Z"
     monitor:
-      enabled: false
+      enabled: true
       env:
         HIERO_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "true"
         HIERO_MIRROR_MONITOR_NETWORK: "MAINNET"
@@ -127,7 +127,7 @@ spec:
               acceptance:
                 network: MAINNET
       cucumberTags: "@critical"
-      enabled: false
+      enabled: true
     web3:
       ingress:
         enabled: true


### PR DESCRIPTION
**Description**:

This PR re-enables mainnet-eu post upgrade:

- enable acceptance tests
- enable java monaitor

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
