### PR TITLE
Bump minimum HAPI version for hooks to 0.73.0 (0.152)

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -19,7 +19,7 @@ public class FeatureProperties {
 
     private boolean contractCallLocalEstimate = true;
 
-    private int hapiMinorVersionWithHooks = 72;
+    private int hapiMinorVersionWithHooks = 73;
 
     private int hapiMinorVersionWithoutGasRefund = 69;
 


### PR DESCRIPTION
**Description**:

This PR cherry-picks the change to `release/0.152`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
