### PR TITLE
Move docker.io image proxy to a CI variable

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -93,7 +93,7 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+              mirrors = ["${{vars.DOCKER_IO_PROXY}}"]
           version: latest
 
       - name: Build and push images

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -94,7 +94,7 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+              mirrors = ["${{vars.DOCKER_IO_PROXY}}"]
           version: latest
 
       - name: Build and push images
@@ -198,7 +198,7 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+              mirrors = ["${{vars.DOCKER_IO_PROXY}}"]
 
       - name: Build images
         run: ./release.sh "${TAG}"

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -65,7 +65,7 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+              mirrors = ["${{vars.DOCKER_IO_PROXY}}"]
           version: latest
 
       - name: Build Image


### PR DESCRIPTION
**Description**:

Allow the docker.io image pull through cache to be disabled by a CI variable to workaround broken proxy when needed.

**Related issue(s)**:

**Notes for reviewer**:

Successful test run: https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/22774677345/job/66065063415

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
