### PR TITLE
Add migration to update record_file pk (0.150)

### DIFF
--- a/importer/src/main/resources/db/migration/v2/V2.23.4__update_record_file_pk.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.23.4__update_record_file_pk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE record_file
+DROP CONSTRAINT IF EXISTS record_file__pk,
+ADD CONSTRAINT record_file__pk PRIMARY KEY (consensus_end);


### PR DESCRIPTION
(cherry picked from commit 68d1600d4f5bbe59fe7b8a6202ce543f055eb24e)

**Description**:
this pr adds the primary key index accidentally dropped in v2.23.0 migration

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
