### PR TITLE
Allow using a smart contract sender in a contract call

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -247,6 +247,8 @@ public class TransactionExecutionService {
         final var account = accountReadableKVState.get(accountIDNum);
         if (account == null) {
             throwPayerAccountNotFoundException(SENDER_NOT_FOUND);
+        } else if (account.smartContract()) {
+            return EntityIdUtils.toAccountId(systemEntity.treasuryAccount());
         } else if (!account.hasKey() || account.key().equals(IMMUTABILITY_SENTINEL_KEY)) {
             // If the account is hollow, complete it in the state as a workaround
             // as this happens in HandleWorkflow in hedera-app but calling the

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -815,8 +815,9 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
-    @Test
-    void createFungibleToken() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void createFungibleToken(final boolean isSenderSmartContract) throws Exception {
         // Given
         final var value = 10000L * 100_000_000_000L;
         final var sender = accountEntityWithSufficientBalancePersist();
@@ -827,7 +828,10 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
         testWeb3jService.setValue(value);
 
-        testWeb3jService.setSender(toAddress(sender.toEntityId()).toHexString());
+        testWeb3jService.setSender(
+                isSenderSmartContract
+                        ? contract.getContractAddress()
+                        : toAddress(sender.toEntityId()).toHexString());
 
         final var treasuryAccount = accountEntityPersist();
 

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
@@ -8,10 +8,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hiero.mirror.common.util.DomainUtils.toEvmAddress;
 import static org.hiero.mirror.web3.convert.BytesDecoder.hexToBytes;
 import static org.hiero.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
-import static org.hiero.mirror.web3.service.utils.KeyValueType.CONTRACT_ID;
-import static org.hiero.mirror.web3.service.utils.KeyValueType.DELEGATABLE_CONTRACT_ID;
-import static org.hiero.mirror.web3.service.utils.KeyValueType.ECDSA_SECPK256K1;
-import static org.hiero.mirror.web3.service.utils.KeyValueType.ED25519;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.ECDSA_KEY;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.ED25519_KEY;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.KEY_WITH_ECDSA_TYPE;
@@ -222,7 +218,24 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
         // When
         final var functionCall =
                 contract.call_isTokenAddress(toAddress(token.getTokenId()).toHexString());
+        // Then
+        assertThat(functionCall.send()).isTrue();
 
+        verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+    }
+
+    @Test
+    void isTokenAddressWithSenderSmartContract() throws Exception {
+        // Given
+        final var token = fungibleTokenPersist();
+        final var tokenId = token.getTokenId();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isTokenAddress(toAddress(token.getTokenId()).toHexString());
+        testWeb3jService.setSender(contract.getContractAddress());
         // Then
         assertThat(functionCall.send()).isTrue();
 

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallServiceTest.java
@@ -512,7 +512,7 @@ final class ContractCallServiceTest extends ContractCallServicePrecompileHistori
     }
 
     @Test
-    void ethCallWithValueAndSenderContractFails() {
+    void ethCallWithValueAndSenderContractSucceeds() {
         // Given
         final var receiverEntity = accountEntityWithEvmAddressPersist();
         final var receiverAddress = getAliasAddressFromEntity(receiverEntity);
@@ -521,13 +521,11 @@ final class ContractCallServiceTest extends ContractCallServicePrecompileHistori
         final var serviceParameters = getContractExecutionParametersWithValue(
                 BlockType.LATEST, HEX_PREFIX, contractAddress, receiverAddress, 10L);
 
-        // Then
-        assertThatThrownBy(() -> contractExecutionService.processCall(serviceParameters))
-                .isInstanceOf(MirrorEvmTransactionException.class)
-                .extracting("detail")
-                .asString()
-                .matches(".*payer account .* is a smart contract.*");
+        // When
+        final var result = contractExecutionService.processCall(serviceParameters);
 
+        // Then
+        assertThat(result).isEqualTo(HEX_PREFIX);
         assertGasLimit(serviceParameters);
     }
 


### PR DESCRIPTION
**Description**:
In order to be Ethereum compatible we need to allow contract calls when the sender is a smart contract. This PR identifies this scenario and replaces in memory the smart contract sender account with the default treasury account. This way we workaround the inherited from hedera-app checks. Any other approach would require changes (and a flag) upstream.

Fixes #13221 