### PR TITLE
Remove hook k6 test cases from the default suite

### DIFF
--- a/tools/k6/src/rest-java/test/index.js
+++ b/tools/k6/src/rest-java/test/index.js
@@ -7,8 +7,6 @@ import * as accountsNftAllowanceOwner from './accountsNftAllowanceOwner.js';
 import * as accountsNftAllowanceSpender from './accountsNftAllowanceSpender.js';
 import * as accountsPendingAirdrop from './accountsPendingAirdrop.js';
 import * as accountsOutstandingAirdrop from './accountsOutstandingAirdrop.js';
-import * as hooks from './hooks.js';
-import * as hookStorage from './hookStorage.js';
 import * as networkExchangeRate from './networkExchangeRate.js';
 import * as networkFees from './networkFees.js';
 import * as networkStake from './networkStake.js';
@@ -22,8 +20,6 @@ const tests = {
   accountsNftAllowanceSpender,
   accountsPendingAirdrop,
   accountsOutstandingAirdrop,
-  hooks,
-  hookStorage,
   networkExchangeRate,
   networkFees,
   networkStake,


### PR DESCRIPTION
**Description**:

This PR removes hook k6 test cases from the default suite.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Will create a follow-up ticket to add it back when hook is enabled in mainnet and we have test data ready.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
