### PR TITLE
Fix exchange rate cache in web3 (0.150)

### DIFF
--- a/tools/cluster-management/copy-live-environment.sh
+++ b/tools/cluster-management/copy-live-environment.sh
@@ -345,7 +345,6 @@ function restoreTarget() {
   resumeCommonChart
   patchBackupPaths
   replaceDisks
-  runAcceptanceTest
 }
 
 function deleteSnapshots() {
@@ -702,5 +701,6 @@ function waitForHelmReleaseReady() {
 
 ensureContext K8S_TARGET_CLUSTER_CONTEXT
 restoreEnvironment
+runAcceptanceTest
 runK6Test
 teardownResources

--- a/web3/src/main/java/org/hiero/mirror/web3/Web3Application.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/Web3Application.java
@@ -9,13 +9,15 @@ import org.hiero.mirror.common.CommonConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.util.FileSystemUtils;
 
+@EnableAsync
 @Import(CommonConfiguration.class)
 @SpringBootApplication
 public class Web3Application {
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         cleanup();
         SpringApplication.run(Web3Application.class, args);
     }
@@ -27,7 +29,7 @@ public class Web3Application {
             FileSystemUtils.deleteRecursively(tmpDir);
             Files.createDirectories(tmpDir);
         } catch (IOException ex) {
-            System.err.println("Could not delete tmp directory %s: %s".formatted(tmpDir, ex.getMessage()));
+            System.err.printf("Could not delete tmp directory %s: %s%n", tmpDir, ex.getMessage());
         }
     }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/state/SystemFileLoader.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/SystemFileLoader.java
@@ -37,13 +37,13 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.hiero.mirror.common.CommonProperties;
 import org.hiero.mirror.common.domain.SystemEntity;
 import org.hiero.mirror.common.domain.entity.EntityId;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.web3.evm.properties.EvmProperties;
 import org.hiero.mirror.web3.exception.InvalidFileException;
 import org.hiero.mirror.web3.repository.FileDataRepository;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryPolicy;
@@ -52,7 +52,9 @@ import org.springframework.core.retry.RetryTemplate;
 @Named
 @NullMarked
 @CustomLog
-public class SystemFileLoader {
+public final class SystemFileLoader {
+
+    private static final long NANOS_PER_HOUR = 3600L * DomainUtils.NANOS_PER_SECOND;
 
     private final EvmProperties properties;
     private final FileDataRepository fileDataRepository;
@@ -71,7 +73,7 @@ public class SystemFileLoader {
     @Getter(lazy = true, value = AccessLevel.PRIVATE)
     private final byte[] mockAddressBook = createMockAddressBook();
 
-    @Getter(lazy = true)
+    @Getter(lazy = true, value = AccessLevel.PRIVATE)
     private final Map<FileID, SystemFile> systemFiles = loadAll();
 
     public SystemFileLoader(
@@ -93,19 +95,25 @@ public class SystemFileLoader {
     }
 
     /**
-     * Load system file by id and consensus timestamp. Uses a cache manager chosen by file id: exchange rate file uses
-     * {@value org.hiero.mirror.web3.evm.config.EvmConfiguration#CACHE_MANAGER_EXCHANGE_RATES_SYSTEM_FILE} (e.g. longer
-     * TTL); other system files use
-     * {@value org.hiero.mirror.web3.evm.config.EvmConfiguration#CACHE_MANAGER_SYSTEM_FILE}.
+     * Load system file by id and consensus timestamp.
      */
     public @Nullable File load(FileID fileId, long consensusTimestamp) {
-        // Skip database for network properties so that CN props can't override MN props and cause it to break.
+        // Skip database for network properties so that CN props can't override MN props and cause us to break.
         if (genesisNetworkProperties.fileId().equals(fileId)) {
             return genesisNetworkProperties;
         }
 
+        var cacheManager = defaultSystemFileCacheManager;
+
+        if (fileId.equals(exchangeRateFileId) || fileId.equals(feeSchedulesFileId)) {
+            cacheManager = exchangeRatesCacheManager;
+            consensusTimestamp = roundDownToHour(consensusTimestamp);
+        }
+
         final var cacheKey = new CacheKey(fileId, consensusTimestamp);
-        final var cache = getCacheForFileId(fileId);
+        log.debug("Looking up {}", cacheKey);
+        final var cache = cacheManager.getCache(CACHE_NAME);
+
         if (cache == null) {
             return loadFromDB(fileId, consensusTimestamp);
         }
@@ -119,8 +127,10 @@ public class SystemFileLoader {
         // The value was not in cache -> try to load from DB
         var result = loadFromDB(fileId, consensusTimestamp);
         if (result != null) {
+            log.info("Updating cache for key {}", cacheKey);
             cache.put(cacheKey, result);
         }
+
         return result;
     }
 
@@ -225,10 +235,9 @@ public class SystemFileLoader {
     }
 
     private byte[] createMockAddressBook() {
-        com.hederahashgraph.api.proto.java.NodeAddressBook.Builder builder =
-                com.hederahashgraph.api.proto.java.NodeAddressBook.newBuilder();
+        final var builder = com.hederahashgraph.api.proto.java.NodeAddressBook.newBuilder();
         long nodeId = 3;
-        NodeAddress.Builder nodeAddressBuilder = NodeAddress.newBuilder()
+        final var nodeAddressBuilder = NodeAddress.newBuilder()
                 .addServiceEndpoint(ServiceEndpoint.newBuilder()
                         .setIpAddressV4(ByteString.copyFromUtf8("127.0.0." + nodeId))
                         .setPort((int) nodeId)
@@ -244,21 +253,20 @@ public class SystemFileLoader {
     }
 
     /**
-     * Returns the cache for the given file id: exchange rate file and fee schedule file use the exchange-rates cache
-     * manager (longer TTL). Other system files use the default manager.
-     *
-     * @param fileId the file id
-     * @return the cache for this file id, or null if the manager has no such cache
+     * Rounds the given consensus timestamp (nanoseconds) down to the start of the hour (e.g. 00:00, 01:00, 02:00).
      */
-    private @Nullable Cache getCacheForFileId(FileID fileId) {
-        final var isExchangeRate = fileId.equals(exchangeRateFileId);
-        final var isFeeSchedule = fileId.equals(feeSchedulesFileId);
-        final var useExchangeRatesManager = isExchangeRate || isFeeSchedule;
-        final var manager = useExchangeRatesManager ? exchangeRatesCacheManager : defaultSystemFileCacheManager;
-        return manager.getCache(CACHE_NAME);
+    private long roundDownToHour(long consensusTimestampNanos) {
+        return (consensusTimestampNanos / NANOS_PER_HOUR) * NANOS_PER_HOUR;
     }
 
     private record SystemFile(File genesisFile, @Nullable Codec<?> codec) {}
 
-    private record CacheKey(FileID fileId, long timestamp) {}
+    private record CacheKey(FileID fileId, long timestamp) {
+
+        @Override
+        public String toString() {
+            final var entityId = EntityId.of(fileId.shardNum(), fileId.realmNum(), fileId.fileNum());
+            return "FileId=" + entityId + ", timestamp=" + Instant.ofEpochSecond(0L, timestamp);
+        }
+    }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/state/singleton/MidnightRatesSingleton.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/singleton/MidnightRatesSingleton.java
@@ -7,35 +7,22 @@ import static com.hedera.node.app.fees.schemas.V0490FeeSchema.MIDNIGHT_RATES_STA
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.fees.FeeService;
-import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import jakarta.inject.Named;
 import lombok.SneakyThrows;
 import org.hiero.mirror.common.domain.SystemEntity;
-import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.web3.common.ContractCallContext;
-import org.hiero.mirror.web3.evm.properties.EvmProperties;
 import org.hiero.mirror.web3.state.SystemFileLoader;
 import org.hiero.mirror.web3.state.Utils;
 
 @Named
 final class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
 
-    private static final long NANOS_PER_HOUR = 3600L * DomainUtils.NANOS_PER_SECOND;
-
-    private final ExchangeRateSet cachedExchangeRateSet;
-    private final SystemFileLoader systemFileLoader;
     private final FileID exchangeRateFileId;
+    private final SystemFileLoader systemFileLoader;
 
-    @SneakyThrows
-    public MidnightRatesSingleton(
-            final EvmProperties evmProperties,
-            final SystemFileLoader systemFileLoader,
-            final SystemEntity systemEntity) {
-        V0490FileSchema fileSchema = new V0490FileSchema();
-        this.cachedExchangeRateSet = ExchangeRateSet.PROTOBUF.parse(
-                fileSchema.genesisExchangeRatesBytes(evmProperties.getVersionedConfiguration()));
-        this.systemFileLoader = systemFileLoader;
+    MidnightRatesSingleton(final SystemEntity systemEntity, final SystemFileLoader systemFileLoader) {
         this.exchangeRateFileId = Utils.toFileID(systemEntity.exchangeRateFile());
+        this.systemFileLoader = systemFileLoader;
     }
 
     @Override
@@ -51,31 +38,8 @@ final class MidnightRatesSingleton implements SingletonState<ExchangeRateSet> {
     @SneakyThrows
     @Override
     public ExchangeRateSet get() {
-        final var context = ContractCallContext.get();
-        long timestamp = context.getTimestamp().orElse(Utils.getCurrentTimestamp());
-        // Round the timestamp down to the nearest hour. The file is updated every hour; all timestamps
-        // in that hour use the same file, so round here to reduce DB calls and cache entries.
-        timestamp = roundDownToHour(timestamp);
-
-        // Return result from the transaction cache if possible to avoid unnecessary calls to the DB
-        // and protobuf parsing. The result will be correct since the record file timestamp will be
-        // consistent throughout the transaction execution.
-        final var cache = context.getReadCacheState(getStateId());
-        final var cached = cache.get(timestamp);
-        if (cached instanceof ExchangeRateSet rates) {
-            return rates;
-        }
-
+        long timestamp = ContractCallContext.get().getTimestamp().orElse(Utils.getCurrentTimestamp());
         final var file = systemFileLoader.load(exchangeRateFileId, timestamp);
-        final var rates = file != null ? ExchangeRateSet.PROTOBUF.parse(file.contents()) : cachedExchangeRateSet;
-        cache.put(timestamp, rates);
-        return rates;
-    }
-
-    /**
-     * Rounds the given consensus timestamp (nanoseconds) down to the start of the hour (e.g. 00:00, 01:00, 02:00).
-     */
-    private long roundDownToHour(long consensusTimestampNanos) {
-        return (consensusTimestampNanos / NANOS_PER_HOUR) * NANOS_PER_HOUR;
+        return ExchangeRateSet.PROTOBUF.parse(file.contents());
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/state/SystemFileLoaderIntegrationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/SystemFileLoaderIntegrationTest.java
@@ -152,7 +152,7 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
                 .customize(f -> f.transactionType(FILECREATE.getProtoId())
                         .fileData(EXCHANGE_RATES_SET.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(200L))
+                        .consensusTimestamp(0L))
                 .persist();
 
         // First load - should get from DB
@@ -172,19 +172,21 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
         final var secondLoad = systemFileLoader.load(fileId, 350L);
         assertThat(secondLoad).isNotNull();
         assertThat(secondLoad.contents()).isEqualTo(Bytes.wrap(EXCHANGE_RATES_SET.toByteArray()));
+        assertThat(systemFileLoader.load(fileId, 351L)).isEqualTo(secondLoad);
     }
 
     @Test
     void loadExchangeRatesWithDifferentTimestampsReturnsDifferentCachedResults() {
         final var fileId = toFileID(systemEntity.exchangeRateFile());
         final var entityId = toEntityId(fileId);
+        final var timestamp = 1773810000000000000L;
 
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILECREATE.getProtoId())
                         .fileData(EXCHANGE_RATES_SET.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(100L))
+                        .consensusTimestamp(0L))
                 .persist();
 
         domainBuilder
@@ -192,11 +194,11 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
                         .fileData(EXCHANGE_RATES_SET_2.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(200L))
+                        .consensusTimestamp(timestamp))
                 .persist();
 
         final var resultAtTimestamp1 = systemFileLoader.load(exchangeRateFileId, 150L);
-        final var resultAtTimestamp2 = systemFileLoader.load(exchangeRateFileId, 350L);
+        final var resultAtTimestamp2 = systemFileLoader.load(exchangeRateFileId, timestamp + 100L);
 
         assertThat(resultAtTimestamp1).isNotNull();
         assertThat(resultAtTimestamp1.contents()).isEqualTo(Bytes.wrap(EXCHANGE_RATES_SET.toByteArray()));
@@ -206,7 +208,7 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
 
         // Verify the cache returns the same distinct results on subsequent calls
         final var cachedResult1 = systemFileLoader.load(exchangeRateFileId, 150L);
-        final var cachedResult2 = systemFileLoader.load(exchangeRateFileId, 350L);
+        final var cachedResult2 = systemFileLoader.load(exchangeRateFileId, timestamp);
 
         assertThat(cachedResult1.contents()).isEqualTo(resultAtTimestamp1.contents());
         assertThat(cachedResult2.contents()).isEqualTo(resultAtTimestamp2.contents());
@@ -217,13 +219,14 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
     void loadFeeScheduleCachingBehavior() {
         final var fileId = toFileID(systemEntity.feeScheduleFile());
         final var entityId = toEntityId(fileId);
+        final var timestamp = 1773810000000000000L;
 
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILECREATE.getProtoId())
                         .fileData(FEE_SCHEDULE.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(200L))
+                        .consensusTimestamp(0L))
                 .persist();
 
         final var firstLoad = systemFileLoader.load(fileId, 350L);
@@ -235,25 +238,27 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
                         .fileData(FEE_SCHEDULE_2.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(300L))
+                        .consensusTimestamp(timestamp))
                 .persist();
 
         final var secondLoad = systemFileLoader.load(fileId, 350L);
         assertThat(secondLoad).isNotNull();
         assertThat(secondLoad.contents()).isEqualTo(Bytes.wrap(FEE_SCHEDULE.toByteArray()));
+        assertThat(systemFileLoader.load(fileId, 351L)).isEqualTo(secondLoad);
     }
 
     @Test
     void loadFeeScheduleWithDifferentTimestampsReturnsDifferentCachedResults() {
         final var fileId = toFileID(systemEntity.feeScheduleFile());
         final var entityId = toEntityId(fileId);
+        final var timestamp = 1773810000000000000L;
 
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILECREATE.getProtoId())
                         .fileData(FEE_SCHEDULE.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(100L))
+                        .consensusTimestamp(0L))
                 .persist();
 
         domainBuilder
@@ -261,11 +266,11 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
                         .fileData(FEE_SCHEDULE_2.toByteArray())
                         .entityId(entityId)
-                        .consensusTimestamp(200L))
+                        .consensusTimestamp(timestamp))
                 .persist();
 
         final var resultAt150 = systemFileLoader.load(feeScheduleFileId, 150L);
-        final var resultAt350 = systemFileLoader.load(feeScheduleFileId, 350L);
+        final var resultAt350 = systemFileLoader.load(feeScheduleFileId, timestamp + 350L);
 
         assertThat(resultAt150).isNotNull();
         assertThat(resultAt150.contents()).isEqualTo(Bytes.wrap(FEE_SCHEDULE.toByteArray()));
@@ -273,7 +278,7 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
         assertThat(resultAt350.contents()).isEqualTo(Bytes.wrap(FEE_SCHEDULE_2.toByteArray()));
 
         final var cachedResult1 = systemFileLoader.load(feeScheduleFileId, 150L);
-        final var cachedResult2 = systemFileLoader.load(feeScheduleFileId, 350L);
+        final var cachedResult2 = systemFileLoader.load(feeScheduleFileId, timestamp + 350L);
 
         assertThat(cachedResult1.contents()).isEqualTo(resultAt150.contents());
         assertThat(cachedResult2.contents()).isEqualTo(resultAt350.contents());
@@ -305,13 +310,14 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
     void loadFileReturnsCorrectWithEmptyAndValidFile(EntityId entityId, byte[] fileData) {
         // Setup
         final var fileId = toFileID(entityId);
+        final var timestamp = 1773810000000000000L;
 
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILECREATE.getProtoId())
                         .fileData(EMPTY_BYTES)
                         .entityId(entityId)
-                        .consensusTimestamp(100L))
+                        .consensusTimestamp(0L))
                 .persist();
 
         domainBuilder
@@ -319,10 +325,10 @@ class SystemFileLoaderIntegrationTest extends Web3IntegrationTest {
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
                         .fileData(fileData)
                         .entityId(entityId)
-                        .consensusTimestamp(200L))
+                        .consensusTimestamp(timestamp))
                 .persist();
 
-        final var actualFile = systemFileLoader.load(fileId, 350L);
+        final var actualFile = systemFileLoader.load(fileId, timestamp);
         assertThat(actualFile).isNotNull();
         assertThat(actualFile.contents()).isEqualTo(Bytes.wrap(fileData));
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/singleton/MidnightRatesSingletonTest.java
@@ -4,46 +4,21 @@ package org.hiero.mirror.web3.state.singleton;
 
 import static com.hedera.node.app.fees.schemas.V0490FeeSchema.MIDNIGHT_RATES_STATE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hiero.mirror.web3.state.Utils.toFileID;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.TimestampSeconds;
-import com.hedera.hapi.node.state.file.File;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.config.data.BootstrapConfig;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.hiero.mirror.common.domain.SystemEntity;
-import org.hiero.mirror.common.domain.transaction.RecordFile;
-import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.web3.Web3IntegrationTest;
-import org.hiero.mirror.web3.common.ContractCallContext;
 import org.hiero.mirror.web3.evm.properties.EvmProperties;
-import org.hiero.mirror.web3.service.model.CallServiceParameters;
-import org.hiero.mirror.web3.state.SystemFileLoader;
-import org.hiero.mirror.web3.viewmodel.BlockType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @RequiredArgsConstructor
-class MidnightRatesSingletonTest extends Web3IntegrationTest {
-
-    private static final long NANOS_PER_HOUR = 3600L * DomainUtils.NANOS_PER_SECOND;
+final class MidnightRatesSingletonTest extends Web3IntegrationTest {
 
     private final MidnightRatesSingleton midnightRatesSingleton;
     private final EvmProperties evmProperties;
-    private final SystemEntity systemEntity;
-    private FileID exchangeRateFileId;
-
-    @BeforeEach
-    void setUp() {
-        exchangeRateFileId = toFileID(systemEntity.exchangeRateFile());
-    }
 
     @Test
     void get() {
@@ -67,134 +42,5 @@ class MidnightRatesSingletonTest extends Web3IntegrationTest {
     @Test
     void key() {
         assertThat(midnightRatesSingleton.getStateId()).isEqualTo(MIDNIGHT_RATES_STATE_ID);
-    }
-
-    @Test
-    void getExchangeRateWithTimestampRoundsDown() {
-        final SystemFileLoader systemFileLoader = mock(SystemFileLoader.class);
-        final var midnightRatesSingleton = new MidnightRatesSingleton(evmProperties, systemFileLoader, systemEntity);
-
-        final var exchangeRate = ExchangeRateSet.newBuilder()
-                .currentRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(1)
-                        .centEquiv(2)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(1))
-                        .build())
-                .nextRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(3)
-                        .centEquiv(4)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(2))
-                        .build())
-                .build();
-
-        when(systemFileLoader.load(eq(exchangeRateFileId), eq(0L))).thenReturn(fileWithRates(exchangeRate));
-
-        long consensusTimestamp = 100;
-        final CallServiceParameters params = mock(CallServiceParameters.class);
-        when(params.getBlock()).thenReturn(BlockType.of("123"));
-        final ExchangeRateSet result = ContractCallContext.run(ctx -> {
-            ctx.setCallServiceParameters(params);
-            ctx.setTimestamp(Optional.of(consensusTimestamp));
-            ctx.setBlockSupplier(
-                    () -> RecordFile.builder().consensusEnd(consensusTimestamp).build());
-            return midnightRatesSingleton.get();
-        });
-
-        assertThat(result).isEqualTo(exchangeRate);
-    }
-
-    @Test
-    void getExchangeRateWithTimestampRoundsDownToCorrectExchangeRate() {
-        final SystemFileLoader systemFileLoader = mock(SystemFileLoader.class);
-        final var midnightRatesSingleton = new MidnightRatesSingleton(evmProperties, systemFileLoader, systemEntity);
-
-        final var exchangeRate = ExchangeRateSet.newBuilder()
-                .currentRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(1)
-                        .centEquiv(2)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(1L))
-                        .build())
-                .nextRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(3)
-                        .centEquiv(4)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(2L))
-                        .build())
-                .build();
-
-        final var exchangeRate2 = ExchangeRateSet.newBuilder()
-                .currentRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(3)
-                        .centEquiv(4)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(2L))
-                        .build())
-                .nextRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(5)
-                        .centEquiv(6)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(3L))
-                        .build())
-                .build();
-
-        when(systemFileLoader.load(eq(exchangeRateFileId), eq(0L))).thenReturn(fileWithRates(exchangeRate));
-        when(systemFileLoader.load(eq(exchangeRateFileId), eq(NANOS_PER_HOUR)))
-                .thenReturn(fileWithRates(exchangeRate2));
-
-        long consensusTimestamp = NANOS_PER_HOUR + 10;
-        final CallServiceParameters params = mock(CallServiceParameters.class);
-        when(params.getBlock()).thenReturn(BlockType.of("123"));
-        final ExchangeRateSet result = ContractCallContext.run(ctx -> {
-            ctx.setCallServiceParameters(params);
-            ctx.setTimestamp(Optional.of(consensusTimestamp));
-            ctx.setBlockSupplier(
-                    () -> RecordFile.builder().consensusEnd(consensusTimestamp).build());
-            return midnightRatesSingleton.get();
-        });
-
-        assertThat(result).isEqualTo(exchangeRate2);
-    }
-
-    @Test
-    void getExchangeRateWithLatestBlock() {
-        final SystemFileLoader systemFileLoader = mock(SystemFileLoader.class);
-        final var midnightRatesSingleton = new MidnightRatesSingleton(evmProperties, systemFileLoader, systemEntity);
-
-        final var exchangeRate = ExchangeRateSet.newBuilder()
-                .currentRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(1)
-                        .centEquiv(2)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(1))
-                        .build())
-                .nextRate(ExchangeRate.newBuilder()
-                        .hbarEquiv(3)
-                        .centEquiv(4)
-                        .expirationTime(TimestampSeconds.newBuilder().seconds(2))
-                        .build())
-                .build();
-
-        // We use getCurrentTimestamp() in this case so we can't pass a more specific value
-        when(systemFileLoader.load(eq(exchangeRateFileId), anyLong())).thenReturn(fileWithRates(exchangeRate));
-
-        long consensusTimestamp = 100;
-        final CallServiceParameters params = mock(CallServiceParameters.class);
-        when(params.getBlock()).thenReturn(BlockType.LATEST);
-        final ExchangeRateSet result = ContractCallContext.run(ctx -> {
-            ctx.setCallServiceParameters(params);
-            ctx.setBlockSupplier(
-                    () -> RecordFile.builder().consensusEnd(consensusTimestamp).build());
-            return midnightRatesSingleton.get();
-        });
-
-        assertThat(result).isEqualTo(exchangeRate);
-    }
-
-    private File fileWithRates(ExchangeRateSet exchangeRateSet) {
-        final var fileId = systemEntity.exchangeRateFile();
-        return File.newBuilder()
-                .fileId(FileID.newBuilder()
-                        .shardNum(fileId.getShard())
-                        .realmNum(fileId.getRealm())
-                        .fileNum(fileId.getNum())
-                        .build())
-                .contents(ExchangeRateSet.PROTOBUF.toBytes(exchangeRateSet))
-                .build();
     }
 }


### PR DESCRIPTION
**Description**:

Cherry pick of #13162 to `release/0.150`:

* Fix running of acceptance tests in copy environment script
* Fix web3 crashing on startup when database is unavailable
* Fix the performance regression caused by #12943 by ensuring timestamp is normalized to nearest hour.

**Related issue(s)**:

Fixes #13114

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
