### PR TITLE
Remove node-flywaydb dependency

### DIFF
--- a/rest/__tests__/globalSetup.js
+++ b/rest/__tests__/globalSetup.js
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {execSync} from 'child_process';
+import {extract} from 'tar';
+import {createGunzip} from 'node:zlib';
+import {pipeline} from 'node:stream/promises';
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
@@ -9,8 +11,8 @@ import {PostgreSqlContainer} from '@testcontainers/postgresql';
 import {isV2Schema} from './testutils.js';
 
 const FLYWAY_DATA_PATH = path.join('.', 'build', process.platform === 'win32' ? 'flyway data' : 'flyway');
-const FLYWAY_EXE_PATH = path.join('.', 'node_modules', 'node-flywaydb', 'bin', 'flyway');
-const FLYWAY_VERSION = '11.8.2';
+const FLYWAY_VERSION = '12.0.3';
+const FLYWAY_EXE_PATH = path.join('.', 'node_modules', 'flyway', FLYWAY_VERSION, 'flyway');
 
 const DB_NAME = 'mirror_node';
 const OWNER_USER = 'mirror_node';
@@ -54,42 +56,44 @@ const createDbContainer = async (workerId) => {
   throw new Error(`Unable to start PostgreSQL container for worker ${workerId} after all attempts`);
 };
 
-const initializeFlyway = () => {
-  const flywayConfigPath = path.join(FLYWAY_DATA_PATH, `config_global.json`);
-  const flywayConfig = {
-    flywayArgs: {
-      url: 'jdbc:postgresql://127.0.0.1:-1/invalid',
-    },
-    version: FLYWAY_VERSION,
-    downloads: {
-      storageDirectory: FLYWAY_DATA_PATH,
-    },
+const initializeFlyway = async () => {
+  if (fs.existsSync(FLYWAY_EXE_PATH)) {
+    console.info(`Found existing Flyway CLI at ${FLYWAY_EXE_PATH}`);
+    return;
+  }
+
+  const platformMap = {
+    darwin: 'macosx-arm64.tar.gz',
+    linux: 'linux-x64.tar.gz',
+    win32: 'windows-x64.zip',
   };
 
-  fs.mkdirSync(FLYWAY_DATA_PATH, {recursive: true});
-  fs.writeFileSync(flywayConfigPath, JSON.stringify(flywayConfig));
-  const command = `node ${FLYWAY_EXE_PATH} -c "${flywayConfigPath}" info`;
-  const options = {stdio: 'pipe'};
+  const destDir = path.dirname(FLYWAY_EXE_PATH);
+  fs.mkdirSync(destDir, {recursive: true});
 
-  let retries = 10;
-  while (retries-- > 0) {
+  const suffix = platformMap[process.platform];
+  const url = `https://github.com/flyway/flyway/releases/download/flyway-${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}-${suffix}`;
+  console.info(`Downloading Flyway from ${url}`);
+
+  for (let i = 0; i < 10; i++) {
     try {
-      execSync(command, options);
-      break;
-    } catch (e) {
-      const errMessage = e.stderr.toString();
-      if (errMessage.includes('-1 not valid')) {
-        console.warn(e.stdout.toString());
-        break;
-      } else {
-        console.warn(errMessage);
+      const response = await fetch(url);
+
+      if (response.ok) {
+        await pipeline(response.body, createGunzip(), extract({cwd: destDir, strip: 1}));
+        console.info(`Downloaded Flyway CLI to ${FLYWAY_EXE_PATH}`);
+        return;
       }
+
+      console.warn(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+      await new Promise((r) => setTimeout(r, 1000));
+    } catch (err) {
+      console.warn(`Failed to download ${url}: ${err}`);
+      await new Promise((r) => setTimeout(r, 1000));
     }
   }
 
-  if (retries < 0) {
-    throw new Error('Failed to initialize flyway');
-  }
+  throw new Error('Failed to initialize flyway');
 };
 
 const startDbContainerServer = () => {
@@ -124,8 +128,8 @@ const startDbContainerServer = () => {
   });
 };
 
-export default () => {
-  initializeFlyway();
+export default async () => {
+  await initializeFlyway();
   startDbContainerServer();
 };
 

--- a/rest/__tests__/integrationContainerOps.js
+++ b/rest/__tests__/integrationContainerOps.js
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 
 import config from '../config';
-import {FLYWAY_DATA_PATH, FLYWAY_EXE_PATH, FLYWAY_VERSION} from './globalSetup';
+import {FLYWAY_DATA_PATH, FLYWAY_EXE_PATH} from './globalSetup';
 import {getModuleDirname, isV2Schema} from './testutils';
 import {getPoolClass} from '../utils';
 import {GenericContainer, PullPolicy, Wait} from 'testcontainers';
@@ -118,49 +118,48 @@ const flywayMigrate = async (connectionParams) => {
   const {database, host, password, port, user} = connectionParams;
   logger.info(`Using flyway CLI to construct schema for jest worker ${workerId} on port ${port}`);
   const jdbcUrl = `jdbc:postgresql://${host}:${port}/${database}`;
-  const flywayConfigPath = path.join(FLYWAY_DATA_PATH, `config_worker_${workerId}.json`);
+  const flywayConfigPath = path.join(FLYWAY_DATA_PATH, `config_worker_${workerId}.toml`);
   const locations = getMigrationScriptLocation(schemaConfigs.locations);
 
-  const flywayConfigObject = {
-    flywayArgs: {
-      baselineOnMigrate: 'true',
-      baselineVersion: schemaConfigs.baselineVersion,
-      locations: `filesystem:${locations}`,
-      password: password,
-      'placeholders.api-password': defaultDbConfig.password,
-      'placeholders.api-user': defaultDbConfig.username,
-      'placeholders.db-name': database,
-      'placeholders.db-user': user,
-      'placeholders.hashShardCount': 2,
-      'placeholders.partitionStartDate': "'1970-01-01'",
-      'placeholders.partitionTimeInterval': "'10years'",
-      'placeholders.topicRunningHashV2AddedTimestamp': 0,
-      'placeholders.transactionHashLookbackInterval': "'60days'",
-      'placeholders.schema': 'public',
-      'placeholders.shardCount': 2,
-      'placeholders.tempSchema': 'temporary',
-      target: 'latest',
-      url: jdbcUrl,
-      user: user,
-    },
-    version: FLYWAY_VERSION,
-    downloads: {
-      storageDirectory: FLYWAY_DATA_PATH,
-    },
-  };
+  const flywayConfig = `
+[environments.default]
+url = "${jdbcUrl}"
+user = "${user}"
+password = "${password}"
+schemas = ["public"]
 
-  const flywayConfig = JSON.stringify(flywayConfigObject, null, 2);
+[flyway.placeholders]
+api-password = "${defaultDbConfig.password}"
+api-user = "${defaultDbConfig.username}"
+db-name = "${database}"
+db-user = "${user}"
+hashShardCount = 2
+partitionStartDate = "'1970-01-01'"
+partitionTimeInterval = "'10years'"
+topicRunningHashV2AddedTimestamp = 0
+transactionHashLookbackInterval = "'60days'"
+schema = "public"
+shardCount = 2
+tempSchema = "temporary"
 
+[flyway]
+locations = ["filesystem:${locations}"]
+baselineOnMigrate = true
+baselineVersion = "0"
+target = "latest"`;
+
+  fs.mkdirSync(FLYWAY_DATA_PATH, {recursive: true});
   fs.writeFileSync(flywayConfigPath, flywayConfig);
-  logger.info(`Added ${flywayConfigPath} to file system for flyway CLI`);
+  logger.info(`Executing flyway migrate with config ${flywayConfigPath}`);
 
   const maxRetries = 10;
   let retries = maxRetries;
   const retryMsDelay = 2000;
+  const command = `${FLYWAY_EXE_PATH} -configFiles="${flywayConfigPath}" migrate`;
 
   while (retries-- > 0) {
     try {
-      execSync(`node ${FLYWAY_EXE_PATH} -c "${flywayConfigPath}" migrate`, {stdio: 'inherit'});
+      execSync(command, {stdio: 'inherit'});
       logger.info(`Successfully executed all Flyway migrations for jest worker ${workerId}`);
       break;
     } catch (e) {

--- a/rest/package-lock.json
+++ b/rest/package-lock.json
@@ -77,12 +77,12 @@
         "jest": "30.2.0",
         "jest-extended": "7.0.0",
         "jest-junit": "16.0.0",
-        "node-flywaydb": "3.0.7",
         "nodemon": "3.1.14",
         "pg-format": "1.0.4",
         "pgsql-parser": "17.9.12",
         "sinon": "21.0.2",
-        "supertest": "7.2.2"
+        "supertest": "7.2.2",
+        "tar": "7.5.10"
       },
       "engines": {
         "node": ">= 24"
@@ -147,6 +147,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -748,6 +749,19 @@
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1621,16 +1635,6 @@
         "testcontainers": "^11.12.0"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
-      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1809,9 +1813,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1920,17 +1924,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2235,25 +2228,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2983,6 +2964,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3212,11 +3194,14 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -3397,14 +3382,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -3767,6 +3749,7 @@
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3931,6 +3914,13 @@
         "node": ">= 8.0"
       }
     },
+    "node_modules/dockerode/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/dockerode/node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -4021,8 +4011,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -4249,6 +4238,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4340,43 +4330,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4430,16 +4383,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fill-range": {
@@ -4669,7 +4612,6 @@
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4881,35 +4823,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -5236,6 +5149,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6804,6 +6718,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -6969,13 +6896,6 @@
         "url": "https://nearley.js.org/#give-to-nearley"
       }
     },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -6984,24 +6904,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-flywaydb": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/node-flywaydb/-/node-flywaydb-3.0.7.tgz",
-      "integrity": "sha512-UzTecD8DgXAdMqc/Gja/vB3Pr3CCgDir7oMfnLqzSk7DwCDKaIQOTKXnLpsh+LiW68Yvum0yPdHAB2p40IkxRg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "commander": "^5.0.0",
-        "extract-zip": "^2.0.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "xml2js": "^0.4.23"
-      },
-      "bin": {
-        "flyway": "bin/flyway.js"
       }
     },
     "node_modules/node-int64": {
@@ -7337,19 +7239,13 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -7623,6 +7519,7 @@
       "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tdigest": "^0.1.1"
       },
@@ -7683,6 +7580,7 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8028,23 +7926,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -8075,16 +7956,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8593,7 +8464,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -8854,6 +8724,23 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -8880,6 +8767,16 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tdigest": {
@@ -9384,30 +9281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9523,27 +9396,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/yocto-queue": {

--- a/rest/package.json
+++ b/rest/package.json
@@ -54,12 +54,12 @@
     "jest": "30.2.0",
     "jest-extended": "7.0.0",
     "jest-junit": "16.0.0",
-    "node-flywaydb": "3.0.7",
     "nodemon": "3.1.14",
     "pg-format": "1.0.4",
     "pgsql-parser": "17.9.12",
     "sinon": "21.0.2",
-    "supertest": "7.2.2"
+    "supertest": "7.2.2",
+    "tar": "7.5.10"
   },
   "peerDependencies": {
     "ansi-regex": "6.2.2",
@@ -76,7 +76,6 @@
   },
   "baseUrlPath": "/api/v1",
   "overrides": {
-    "@tootallnate/once": "3.0.1",
     "glob": "13.0.6",
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
@@ -86,8 +85,7 @@
       "path-to-regexp": "6.3.0",
       "send": "0.19.2"
     },
-    "test-exclude": "7.0.1",
-    "xml2js": "0.6.2"
+    "test-exclude": "7.0.1"
   },
   "bundleDependencies": true
 }


### PR DESCRIPTION
**Description**:

* Add logic to download flyway CLI from GitHub releases
* Bump Flyway from 11.8.2 to 12.0.3
* Convert unsupported Flyway legacy JSON config to TOML
* Remove unsupported `node-flywaydb` dependency

**Related issue(s)**:

Fixes #8169

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
