### PR TITLE
Fix mirror_web3 pgbouncer worker user connection lmit

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -372,8 +372,8 @@ stackgres:
           max_user_client_connections: 1000
           max_user_connections: 250
         mirror_web3:
-          max_user_client_connections: 1800
-          max_user_connections: 275
+          max_user_client_connections: 1000
+          max_user_connections: 250
     resources:
       cpu: 100m
       memory: 1Gi
@@ -437,6 +437,9 @@ stackgres:
           pool_mode: session
         mirror_importer:
           pool_mode: session
+        mirror_web3:
+          max_user_client_connections: 1800
+          max_user_connections: 275
     replicasPerInstance: 1
     resources:
       cpu: 100m


### PR DESCRIPTION
**Description**:

This PR fixes mirror_web3 pgbouncer worker user connection limit:

- Add the worker user connection limit to the worker section
- Revert accidental changes to the coordinator section

**Related issue(s)**:

Fixes #13244 

**Notes for reviewer**:

I reverted the changes for coordinator. Note we have two coordinators, so the effective limit is twice of the number in the config.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
