### PR TITLE
Add timeout to flux reconcile in cluster management scripts

### DIFF
--- a/tools/cluster-management/copy-live-environment.sh
+++ b/tools/cluster-management/copy-live-environment.sh
@@ -385,7 +385,8 @@ function runAcceptanceTest() {
   suspendKustomization
   kubectl patch helmrelease "${HELM_RELEASE_NAME}" -n "${TEST_KUBE_TARGET_NAMESPACE}" --type merge \
     -p '{"spec": {"values": {"test": {"enabled": true }}}}'
-  flux reconcile helmrelease "${HELM_RELEASE_NAME}" -n "${TEST_KUBE_TARGET_NAMESPACE}"
+  flux reconcile helmrelease "${HELM_RELEASE_NAME}" -n "${TEST_KUBE_TARGET_NAMESPACE}" \
+    --timeout "${FLUX_RECONCILE_HR_TIMEOUT}"
 }
 
 function scaleDownNodePools() {

--- a/tools/cluster-management/utils/utils.sh
+++ b/tools/cluster-management/utils/utils.sh
@@ -323,7 +323,8 @@ function resumeCommonChart() {
       return 1
     fi
     log "Waiting for helmrelease/${HELM_RELEASE_NAME} to become Ready… retrying reconcile"
-    flux reconcile helmrelease "${HELM_RELEASE_NAME}" -n "${COMMON_NAMESPACE}" --with-source >/dev/null 2>&1 || true
+    flux reconcile helmrelease "${HELM_RELEASE_NAME}" -n "${COMMON_NAMESPACE}" \
+      --timeout "${FLUX_RECONCILE_HR_TIMEOUT}" --with-source >/dev/null 2>&1 || true
   done
 
   log "HelmRelease ${HELM_RELEASE_NAME} is Ready"
@@ -892,6 +893,7 @@ AUTO_UNROUTE="${AUTO_UNROUTE:-true}"
 CITUS_NAMESPACES=
 COMMON_NAMESPACE="${COMMON_NAMESPACE:-common}"
 DISK_PREFIX=
+FLUX_RECONCILE_HR_TIMEOUT="${FLUX_RECONCILE_HR_TIMEOUT:-60m}"
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-mirror}"
 KUSTOMIZATION_NAME="${KUSTOMIZATION_NAME:-flux-system}"
 KUSTOMIZATION_NAMESPACE="${KUSTOMIZATION_NAMESPACE:-flux-system}"


### PR DESCRIPTION
**Description**:

This PR adds custom timeout to flux reconcile hr in the scripts

- Add `FLUX_RECONCILE_HR_TIMEOUT` with default of 60m

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
