### PR TITLE
Switch to self hosted buildkit image in workflows

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: network=host
+          driver-opts: |
+            image=gcr.io/mirrornode/buildkit:buildx-stable-1
+            network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["${{vars.DOCKER_IO_PROXY}}"]

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -91,7 +91,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: network=host
+          driver-opts: |
+            image=gcr.io/mirrornode/buildkit:buildx-stable-1
+            network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["${{vars.DOCKER_IO_PROXY}}"]
@@ -195,7 +197,9 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: network=host
+          driver-opts: |
+            image=gcr.io/mirrornode/buildkit:buildx-stable-1
+            network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["${{vars.DOCKER_IO_PROXY}}"]

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
-          driver-opts: network=host
+          driver-opts: |
+            image=gcr.io/mirrornode/buildkit:buildx-stable-1
+            network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["${{vars.DOCKER_IO_PROXY}}"]


### PR DESCRIPTION
**Description**:

This PR switches to self hosted buildkit image in workflows.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

This will avoid hitting docker hub throttle.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
