### PR TITLE
Fix GCP Marketplace workflow

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -170,7 +170,7 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.34.3-k3s1
+        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.32.12-k3s1
 
       - name: Get tag
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV


### PR DESCRIPTION
**Description**:

Fix GCP Marketplace [workflow](https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/21996627689/job/63571788815) error: `version difference between client (1.31) and server (1.34) exceeds the supported minor version skew of +/-1`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

GCP Marketplace only [supports](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/41a3bfc55bfeade38b243e1a000d67e1ae1ec7fd/marketplace/deployer_helm_base/Dockerfile#L28) Kubernetes 1.31 +/- 1 versions.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
