### PR TITLE
Update test script in package.json

### DIFF
--- a/tools/mirror-report/package.json
+++ b/tools/mirror-report/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "start": "node ./index.js",
-    "test": "node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "type": "module",
   "version": "0.1.6"


### PR DESCRIPTION
**Description**:

The `experimental-specifier-resolution` option was removed in Node.js 19, and since then its presence is accepted (no error is shown) but without any effect. The script now requires Node.js 24, so it's safe to remove the parameter entirely.

**Related issue(s)**:

Fixes: N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
