### PR TITLE
Fix non-zero realm issues

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/config/RestJavaConfiguration.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/config/RestJavaConfiguration.java
@@ -12,9 +12,11 @@ import com.hedera.node.app.workflows.standalone.TransactionExecutors;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.common.CommonProperties;
 import org.hiero.mirror.restjava.jooq.DomainRecordMapperProvider;
 import org.hiero.mirror.restjava.service.fee.FeeEstimationState;
 import org.hiero.mirror.restjava.service.fee.FeeProperties;
@@ -49,12 +51,16 @@ class RestJavaConfiguration {
     }
 
     @Bean
-    StandaloneFeeCalculator standaloneFeeCalculator(FeeEstimationState feeEstimationState) {
+    StandaloneFeeCalculator standaloneFeeCalculator(
+            CommonProperties commonProperties, FeeEstimationState feeEstimationState) {
+        final var overrideValues = new HashMap<>(INTRINSIC_PROPERTIES);
+        overrideValues.put("hedera.realm", String.valueOf(commonProperties.getRealm()));
+        overrideValues.put("hedera.shard", String.valueOf(commonProperties.getShard()));
         final var properties = TransactionExecutors.Properties.newBuilder()
                 .state(feeEstimationState)
-                .appProperties(INTRINSIC_PROPERTIES)
+                .appProperties(overrideValues)
                 .build();
-        final var config = new ConfigProviderImpl(false, null, INTRINSIC_PROPERTIES).getConfiguration();
+        final var config = new ConfigProviderImpl(false, null, overrideValues).getConfiguration();
         return new StandaloneFeeCalculatorImpl(feeEstimationState, properties, new AppEntityIdFactory(config));
     }
 

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/controller/NetworkController.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/controller/NetworkController.java
@@ -135,7 +135,8 @@ final class NetworkController {
 
     @GetMapping("/nodes")
     ResponseEntity<NetworkNodesResponse> getNodes(@RequestParameter NetworkNodeRequest request) {
-        if (request.getFileId().operator() != RangeOperator.EQ) {
+        final var fileId = request.getFileId();
+        if (fileId != null && fileId.operator() != RangeOperator.EQ) {
             throw new IllegalArgumentException("Only equality operator is supported for file.id");
         }
         final var networkNodeRows = networkService.getNetworkNodes(request);

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeRequest.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeRequest.java
@@ -13,8 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hiero.mirror.restjava.common.RangeOperator;
 import org.hiero.mirror.restjava.parameter.EntityIdRangeParameter;
+import org.hiero.mirror.restjava.parameter.NumberRangeParameter;
 import org.hiero.mirror.restjava.parameter.RestJavaQueryParam;
 import org.springframework.data.domain.Sort.Direction;
 
@@ -31,12 +31,11 @@ public class NetworkNodeRequest {
     public static final int MAX_LIMIT = 25;
 
     @RestJavaQueryParam(name = FILE_ID, required = false)
-    @Builder.Default
-    private EntityIdRangeParameter fileId = new EntityIdRangeParameter(RangeOperator.EQ, 102L);
+    private EntityIdRangeParameter fileId;
 
     @RestJavaQueryParam(name = NODE_ID, required = false)
     @Builder.Default
-    private List<EntityIdRangeParameter> nodeIds = List.of();
+    private List<NumberRangeParameter> nodeIds = List.of();
 
     @RestJavaQueryParam(name = LIMIT, required = false)
     @Builder.Default

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/service/NetworkServiceImpl.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/service/NetworkServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.common.domain.SystemEntity;
 import org.hiero.mirror.common.domain.addressbook.NetworkStake;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.restjava.common.RangeOperator;
@@ -34,6 +35,7 @@ final class NetworkServiceImpl implements NetworkService {
     private final NetworkStakeRepository networkStakeRepository;
     private final NetworkProperties networkProperties;
     private final NetworkNodeRepository networkNodeRepository;
+    private final SystemEntity systemEntity;
 
     @Override
     public NetworkStake getLatestNetworkStake() {
@@ -85,7 +87,7 @@ final class NetworkServiceImpl implements NetworkService {
 
     @Override
     public List<NetworkNodeDto> getNetworkNodes(NetworkNodeRequest request) {
-        final var fileId = request.getFileId().value();
+        final long fileId = getAddressBookFileId(request);
         final var limit = request.getEffectiveLimit();
         final var nodeIdParams = request.getNodeIds();
         final var orderDirection = request.getOrder().name();
@@ -121,5 +123,11 @@ final class NetworkServiceImpl implements NetworkService {
 
         return networkNodeRepository.findNetworkNodes(
                 fileId, nodeIdArray, lowerBound, upperBound, orderDirection, limit);
+    }
+
+    private long getAddressBookFileId(final NetworkNodeRequest request) {
+        return request.getFileId() != null
+                ? request.getFileId().value()
+                : systemEntity.addressBookFile102().getId();
     }
 }

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/controller/NetworkControllerTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/controller/NetworkControllerTest.java
@@ -1114,7 +1114,6 @@ final class NetworkControllerTest extends ControllerTest {
                     .addressBook()
                     .customize(ab -> ab.startConsensusTimestamp(timestamp))
                     .persist();
-            var fileId = addressBook.getFileId().getId();
 
             // Create 3 network nodes linked to this address book
             domainBuilder
@@ -1133,7 +1132,7 @@ final class NetworkControllerTest extends ControllerTest {
             // when
             final var actual = restClient
                     .get()
-                    .uri("?file.id=" + fileId)
+                    .uri("?file.id=" + addressBook.getFileId())
                     .retrieve()
                     .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
 

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/repository/NetworkNodeRepositoryTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/repository/NetworkNodeRepositoryTest.java
@@ -5,13 +5,23 @@ package org.hiero.mirror.restjava.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.common.domain.SystemEntity;
 import org.hiero.mirror.restjava.RestJavaIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @RequiredArgsConstructor
 final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
 
     private final NetworkNodeRepository networkNodeRepository;
+    private final SystemEntity systemEntity;
+
+    private long fileId102;
+
+    @BeforeEach
+    void setup() {
+        fileId102 = systemEntity.addressBookFile102().getId();
+    }
 
     @Test
     void findNetworkNodesWithNoFilters() {
@@ -19,7 +29,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(3);
@@ -69,7 +79,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[] {1L}, 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[] {1L}, 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -82,7 +92,8 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[] {1L, 3L}, 0L, Long.MAX_VALUE, "ASC", 25);
+        var results =
+                networkNodeRepository.findNetworkNodes(fileId102, new Long[] {1L, 3L}, 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(2);
@@ -96,7 +107,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 2L, 3L, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 2L, 3L, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(2);
@@ -110,7 +121,8 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when - combining equality (1L, 3L) and range (>=2L)
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[] {1L, 3L}, 2L, Long.MAX_VALUE, "ASC", 25);
+        var results =
+                networkNodeRepository.findNetworkNodes(fileId102, new Long[] {1L, 3L}, 2L, Long.MAX_VALUE, "ASC", 25);
 
         // then - should return nodes matching equality AND range (node 3 matches both conditions)
         assertThat(results).isNotNull().hasSize(1);
@@ -123,7 +135,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(3);
@@ -138,7 +150,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "DESC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "DESC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(3);
@@ -153,7 +165,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 2);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 2);
 
         // then
         assertThat(results).isNotNull().hasSize(2);
@@ -167,7 +179,8 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[] {99999L}, 0L, Long.MAX_VALUE, "ASC", 25);
+        var results =
+                networkNodeRepository.findNetworkNodes(fileId102, new Long[] {99999L}, 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().isEmpty();
@@ -188,7 +201,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         domainBuilder.nodeStake().customize(ns -> ns.nodeId(1L)).persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -215,7 +228,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         domainBuilder.node().customize(n -> n.nodeId(1L)).persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -239,7 +252,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
                 .persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -263,7 +276,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         domainBuilder.node().customize(n -> n.nodeId(1L)).persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -299,7 +312,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
                 .persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);
@@ -339,7 +352,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
                 .persist();
 
         // when - no fileId filter, should return latest address book
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then - should only return nodes from latest address book
         assertThat(results).isNotNull().hasSize(1);
@@ -373,7 +386,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
                 .persist();
 
         // when
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, Long.MAX_VALUE, "ASC", 25);
 
         // then - should use latest node stake
         assertThat(results).isNotNull().hasSize(1);
@@ -421,7 +434,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when - min range equals a node id
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 1L, Long.MAX_VALUE, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 1L, Long.MAX_VALUE, "ASC", 25);
 
         // then - should include the min value
         assertThat(results).isNotNull().hasSize(3);
@@ -434,7 +447,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when - max range equals a node id
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 0L, 2L, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 0L, 2L, "ASC", 25);
 
         // then - should include the max value
         assertThat(results).isNotNull().hasSize(2);
@@ -447,7 +460,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         setupNetworkNodeData();
 
         // when - range that includes only one node
-        var results = networkNodeRepository.findNetworkNodes(102L, new Long[0], 2L, 2L, "ASC", 25);
+        var results = networkNodeRepository.findNetworkNodes(fileId102, new Long[0], 2L, 2L, "ASC", 25);
 
         // then
         assertThat(results).isNotNull().hasSize(1);

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/service/FeeEstimationServiceTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/service/FeeEstimationServiceTest.java
@@ -22,6 +22,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -193,11 +194,14 @@ final class FeeEstimationServiceTest extends RestJavaIntegrationTest {
     void loadsSimpleFeeScheduleFromDatabase() {
         // given
         final var state = new FeeEstimationState(systemEntity, fileService);
+        final var overrideValues = new HashMap<>(INTRINSIC_PROPERTIES);
+        overrideValues.put("hedera.realm", String.valueOf(commonProperties.getRealm()));
+        overrideValues.put("hedera.shard", String.valueOf(commonProperties.getShard()));
         final var properties = TransactionExecutors.Properties.newBuilder()
                 .state(state)
-                .appProperties(INTRINSIC_PROPERTIES)
+                .appProperties(overrideValues)
                 .build();
-        final var config = new ConfigProviderImpl(false, null, INTRINSIC_PROPERTIES).getConfiguration();
+        final var config = new ConfigProviderImpl(false, null, overrideValues).getConfiguration();
         final var calculator = new StandaloneFeeCalculatorImpl(state, properties, new AppEntityIdFactory(config));
         final var freshService = new FeeEstimationService(calculator);
 

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/service/NetworkServiceTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/service/NetworkServiceTest.java
@@ -12,6 +12,7 @@ import org.hiero.mirror.restjava.RestJavaIntegrationTest;
 import org.hiero.mirror.restjava.common.RangeOperator;
 import org.hiero.mirror.restjava.dto.NetworkNodeRequest;
 import org.hiero.mirror.restjava.parameter.EntityIdRangeParameter;
+import org.hiero.mirror.restjava.parameter.NumberRangeParameter;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Sort;
 
@@ -96,7 +97,7 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var fileId = setupNetworkNodeData();
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
-                .nodeIds(List.of(new EntityIdRangeParameter(RangeOperator.EQ, 1L)))
+                .nodeIds(List.of(new NumberRangeParameter(RangeOperator.EQ, 1L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -117,8 +118,8 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.GTE, 1L),
-                        new EntityIdRangeParameter(RangeOperator.LTE, 2L)))
+                        new NumberRangeParameter(RangeOperator.GTE, 1L),
+                        new NumberRangeParameter(RangeOperator.LTE, 2L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -140,9 +141,9 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.EQ, 2L),
-                        new EntityIdRangeParameter(RangeOperator.EQ, 3L),
-                        new EntityIdRangeParameter(RangeOperator.GTE, 2L)))
+                        new NumberRangeParameter(RangeOperator.EQ, 2L),
+                        new NumberRangeParameter(RangeOperator.EQ, 3L),
+                        new NumberRangeParameter(RangeOperator.GTE, 2L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -208,7 +209,7 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var fileId = setupNetworkNodeData();
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
-                .nodeIds(List.of(new EntityIdRangeParameter(RangeOperator.EQ, 99999L)))
+                .nodeIds(List.of(new NumberRangeParameter(RangeOperator.EQ, 99999L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -262,8 +263,8 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.GTE, 1L),
-                        new EntityIdRangeParameter(RangeOperator.GTE, 2L)))
+                        new NumberRangeParameter(RangeOperator.GTE, 1L),
+                        new NumberRangeParameter(RangeOperator.GTE, 2L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -285,8 +286,8 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.LTE, 3L),
-                        new EntityIdRangeParameter(RangeOperator.LTE, 2L)))
+                        new NumberRangeParameter(RangeOperator.LTE, 3L),
+                        new NumberRangeParameter(RangeOperator.LTE, 2L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -308,8 +309,7 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.GT, 4L),
-                        new EntityIdRangeParameter(RangeOperator.LT, 5L)))
+                        new NumberRangeParameter(RangeOperator.GT, 4L), new NumberRangeParameter(RangeOperator.LT, 5L)))
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();
@@ -327,9 +327,9 @@ final class NetworkServiceTest extends RestJavaIntegrationTest {
         var request = NetworkNodeRequest.builder()
                 .fileId(new EntityIdRangeParameter(RangeOperator.EQ, fileId.getId()))
                 .nodeIds(List.of(
-                        new EntityIdRangeParameter(RangeOperator.EQ, 1L), // Node 1 exists
-                        new EntityIdRangeParameter(RangeOperator.EQ, 2L), // Node 2 exists
-                        new EntityIdRangeParameter(RangeOperator.GT, 10L))) // Range gt:10 excludes nodes 1, 2
+                        new NumberRangeParameter(RangeOperator.EQ, 1L), // Node 1 exists
+                        new NumberRangeParameter(RangeOperator.EQ, 2L), // Node 2 exists
+                        new NumberRangeParameter(RangeOperator.GT, 10L))) // Range gt:10 excludes nodes 1, 2
                 .limit(25)
                 .order(Sort.Direction.ASC)
                 .build();

--- a/rest/__tests__/integration/template.js
+++ b/rest/__tests__/integration/template.js
@@ -15,7 +15,6 @@
  */
 
 // external libraries
-import crypto from 'crypto';
 import fs from 'fs';
 import {jest} from '@jest/globals';
 import _ from 'lodash';
@@ -129,7 +128,7 @@ const getSpecs = async () => {
 const readAndTransformSpec = (filepath) => {
   const text = fs.readFileSync(filepath, 'utf8');
   const spec = JSONParse(text);
-  const transformed = filepath.indexOf('stateproof') > -1 ? spec : transformShardRealmValues(spec);
+  const transformed = transformShardRealmValues(spec);
   transformed.name = path.basename(filepath);
   return transformed;
 };

--- a/rest/__tests__/integrationDomainOps.js
+++ b/rest/__tests__/integrationDomainOps.js
@@ -651,10 +651,11 @@ const addEntity = async (defaults, custom) => {
 };
 
 const addEntityTransaction = async (entityTransaction) => {
-  entityTransaction.entity_id = encodedIdFromSpecValue(entityTransaction.entity_id);
-  entityTransaction.payer_account_id = encodedIdFromSpecValue(entityTransaction.payer_account_id);
+  const clone = {...entityTransaction};
+  clone.entity_id = encodedIdFromSpecValue(entityTransaction.entity_id);
+  clone.payer_account_id = encodedIdFromSpecValue(entityTransaction.payer_account_id);
 
-  await insertDomainObject('entity_transaction', Object.keys(entityTransaction), entityTransaction);
+  await insertDomainObject('entity_transaction', Object.keys(clone), clone);
 };
 
 const SECONDS_PER_DAY = 86400;


### PR DESCRIPTION
**Description**:

This PR fixes non-zero realm issues in rest and rest-java:

- Fix entity ids in `EntityTransaction` domain object encoded with non-zero realm shard/realm multiple times
- Fix rest-java not setting hedera.shard/hedera.realm
- Fix rest-java network nodes endpoint handling of fileId and nodeId
- Fix rest-java test cases
 
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
