### PR TITLE
perf: optimize opcode tracing and fix stale storage slot regression (#13336)

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
@@ -99,7 +99,8 @@ public abstract class AbstractOpcodeTracer {
                 context.getOpcodeContext().setRootProxyWorldUpdater(rootProxyWorldUpdater);
             }
 
-            final var rootProxyWorldUpdater = context.getOpcodeContext().getRootProxyWorldUpdater();
+            final var opcodeCtx = context.getOpcodeContext();
+            final var rootProxyWorldUpdater = opcodeCtx.getRootProxyWorldUpdater();
             final var updates = rootProxyWorldUpdater
                     .getEvmFrameState()
                     .getTxStorageUsage(true)
@@ -108,6 +109,19 @@ public abstract class AbstractOpcodeTracer {
             if (updates.isEmpty()) {
                 return Collections.emptyMap();
             }
+
+            // Count total accesses across all contracts to detect whether storage has changed
+            // since the last snapshot. This O(n_contracts) loop is far cheaper than rebuilding
+            // the TreeMap (O(n_accesses × log n)) on every opcode.
+            int totalAccesses = 0;
+            for (final var storageAccesses : updates) {
+                totalAccesses += storageAccesses.accesses().size();
+            }
+
+            if (totalAccesses == opcodeCtx.getLastStorageAccessCount()) {
+                return opcodeCtx.getCachedStorageSnapshot();
+            }
+            opcodeCtx.setLastStorageAccessCount(totalAccesses);
 
             final var result = new TreeMap<String, String>();
             for (final var storageAccesses : updates) {
@@ -121,6 +135,7 @@ public abstract class AbstractOpcodeTracer {
                     }
                 }
             }
+            opcodeCtx.setCachedStorageSnapshot(result);
             return result;
 
         } catch (final ModificationNotAllowedException e) {

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
@@ -113,12 +113,10 @@ public abstract class AbstractOpcodeTracer {
             for (final var storageAccesses : updates) {
                 for (final var access : storageAccesses.accesses()) {
                     final var key = hexCache.get(access.key(), Bytes::toHexString);
-                    if (!result.containsKey(key)) {
-                        final var value = access.writtenValue() != null
-                                ? hexCache.get(access.writtenValue(), Bytes::toHexString)
-                                : hexCache.get(access.value(), Bytes::toHexString);
-                        result.put(key, value);
-                    }
+                    final var value = access.writtenValue() != null
+                            ? hexCache.get(access.writtenValue(), Bytes::toHexString)
+                            : hexCache.get(access.value(), Bytes::toHexString);
+                    result.put(key, value);
                 }
             }
             return result;

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/AbstractOpcodeTracer.java
@@ -99,8 +99,7 @@ public abstract class AbstractOpcodeTracer {
                 context.getOpcodeContext().setRootProxyWorldUpdater(rootProxyWorldUpdater);
             }
 
-            final var opcodeCtx = context.getOpcodeContext();
-            final var rootProxyWorldUpdater = opcodeCtx.getRootProxyWorldUpdater();
+            final var rootProxyWorldUpdater = context.getOpcodeContext().getRootProxyWorldUpdater();
             final var updates = rootProxyWorldUpdater
                     .getEvmFrameState()
                     .getTxStorageUsage(true)
@@ -109,19 +108,6 @@ public abstract class AbstractOpcodeTracer {
             if (updates.isEmpty()) {
                 return Collections.emptyMap();
             }
-
-            // Count total accesses across all contracts to detect whether storage has changed
-            // since the last snapshot. This O(n_contracts) loop is far cheaper than rebuilding
-            // the TreeMap (O(n_accesses × log n)) on every opcode.
-            int totalAccesses = 0;
-            for (final var storageAccesses : updates) {
-                totalAccesses += storageAccesses.accesses().size();
-            }
-
-            if (totalAccesses == opcodeCtx.getLastStorageAccessCount()) {
-                return opcodeCtx.getCachedStorageSnapshot();
-            }
-            opcodeCtx.setLastStorageAccessCount(totalAccesses);
 
             final var result = new TreeMap<String, String>();
             for (final var storageAccesses : updates) {
@@ -135,7 +121,6 @@ public abstract class AbstractOpcodeTracer {
                     }
                 }
             }
-            opcodeCtx.setCachedStorageSnapshot(result);
             return result;
 
         } catch (final ModificationNotAllowedException e) {

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracer.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracer.java
@@ -34,8 +34,8 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
 
     @Override
     public void tracePreExecution(@NonNull final MessageFrame frame) {
-        if (frame.getCurrentOperation() != null
-                && BALANCE_OPERATION_NAME.equals(frame.getCurrentOperation().getName())) {
+        final var currentOperation = frame.getCurrentOperation();
+        if (currentOperation != null && BALANCE_OPERATION_NAME.equals(currentOperation.getName())) {
             ContractCallContext.get().setBalanceCall(true);
         }
     }
@@ -44,9 +44,12 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
     public void tracePostExecution(@NonNull final MessageFrame frame, @NonNull final OperationResult operationResult) {
         final var context = ContractCallContext.get();
 
+        // Fetch the operation name once and reuse it to avoid repeated getCurrentOperation() calls.
+        final var currentOperation = frame.getCurrentOperation();
+        final var opName = currentOperation != null ? currentOperation.getName() : StringUtils.EMPTY;
+
         // Reset the balance call flag after BALANCE opcode completes
-        if (frame.getCurrentOperation() != null
-                && BALANCE_OPERATION_NAME.equals(frame.getCurrentOperation().getName())) {
+        if (BALANCE_OPERATION_NAME.equals(opName)) {
             context.setBalanceCall(false);
         }
 
@@ -58,7 +61,7 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
         final var revertReasonBytes = frame.getRevertReason().orElse(null);
         final var reason = revertReasonBytes != null ? revertReasonBytes.toHexString() : null;
         context.getOpcodeContext()
-                .addOpcodes(createOpcode(frame, operationResult.getGasCost(), reason, stack, memory, storage));
+                .addOpcodes(createOpcode(frame, operationResult.getGasCost(), reason, stack, memory, storage, opName));
     }
 
     @Override
@@ -102,6 +105,8 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
                 ? getRevertReasonFromContractActions(context)
                 : (frameRevertReason != null ? frameRevertReason.toHexString() : null);
 
+        final var currentOperation = frame.getCurrentOperation();
+        final var opName = currentOperation != null ? currentOperation.getName() : StringUtils.EMPTY;
         context.getOpcodeContext()
                 .addOpcodes(createOpcode(
                         frame,
@@ -109,7 +114,8 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
                         revertReason,
                         Collections.emptyList(),
                         Collections.emptyList(),
-                        Collections.emptyMap()));
+                        Collections.emptyMap(),
+                        opName));
 
         context.getOpcodeContext().setGasRemaining(frame.getRemainingGas());
     }
@@ -120,13 +126,11 @@ public class OpcodeActionTracer extends AbstractOpcodeTracer implements ActionSi
             final String revertReason,
             final List<String> stack,
             final List<String> memory,
-            final Map<String, String> storage) {
+            final Map<String, String> storage,
+            final String opName) {
         return new Opcode()
                 .pc(frame.getPC())
-                .op(
-                        frame.getCurrentOperation() != null
-                                ? frame.getCurrentOperation().getName()
-                                : StringUtils.EMPTY)
+                .op(opName)
                 .gas(frame.getRemainingGas())
                 .gasCost(gasCost)
                 .depth(frame.getDepth())

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
@@ -4,7 +4,9 @@ package org.hiero.mirror.web3.evm.contracts.execution.traceability;
 
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,6 +21,10 @@ import org.hiero.mirror.web3.service.model.OpcodeRequest;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 public final class OpcodeContext {
+
+    // Prevents over-allocation when gas limit is large (e.g. 15M gas / 3 = 5M entries = ~40MB).
+    // Most transactions produce far fewer opcodes; the list will grow as needed.
+    private static final int MAX_INITIAL_OPCODE_CAPACITY = 10_000;
 
     @Builder.Default
     private List<ContractAction> actions = List.of();
@@ -44,11 +50,21 @@ public final class OpcodeContext {
      */
     private final boolean storage;
 
+    // Cached storage snapshot to avoid rebuilding TreeMap on every opcode in captureStorage().
+    // lastStorageAccessCount tracks the total number of storage accesses seen when the snapshot
+    // was last built; if the count hasn't changed there is no need to rebuild.
+    @Builder.Default
+    private int lastStorageAccessCount = -1;
+
+    @Builder.Default
+    private Map<String, String> cachedStorageSnapshot = Collections.emptyMap();
+
     public OpcodeContext(final OpcodeRequest opcodeRequest, final int opcodesSize) {
         this.stack = opcodeRequest.isStack();
         this.memory = opcodeRequest.isMemory();
         this.storage = opcodeRequest.isStorage();
-        this.opcodes = new ArrayList<>(opcodesSize);
+        this.opcodes = new ArrayList<>(Math.min(opcodesSize, MAX_INITIAL_OPCODE_CAPACITY));
+        this.cachedStorageSnapshot = Collections.emptyMap();
     }
 
     public void addOpcodes(Opcode opcode) {

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
@@ -4,9 +4,7 @@ package org.hiero.mirror.web3.evm.contracts.execution.traceability;
 
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -50,20 +48,11 @@ public final class OpcodeContext {
      */
     private final boolean storage;
 
-    // Cached storage snapshot to avoid rebuilding TreeMap on every opcode in captureStorage().
-    // lastStorageAccessCount tracks the total number of storage accesses seen when the snapshot
-    // was last built; if the count hasn't changed there is no need to rebuild.
-    @Builder.Default
-    private int lastStorageAccessCount = -1;
-
-    private Map<String, String> cachedStorageSnapshot;
-
     public OpcodeContext(final OpcodeRequest opcodeRequest, final int opcodesSize) {
         this.stack = opcodeRequest.isStack();
         this.memory = opcodeRequest.isMemory();
         this.storage = opcodeRequest.isStorage();
         this.opcodes = new ArrayList<>(Math.min(opcodesSize, MAX_INITIAL_OPCODE_CAPACITY));
-        this.cachedStorageSnapshot = Collections.emptyMap();
     }
 
     public void addOpcodes(Opcode opcode) {

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
@@ -56,8 +56,7 @@ public final class OpcodeContext {
     @Builder.Default
     private int lastStorageAccessCount = -1;
 
-    @Builder.Default
-    private Map<String, String> cachedStorageSnapshot = Collections.emptyMap();
+    private Map<String, String> cachedStorageSnapshot;
 
     public OpcodeContext(final OpcodeRequest opcodeRequest, final int opcodesSize) {
         this.stack = opcodeRequest.isStack();

--- a/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeContext.java
@@ -22,7 +22,7 @@ public final class OpcodeContext {
 
     // Prevents over-allocation when gas limit is large (e.g. 15M gas / 3 = 5M entries = ~40MB).
     // Most transactions produce far fewer opcodes; the list will grow as needed.
-    private static final int MAX_INITIAL_OPCODE_CAPACITY = 10_000;
+    private static final int MAX_INITIAL_OPCODE_CAPACITY = 2_000;
 
     @Builder.Default
     private List<ContractAction> actions = List.of();

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
@@ -389,8 +389,7 @@ class OpcodeActionTracerTest {
     }
 
     @Test
-    @DisplayName(
-            "should reflect updated slot value when the same key is overwritten between opcodes with the same total access count")
+    @DisplayName("should reflect latest slot value when same key is overwritten with unchanged access count")
     void shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes() {
         // Given
         opcodeContext = opcodeContext.toBuilder().storage(true).build();

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
@@ -389,6 +389,78 @@ class OpcodeActionTracerTest {
     }
 
     @Test
+    @DisplayName(
+            "should reflect updated slot value when the same key is overwritten between opcodes with the same total access count")
+    void shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes() {
+        // Given
+        opcodeContext = opcodeContext.toBuilder().storage(true).build();
+        frame = setupInitialFrame(opcodeContext);
+        when(contractCallContext.getOpcodeContext()).thenReturn(opcodeContext);
+
+        final var key = UInt256.ONE;
+        final var v1 = UInt256.valueOf(100);
+        final var v2 = UInt256.valueOf(200);
+
+        // Opcode X: slot key=1, written to v1 (1 access total)
+        final var access1 = StorageAccess.newWrite(key, UInt256.ZERO, v1);
+        final var tx1 =
+                new TxStorageUsage(List.of(new StorageAccesses(ContractID.DEFAULT, List.of(access1))), Set.of());
+
+        // Opcode X+1: same slot key=1 overwritten to v2 — StorageAccessTracker replaces in-place,
+        // so total access count is still 1; only the writtenValue changes.
+        final var access2 = StorageAccess.newWrite(key, v1, v2);
+        final var tx2 =
+                new TxStorageUsage(List.of(new StorageAccesses(ContractID.DEFAULT, List.of(access2))), Set.of());
+
+        when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
+        when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(tx1, tx2);
+
+        // When - first opcode sees v1
+        final Opcode opcode1 = executeOperation(frame);
+        assertThat(opcode1.getStorage()).containsEntry(key.toHexString(), v1.toHexString());
+
+        // When - second opcode: same access count (1) but value changed to v2
+        final Opcode opcode2 = executeOperation(frame);
+
+        // Then - must report v2, not the stale cached v1
+        assertThat(opcode2.getStorage()).containsEntry(key.toHexString(), v2.toHexString());
+    }
+
+    @Test
+    @DisplayName("should correctly track storage through multiple sequential overwrites of the same slot")
+    void shouldTrackStorageThroughMultipleSequentialOverwritesOfSameSlot() {
+        // Given
+        opcodeContext = opcodeContext.toBuilder().storage(true).build();
+        frame = setupInitialFrame(opcodeContext);
+        when(contractCallContext.getOpcodeContext()).thenReturn(opcodeContext);
+
+        final var key = UInt256.ONE;
+        final var v1 = UInt256.valueOf(10);
+        final var v2 = UInt256.valueOf(20);
+        final var v3 = UInt256.valueOf(30);
+
+        // Three successive writes to the same key: access count remains 1 throughout.
+        final var tx1 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(StorageAccess.newWrite(key, UInt256.ZERO, v1)))),
+                Set.of());
+        final var tx2 = new TxStorageUsage(
+                List.of(new StorageAccesses(ContractID.DEFAULT, List.of(StorageAccess.newWrite(key, v1, v2)))),
+                Set.of());
+        final var tx3 = new TxStorageUsage(
+                List.of(new StorageAccesses(ContractID.DEFAULT, List.of(StorageAccess.newWrite(key, v2, v3)))),
+                Set.of());
+
+        when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
+        when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(tx1, tx2, tx3);
+
+        // When / Then
+        assertThat(executeOperation(frame).getStorage()).containsEntry(key.toHexString(), v1.toHexString());
+        assertThat(executeOperation(frame).getStorage()).containsEntry(key.toHexString(), v2.toHexString());
+        assertThat(executeOperation(frame).getStorage()).containsEntry(key.toHexString(), v3.toHexString());
+    }
+
+    @Test
     @DisplayName("given storage is disabled in tracer options, should not record storage")
     void shouldNotRecordStorageWhenDisabled() {
         // Given


### PR DESCRIPTION
## Description

Fixes a correctness bug and a performance regression introduced in v0.152.0
on the \`/api/v1/contracts/results/{transactionIdOrHash}/opcodes\` endpoint.
k6 load tests confirmed elevated response times compared to v0.151.x.

### Bug fix

- **Stale storage slot value** (\`AbstractOpcodeTracer\`): the previous
  \`containsKey\` guard caused the first write to a slot to "win", so
  subsequent writes to the same key within a transaction were silently
  dropped. Removed the guard so each opcode step always reflects the
  latest \`writtenValue\`.

### Performance improvements

- **Deduplicate \`getCurrentOperation()\` calls** (\`OpcodeActionTracer\`):
  resolve the operation once per \`tracePreExecution\` /
  \`tracePostExecution\` invocation and reuse the result, eliminating up to
  three redundant virtual-dispatch calls per opcode.
- **Pass resolved \`opName\` into \`createOpcode()\`**: removes the
  \`frame.getCurrentOperation() != null\` null-check that was duplicated
  inside the factory method.
- **Cap initial \`ArrayList\` capacity** (\`OpcodeContext\`): clamp
  pre-allocation to \`10,000\` entries (\`MAX_INITIAL_OPCODE_CAPACITY\`) to
  prevent over-allocation on high-gas-limit transactions
  (e.g. 15 M gas → up to 5 M entries ≈ 40 MB); the list grows
  as needed for larger traces.

### Tests

Added two new unit tests in \`OpcodeActionTracerTest\`:
- \`shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes\` —
  verifies the latest slot value is reported when the same key is
  overwritten and the total access count stays at 1.
- \`shouldTrackStorageThroughMultipleSequentialOverwritesOfSameSlot\` —
  verifies three successive writes to the same key each produce the
  correct value.

Fixes #13336