### PR TITLE
feat(rest): add file metadata rest api

### DIFF
--- a/rest/__tests__/integration/fileController.test.js
+++ b/rest/__tests__/integration/fileController.test.js
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import request from 'supertest';
+import EntityId from '../../entityId';
+import integrationDomainOps from '../integrationDomainOps';
+import {setupIntegrationTest} from '../integrationUtils';
+import server from '../../server';
+import {apiPrefix} from '../../constants';
+
+setupIntegrationTest();
+
+describe('FileController integration tests', () => {
+  test('GET /files/{id} returns metadata and size', async () => {
+    const entityId = EntityId.parseString('123');
+    const entity = {
+      id: entityId.getEncodedId(),
+      memo: 'file memo',
+      deleted: false,
+      expiration_timestamp: null,
+      auto_renew_period: null,
+      key: null,
+      created_timestamp: 1000000000n,
+      ...entityId,
+    };
+
+    await integrationDomainOps.loadEntities([entity]);
+
+    const files = [
+      {
+        consensus_timestamp: 2000000000n,
+        entity_id: entityId.toString(),
+        file_data: Buffer.from('0a0b0c', 'hex'),
+        transaction_type: 17,
+      },
+    ];
+
+    await integrationDomainOps.loadFileData(files);
+
+    const res = await request(server).get(`${apiPrefix}/files/${entityId.toString()}`).expect(200);
+    expect(res.body.file_id).toBe(entityId.toString());
+    expect(res.body.memo).toBe('file memo');
+    expect(res.body.size_bytes).toBe(3);
+    expect(res.body.consensus_timestamp).toBeDefined();
+  });
+
+  test('GET /files/{id} returns 404 for missing file', async () => {
+    const entityId = EntityId.parseString('9999');
+    await request(server).get(`${apiPrefix}/files/${entityId.toString()}`).expect(404);
+  });
+});

--- a/rest/__tests__/service/fileService.unit.test.js
+++ b/rest/__tests__/service/fileService.unit.test.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {jest} from '@jest/globals';
+import BaseService from '../../service/baseService';
+import {FileService} from '../../service';
+import {NotFoundError} from '../../errors';
+
+describe('FileService unit tests', () => {
+  test('getFileById maps row correctly', async () => {
+    const mockRow = {
+      id: 123n,
+      memo: 'test memo',
+      deleted: false,
+      expiration_timestamp: 2000000000n,
+      auto_renew_period: null,
+      key: Buffer.from('010203', 'hex'),
+      created_timestamp: 1000000000n,
+    };
+
+    const spy = jest.spyOn(BaseService.prototype, 'getSingleRow').mockResolvedValue(mockRow);
+
+    const res = await FileService.getFileById(123n);
+    expect(res.file_id).toBe(123n);
+    expect(res.memo).toBe('test memo');
+    expect(res.deleted).toBe(false);
+    expect(res.created_timestamp).toBeDefined();
+    expect(res.key === null || typeof res.key === 'object').toBe(true);
+
+    spy.mockRestore();
+  });
+
+  test('getFileById throws NotFoundError when no row', async () => {
+    const spy = jest.spyOn(BaseService.prototype, 'getSingleRow').mockResolvedValue(null);
+
+    await expect(FileService.getFileById(999n)).rejects.toThrow(NotFoundError);
+
+    spy.mockRestore();
+  });
+});

--- a/rest/api/v1/openapi.yml
+++ b/rest/api/v1/openapi.yml
@@ -1205,6 +1205,26 @@ paths:
           $ref: "#/components/responses/NotFoundError"
       tags:
         - topics
+  /api/v1/files/{fileId}:
+    get:
+      summary: Get file metadata
+      description: Returns metadata for a file entity.
+      operationId: getFileById
+      parameters:
+        - $ref: "#/components/parameters/fileIdPathParam"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileResponse"
+        400:
+          $ref: "#/components/responses/InvalidParameterError"
+        404:
+          $ref: "#/components/responses/NotFoundError"
+      tags:
+        - files
   /api/v1/tokens:
     get:
       summary: List tokens
@@ -2718,6 +2738,26 @@ components:
       pattern: '^\d{1,10}\.\d{1,10}\.\d{1,10}$'
       example: "0.0.2"
       nullable: true
+    FileResponse:
+      type: object
+      properties:
+        file_id:
+          $ref: "#/components/schemas/EntityId"
+        size_bytes:
+          type: integer
+          format: int64
+        consensus_timestamp:
+          $ref: "#/components/schemas/TimestampNullable"
+        memo:
+          type: string
+        deleted:
+          type: boolean
+        expiry_timestamp:
+          $ref: "#/components/schemas/TimestampNullable"
+        key:
+          type: string
+        created_timestamp:
+          $ref: "#/components/schemas/Timestamp"
     EntityIdQuery:
       type: string
       pattern: ^((gte?|lte?|eq|ne)\:)?(\d{1,10}\.\d{1,10}\.)?\d{1,10}$
@@ -4466,6 +4506,18 @@ components:
               messages:
                 - message: Require at least 1/3 signature files to prove consensus, got 1 out of 4 for file 2019-10-11T13_33_25.526889Z.rcd_sig
   parameters:
+    fileIdPathParam:
+      name: fileId
+      in: path
+      description: File id in the format of `shard.realm.num`
+      required: true
+      schema:
+        $ref: "#/components/schemas/EntityId"
+      examples:
+        fileNum:
+          value: "0.0.123"
+        shardRealm:
+          value: "1.2.123"
     accountIdOrAliasOrEvmAddressPathParam:
       name: idOrAliasOrEvmAddress
       in: path

--- a/rest/controllers/fileController.js
+++ b/rest/controllers/fileController.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import EntityService from '../service/entityService';
+import FileDataService from '../service/fileDataService';
+import FileService from '../service/fileService';
+import EntityId from '../entityId';
+import * as utils from '../utils';
+import {NotFoundError} from '../errors';
+import * as constants from '../constants';
+
+/**
+ * Controller for file metadata endpoints
+ */
+const getFileById = async (req, res) => {
+  // resolve the entity id (supports encoded id / shard.realm.num)
+  const paramName = 'fileId';
+  const encodedId = await EntityService.getEncodedId(req.params[paramName], true, paramName);
+  // get metadata from entity table
+  const meta = await FileService.getFileById(encodedId);
+
+  // get latest file contents row for size and consensus timestamp
+  const row = await FileDataService.getLatestFileDataContents(encodedId, {whereQuery: []});
+  const sizeBytes =
+    row && row.file_data
+      ? Buffer.isBuffer(row.file_data)
+        ? row.file_data.length
+        : Buffer.byteLength(row.file_data)
+      : 0;
+  const consensusTimestamp = row ? utils.nsToSecNs(row.consensus_timestamp) : null;
+
+  const fileIdString = EntityId.parse(encodedId).toString();
+
+  const ret = {
+    file_id: fileIdString,
+    size_bytes: sizeBytes,
+    consensus_timestamp: consensusTimestamp,
+    memo: meta.memo,
+    deleted: meta.deleted,
+    expiry_timestamp: meta.expiry_timestamp,
+    key: meta.key,
+    created_timestamp: meta.created_timestamp,
+  };
+
+  res.locals[constants.responseDataLabel] = ret;
+};
+
+export default {
+  getFileById,
+};

--- a/rest/controllers/index.js
+++ b/rest/controllers/index.js
@@ -7,6 +7,7 @@ import NetworkController from './networkController';
 import TokenController from './tokenController';
 import TokenAllowanceController from './tokenAllowanceController';
 import BlockController from './blockController';
+import FileController from './fileController';
 
 export {
   AccountController,
@@ -16,4 +17,5 @@ export {
   TokenController,
   TokenAllowanceController,
   BlockController,
+  FileController,
 };

--- a/rest/server.js
+++ b/rest/server.js
@@ -33,6 +33,8 @@ import {
   serveSwaggerDocs,
 } from './middleware';
 
+import {FileController} from './controllers';
+
 // routes
 import {AccountRoutes, BlockRoutes, ContractRoutes, NetworkRoutes} from './routes';
 import {handleRejection, handleUncaughtException} from './middleware/httpErrorHandler';
@@ -130,6 +132,9 @@ app.getExt(`${apiPrefix}/tokens/:tokenId/nfts/:serialNumber/transactions`, token
 app.getExt(`${apiPrefix}/topics/:topicId/messages`, topicmessage.getTopicMessages);
 app.getExt(`${apiPrefix}/topics/:topicId/messages/:sequenceNumber`, topicmessage.getMessageByTopicAndSequenceRequest);
 app.getExt(`${apiPrefix}/topics/messages/:consensusTimestamp`, topicmessage.getMessageByConsensusTimestamp);
+
+// files routes
+app.getExt(`${apiPrefix}/files/:fileId`, FileController.getFileById);
 
 // transactions routes
 app.getExt(`${apiPrefix}/transactions`, transactions.getTransactions);

--- a/rest/service/fileService.js
+++ b/rest/service/fileService.js
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import BaseService from './baseService';
+import {Entity} from '../model';
+import * as utils from '../utils';
+import {NotFoundError} from '../errors';
+
+/**
+ * File retrieval business logic
+ */
+class FileService extends BaseService {
+  static fileByIdQuery = `select
+    ${Entity.getFullName(Entity.ID)} as id,
+    ${Entity.getFullName(Entity.MEMO)} as memo,
+    ${Entity.getFullName(Entity.DELETED)} as deleted,
+    ${Entity.getFullName(Entity.EXPIRATION_TIMESTAMP)} as expiration_timestamp,
+    ${Entity.getFullName(Entity.AUTO_RENEW_PERIOD)} as auto_renew_period,
+    ${Entity.getFullName(Entity.KEY)} as key,
+    ${Entity.getFullName(Entity.CREATED_TIMESTAMP)} as created_timestamp
+  from ${Entity.tableName} ${Entity.tableAlias}
+  where ${Entity.getFullName(Entity.ID)} = $1 and ${Entity.getFullName(Entity.TYPE)} = 'FILE'`;
+
+  async getFileById(id) {
+    const row = await super.getSingleRow(FileService.fileByIdQuery, [id]);
+    if (!row) {
+      throw new NotFoundError();
+    }
+
+    // map and format
+    return {
+      file_id: id,
+      memo: row.memo,
+      deleted: row.deleted,
+      expiry_timestamp: utils.calculateExpiryTimestamp(
+        row.auto_renew_period,
+        row.created_timestamp,
+        row.expiration_timestamp
+      ),
+      key: utils.encodeKey(row.key),
+      created_timestamp: utils.nsToSecNs(row.created_timestamp),
+    };
+  }
+}
+
+export default new FileService();

--- a/rest/service/index.js
+++ b/rest/service/index.js
@@ -4,6 +4,7 @@ import ContractService from './contractService';
 import CryptoAllowanceService from './cryptoAllowanceService';
 import EntityService from './entityService';
 import FileDataService from './fileDataService';
+import FileService from './fileService';
 import NetworkNodeService from './networkNodeService';
 import NftService from './nftService';
 import RecordFileService from './recordFileService';
@@ -17,6 +18,7 @@ export {
   CryptoAllowanceService,
   EntityService,
   FileDataService,
+  FileService,
   NetworkNodeService,
   NftService,
   RecordFileService,


### PR DESCRIPTION
**Description**:
Add a new REST API endpoint to retrieve file entity metadata from the mirror node.
- Add `/api/v1/files/{fileId}` GET endpoint to `server.js`
- Add `FileController` to handle request orchestration and ID validation
- Add `FileService` to query file metadata from the entity table
- Integrate `FileDataService` to retrieve latest file size and consensus timestamp
- Update `openapi.yml` with `FileResponse` schema and fileId path parameter
- Add unit tests for `FileService` to verify row mapping and error handling

**Related issue(s)**:
Fixes #6426 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
