### PR TITLE
Update copy script to use static snapshot by default

### DIFF
--- a/.github/workflows/copy-stackgres-cluster.yml
+++ b/.github/workflows/copy-stackgres-cluster.yml
@@ -12,7 +12,7 @@ on:
         default: true
         type: boolean
       run_acceptance_test:
-        default: true
+        default: false
         type: boolean
       run_k6_test:
         default: true
@@ -29,6 +29,10 @@ on:
         type: string
         default: "prod"
         required: true
+      staging_snapshot_id:
+        description: "Snapshot ID override; defaults to vars.STAGING_SNAPSHOT_ID when empty"
+        required: false
+        type: string
       target_cluster_location:
         type: string
         default: "us-central1"
@@ -49,6 +53,9 @@ on:
         type: boolean
         default: false
         required: true
+      use_static_snapshot:
+        default: true
+        type: boolean
     secrets:
       GH_ACTIONS_KUBECTL_MAIN_PROJECT_ID:
         required: true
@@ -86,6 +93,10 @@ on:
         options: [prod, nonprod]
         required: true
         type: choice
+      staging_snapshot_id:
+        description: "Snapshot ID override; defaults to vars.STAGING_SNAPSHOT_ID when empty"
+        required: false
+        type: string
       target_cluster_location:
         default: "us-central1"
         description: "Target: GKE location (zone or region)"
@@ -107,6 +118,11 @@ on:
       teardown_target:
         default: false
         description: "Tear down target cluster"
+        required: true
+        type: boolean
+      use_static_snapshot:
+        default: true
+        description: "Use a static snapshot (false will copy live environment)"
         required: true
         type: boolean
 
@@ -245,6 +261,8 @@ jobs:
         env:
           AUTO_CONFIRM: "true"
           DEFAULT_POOL_NAME: ${{ inputs.target_default_pool }}
+          SNAPSHOT_ID: ${{ inputs.use_static_snapshot && (inputs.staging_snapshot_id || vars.STAGING_SNAPSHOT_ID) || '' }}
+          USE_STATIC_SNAPSHOT: ${{ inputs.use_static_snapshot }}
         run: |
           set -Eeuo pipefail
           export PATH="${CLOUDSDK_BIN_DIR}:${PATH}"

--- a/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
@@ -49,6 +49,7 @@ spec:
             effect: NoSchedule
         {{- end }}
     replication:
+      # can remove this initialization block once https://gitlab.com/ongresinc/stackgres/-/work_items/3140 is resolved
       initialization:
         mode: {{ .Values.stackgres.replication.initialization.mode }}
     sgInstanceProfile: {{ include "hedera-mirror.stackgres" . }}-coordinator

--- a/docs/checklist/release.md
+++ b/docs/checklist/release.md
@@ -52,6 +52,7 @@ Deployed automatically on every tag.
   - Uncheck `Restore the target cluster from the source`
   - Uncheck `Run k6 test`
   - Check `Tear down target cluster`
+- [ ] Create new static snapshot if necessary (long migration) and update github env var
 
 ## Generally Available
 

--- a/docs/runbook/copy-live-environment.md
+++ b/docs/runbook/copy-live-environment.md
@@ -16,14 +16,16 @@ Need to copy live environment with zero downtime on source
 - If you have multiple Citus clusters in the `target cluster`, you will need to restore all of them
 - All bash commands assume your working directory is `tools/cluster-management`
 - Only a single citus cluster is installed per namespace
+- If `USE_STATIC_SNAPSHOT` is true(default), the `SNAPSHOT_ID` must reference a snapshot created by running the [`volume-snapshot.sh`](../../tools/cluster-management/volume-snapshot.sh) script
 
 ## Steps
 
 1. Configure kubernetes context for source and target by setting `K8S_SOURCE_CLUSTER_CONTEXT` and `K8S_TARGET_CLUSTER_CONTEXT`
-2. By default, the script will copy the environment, run k6 tests, and leave the environment. Set the following
+2. By default, the script deploys a static snapshot specified using `SNAPSHOT_ID`, run k6 tests, and leave the environment. Set the following
    environment variables to a non-default value if needed
    - `DEFAULT_POOL_NAME`
    - `TEST_KUBE_TARGET_NAMESPACE`
+   - `USE_STATIC_SNAPSHOT` (will copy from live environment if set to false)
 3. Run script and follow along with all prompts. To auto confirm destructive operations, set `AUTO_CONFIRM=true`
 4. You can skip any prompts or inputs by setting the following variables. If they are not set you will be prompted for
    their values
@@ -31,6 +33,7 @@ Need to copy live environment with zero downtime on source
    - `GCP_TARGET_PROJECT`
    - `GCP_K8S_TARGET_CLUSTER_REGION`
    - `GCP_K8S_TARGET_CLUSTER_NAME`
+   - `SNAPSHOT_ID` (if `USE_STATIC_SNAPSHOT=true` - default is true)
 5. Use different combinations of `RESTORE` (default `true`), `RUN_K6_TEST` (default `true`), and `TEARDOWN_TARGET`
    (default `false`) for different tasks. Examples:
    - `TEARDOWN_TARGET=true`: Copy the environment, run k6 tests, and tear down the target cluster

--- a/tools/cluster-management/copy-live-environment.sh
+++ b/tools/cluster-management/copy-live-environment.sh
@@ -16,11 +16,13 @@ K6_TEST_SUITE_NAME="${K6_TEST_SUITE_NAME:-test-suite-rest-mainnet-citus}"
 K8S_SOURCE_CLUSTER_CONTEXT=${K8S_SOURCE_CLUSTER_CONTEXT:-}
 K8S_TARGET_CLUSTER_CONTEXT=${K8S_TARGET_CLUSTER_CONTEXT:-}
 RESTORE="${RESTORE:-true}"
-RUN_ACCEPTANCE_TEST="${RUN_ACCEPTANCE_TEST:-true}"
+RUN_ACCEPTANCE_TEST="${RUN_ACCEPTANCE_TEST:-false}"
 RUN_K6_TEST="${RUN_K6_TEST:-true}"
 TEARDOWN_TARGET="${TEARDOWN_TARGET:-false}"
 TEST_KUBE_NAMESPACE="${TEST_KUBE_NAMESPACE:-testkube}"
 TEST_KUBE_TARGET_NAMESPACE="${TEST_KUBE_TARGET_NAMESPACE:-mainnet-citus}"
+SNAPSHOT_ID="${SNAPSHOT_ID:-}"
+USE_STATIC_SNAPSHOT="${USE_STATIC_SNAPSHOT:-true}"
 
 function deleteBackupsFromSource() {
   local lines
@@ -266,6 +268,10 @@ function snapshotSource() {
 }
 
 function patchBackupPaths() {
+  if [[ "${USE_STATIC_SNAPSHOT}" == "true" ]]; then
+    return 0
+  fi
+
   local lines
   lines="$(
     jq -r '
@@ -332,11 +338,6 @@ function scaleupResources() {
 }
 
 function restoreTarget() {
-  if [[ -z "${SNAPSHOT_ID}" ]]; then
-    log "SNAPSHOT_ID is not set"
-    exit 1
-  fi
-
   PAUSE_CLUSTER="true"
   changeContext "${K8S_TARGET_CLUSTER_CONTEXT}"
   configureAndValidateSnapshotRestore
@@ -519,14 +520,14 @@ function getHpaMaxReplicas() {
   kubectl get hpa "${hpaName}" -n "${namespace}" -o jsonpath='{.spec.maxReplicas}' 2>/dev/null || true
 }
 
-function restoreEnvironment() {
+function copyLiveEnvironment() {
   if [[ "${RESTORE}" != "true" ]]; then
     return 0
   fi
 
   ensureContext K8S_SOURCE_CLUSTER_CONTEXT
-
   changeContext "${K8S_TARGET_CLUSTER_CONTEXT}"
+
   if [[ $(kubectl get nodes -o json | jq '.items | length') != 0 ]]; then
     log "There are GKE nodes in the target cluster, please teardown the environment before any restore attempt."
     exit 1
@@ -699,8 +700,16 @@ function waitForHelmReleaseReady() {
   done
 }
 
-ensureContext K8S_TARGET_CLUSTER_CONTEXT
-restoreEnvironment
+function createEnvironment() {
+  if [[ "${USE_STATIC_SNAPSHOT}" == "true" ]]; then
+    export KILL_IMPORTER_AFTER_READY="true"
+    restoreTarget
+  else
+    copyLiveEnvironment
+  fi
+}
+
+createEnvironment
 runAcceptanceTest
 runK6Test
 teardownResources

--- a/tools/cluster-management/utils/utils.sh
+++ b/tools/cluster-management/utils/utils.sh
@@ -332,12 +332,20 @@ function resumeCommonChart() {
 
 function resumeKustomization() {
   log "Resuming kustomization ${KUSTOMIZATION_NAME} in namespace ${KUSTOMIZATION_NAMESPACE}"
-  flux resume kustomization "${KUSTOMIZATION_NAME}" -n "${KUSTOMIZATION_NAMESPACE}"
+  if kubectl get kustomizations -n "${KUSTOMIZATION_NAMESPACE}" "${KUSTOMIZATION_NAME}" >/dev/null; then
+    flux resume kustomization "${KUSTOMIZATION_NAME}" -n "${KUSTOMIZATION_NAMESPACE}"
+  else
+    log "No kustomization ${KUSTOMIZATION_NAME} in ${KUSTOMIZATION_NAMESPACE} skipping resume"
+  fi
 }
 
 function suspendKustomization() {
   log "Suspending kustomization ${KUSTOMIZATION_NAME} in namespace ${KUSTOMIZATION_NAMESPACE}"
-  flux suspend kustomization "${KUSTOMIZATION_NAME}" -n "${KUSTOMIZATION_NAMESPACE}"
+  if kubectl get kustomizations -n "${KUSTOMIZATION_NAMESPACE}" "${KUSTOMIZATION_NAME}" >/dev/null; then
+    flux suspend kustomization "${KUSTOMIZATION_NAME}" -n "${KUSTOMIZATION_NAMESPACE}"
+  else
+    log "No kustomization ${KUSTOMIZATION_NAME} in ${KUSTOMIZATION_NAMESPACE} skipping suspend"
+  fi
 }
 
 function unrouteTraffic() {
@@ -396,7 +404,12 @@ function routeTraffic() {
   checkCitusMetadataSyncStatus "${namespace}"
   runTestQueries "${namespace}"
   scaleDeployment "${namespace}" 1 "app.kubernetes.io/component=importer"
-  waitForRecordStreamSync "${namespace}"
+
+  if [[ "${KILL_IMPORTER_AFTER_READY}" == "true" ]]; then
+    scaleDeployment "${namespace}" 0 "app.kubernetes.io/component=importer"
+  else
+    waitForRecordStreamSync "${namespace}"
+  fi
 
   if [[ "${AUTO_UNROUTE}" == "true" ]]; then
     if kubectl get helmrelease -n "${namespace}" "${HELM_RELEASE_NAME}" >/dev/null; then
@@ -905,5 +918,6 @@ PATRONI_MASTER_ROLE="${PATRONI_MASTER_ROLE:-Leader}"
 PAUSE_CLUSTER="${PAUSE_CLUSTER:-true}"
 STACKGRES_MASTER_LABELS="${STACKGRES_MASTER_LABELS:-app=StackGresCluster,role=master}"
 ZFS_POOL_NAME="${ZFS_POOL_NAME:-zfspv-pool}"
+KILL_IMPORTER_AFTER_READY="${KILL_IMPORTER_AFTER_READY:-false}"
 
 alias kubectl_common="kubectl -n ${COMMON_NAMESPACE}"


### PR DESCRIPTION
**Description**:
this pr adds changes to make it possible to use a static snapshot for release testing
* update copy-live-environment.sh to use static snapshot by default
* update workflow to add configuration to use static snapshot id

**Related issue(s)**:

Fixes #13301 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
