### PR TITLE
Volume snapshot script fixes

### DIFF
--- a/tools/cluster-management/utils/utils.sh
+++ b/tools/cluster-management/utils/utils.sh
@@ -846,7 +846,7 @@ function pauseClustersIfNeeded() {
   if [[ "${PAUSE_CLUSTER}" == "true" ]]; then
     for namespace in "${CITUS_NAMESPACES[@]}"; do
       unrouteTraffic "${namespace}"
-      pauseCitus "${namespace}"
+      pauseCitus "${namespace}" "true"
     done
   fi
 }
@@ -855,7 +855,7 @@ function resumeClustersIfNeeded() {
   if [[ "${PAUSE_CLUSTER}" == "true" ]]; then
     for namespace in "${CITUS_NAMESPACES[@]}"; do
       log "Resuming Citus in namespace ${namespace}"
-      unpauseCitus "${namespace}" true
+      unpauseCitus "${namespace}" false
       routeTraffic "${namespace}"
     done
   fi


### PR DESCRIPTION
**Description**:

A volume snapshot was take against mainnet-na and cluster would not come back up. It was observed that the coordinator replica was flapping and failing with

2026-01-21 18:15:23,609 CRITICAL: system ID mismatch, node mirror-citus-coord-1 belongs to a different cluster: 7597877766017639158 != 7384560803740303938

**Root Cause**
When PAUSE_CLUSTER=true, the snapshot script called pauseCitus without skipCleanShutdown, triggering patroniFailoverToFirstPod before scaling down pods. This caused unnecessary leader election and DCS
state changes right before the snapshot.

On resume, resumeClustersIfNeeded called unpauseCitus with reinitializeCitus=true, which deleted the Patroni initialize key from DCS. This key holds the cluster's system_identifier from pg_control.
With it cleared, the first pod to restart re-bootstrapped and wrote its system ID to DCS. If any other pod had a different system identifier on disk (due to the failover-induced inconsistency), Patroni
rejected it with:

system ID mismatch, node mirror-citus-coord-1 belongs to a different cluster

**Fix**
Pass skipCleanShutdown=true to pauseCitus in pauseClustersIfNeeded - avoids patroni failover and DCS mutations before snapshot, letting Kubernetes SIGTERM handle graceful pod shutdown.
Pass reinitializeCitus=false to unpauseCitus in resumeClustersIfNeeded - preserves the initialize key in DCS so all pods resume against the existing system identifier instead of re-bootstrapping.

Fixes #12805

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
