### PR TITLE
Bump up acceptance test dependencies

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -12,7 +12,6 @@ on:
       - "test/**"
   push:
     branches:
-      - "bump-up-acceptance-test-dependencies"
       - "main"
       - "release/**"
   workflow_dispatch:


### PR DESCRIPTION
**Description**:

This PR bumps up the following acceptance test dependencies

- block node v0.27.0
- consensus node v0.72.0-alpha.2
- solo v0.56.0

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Succesfull run:

https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/22147184811/job/64027669339

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
