### PR TITLE
Add block label to web3 metrics

### DIFF
--- a/rest-java/build.gradle.kts
+++ b/rest-java/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-health")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-web")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-health")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-web")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))


### PR DESCRIPTION
**Description**:

* Add a `block` label to `hiero.mirror.web3.evm.invocation` metric with `YYYY-MM` or `latest` values
* Fix not publishing cache metrics in rest-java and web3

**Related issue(s)**:

Fixes #13007

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
