### PR TITLE
HIP-1137 Add associated_registered_nodes to `/api/v1/network/nodes`

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeDto.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeDto.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.NullUnmarked;
 @NullUnmarked
 public record NetworkNodeDto(
         byte[] adminKey,
+        Long[] associatedRegisteredNodes,
         Boolean declineReward,
         String description,
         Long endConsensusTimestamp,
@@ -32,4 +33,12 @@ public record NetworkNodeDto(
         Long stakeNotRewarded,
         Long stakeRewarded,
         Long stakingPeriod,
-        Long startConsensusTimestamp) {}
+        Long startConsensusTimestamp) {
+
+    private static final Long[] EMPTY = {};
+
+    @Override
+    public Long[] associatedRegisteredNodes() {
+        return associatedRegisteredNodes != null ? associatedRegisteredNodes : EMPTY;
+    }
+}

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/repository/NetworkNodeRepository.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/repository/NetworkNodeRepository.java
@@ -38,11 +38,12 @@ public interface NetworkNodeRepository extends CrudRepository<AddressBookEntry, 
                 where consensus_timestamp = (select max(consensus_timestamp) from node_stake)
             ),
             node_info as (
-                select admin_key, decline_reward, grpc_proxy_endpoint, node_id, account_id
+                select account_id, admin_key, associated_registered_nodes, decline_reward, grpc_proxy_endpoint, node_id
                 from node
             )
             select
                 n.admin_key as adminKey,
+                n.associated_registered_nodes as associatedRegisteredNodes,
                 n.decline_reward as declineReward,
                 abe.description as description,
                 ab.end_consensus_timestamp as endConsensusTimestamp,

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/controller/NetworkControllerTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/controller/NetworkControllerTest.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.restjava.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
@@ -23,6 +24,7 @@ import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -39,8 +41,11 @@ import org.hiero.mirror.common.domain.file.FileData;
 import org.hiero.mirror.common.domain.node.RegisteredNodeType;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.rest.model.FeeEstimateResponse;
+import org.hiero.mirror.rest.model.Links;
 import org.hiero.mirror.rest.model.NetworkExchangeRateSetResponse;
 import org.hiero.mirror.rest.model.NetworkFeesResponse;
+import org.hiero.mirror.rest.model.NetworkNode;
+import org.hiero.mirror.rest.model.NetworkNodesResponse;
 import org.hiero.mirror.rest.model.NetworkStakeResponse;
 import org.hiero.mirror.rest.model.NetworkSupplyResponse;
 import org.hiero.mirror.rest.model.RegisteredNodesResponse;
@@ -1244,17 +1249,32 @@ final class NetworkControllerTest extends ControllerTest {
         @Test
         void success() {
             // given
-            var nodes = setupNetworkNodeData();
+            setupNetworkNodeData();
 
             // when
-            final var actual =
-                    restClient.get().uri("").retrieve().body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("").retrieve().body(NetworkNodesResponse.class);
 
             // then
-            assertThat(actual).isNotNull();
-            assertThat(actual.getNodes()).isNotNull().hasSize(3);
-            assertThat(actual.getLinks()).isNotNull();
-            assertThat(actual.getLinks().getNext()).isNull(); // All results fit in one page
+            assertThat(actual)
+                    .extracting(NetworkNodesResponse::getNodes, list(NetworkNode.class))
+                    .hasSize(3)
+                    .satisfies(
+                            nodes -> assertThat(nodes)
+                                    .first()
+                                    .extracting(NetworkNode::getAssociatedRegisteredNodes, list(Long.class))
+                                    .isEmpty(),
+                            nodes -> assertThat(nodes.get(1))
+                                    .extracting(NetworkNode::getAssociatedRegisteredNodes, list(Long.class))
+                                    .isEmpty(),
+                            nodes -> assertThat(nodes)
+                                    .last()
+                                    .extracting(NetworkNode::getAssociatedRegisteredNodes, list(Long.class))
+                                    .hasSize(2));
+            // All results fit in one page
+            assertThat(actual)
+                    .extracting(NetworkNodesResponse::getLinks)
+                    .extracting(Links::getNext)
+                    .isNull();
         }
 
         @Test
@@ -1285,7 +1305,7 @@ final class NetworkControllerTest extends ControllerTest {
                     .get()
                     .uri("?file.id=" + addressBook.getFileId())
                     .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+                    .body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1299,11 +1319,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(1).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1318,11 +1335,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(0).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=eq:" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=eq:" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1337,11 +1351,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(0).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=gt:" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=gt:" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1357,11 +1368,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(1).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=gte:" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=gte:" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1377,11 +1385,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(2).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=lt:" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=lt:" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1397,11 +1402,8 @@ final class NetworkControllerTest extends ControllerTest {
             var nodeId = nodes.get(1).getNodeId();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=lte:" + nodeId)
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?node.id=lte:" + nodeId).retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1422,7 +1424,7 @@ final class NetworkControllerTest extends ControllerTest {
                     .get()
                     .uri("?node.id=gte:" + minNodeId + "&node.id=lte:" + maxNodeId)
                     .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+                    .body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1444,7 +1446,7 @@ final class NetworkControllerTest extends ControllerTest {
                     .get()
                     .uri("?node.id=" + nodeId1 + "&node.id=" + nodeId2)
                     .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+                    .body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1467,7 +1469,7 @@ final class NetworkControllerTest extends ControllerTest {
                     .get()
                     .uri("?node.id=" + nodeId2 + "&node.id=" + nodeId3 + "&node.id=gte:" + nodeId2)
                     .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+                    .body(NetworkNodesResponse.class);
 
             // then - should return nodes matching equality AND range
             assertThat(actual).isNotNull();
@@ -1483,11 +1485,7 @@ final class NetworkControllerTest extends ControllerTest {
             setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?limit=2")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?limit=2").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1502,11 +1500,7 @@ final class NetworkControllerTest extends ControllerTest {
             var nodes = setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?order=asc")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?order=asc").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1525,11 +1519,7 @@ final class NetworkControllerTest extends ControllerTest {
             var nodes = setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?order=desc")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?order=desc").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1548,11 +1538,7 @@ final class NetworkControllerTest extends ControllerTest {
             setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?node.id=99999")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?node.id=99999").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1571,7 +1557,7 @@ final class NetworkControllerTest extends ControllerTest {
                     .get()
                     .uri("?node.id=" + nodes.get(0).getNodeId())
                     .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+                    .body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1585,11 +1571,7 @@ final class NetworkControllerTest extends ControllerTest {
             setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?limit=3")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?limit=3").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1677,11 +1659,8 @@ final class NetworkControllerTest extends ControllerTest {
             setupNetworkNodeData();
 
             // when
-            final var actual = restClient
-                    .get()
-                    .uri("?file.id=0.0.99999")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual =
+                    restClient.get().uri("?file.id=0.0.99999").retrieve().body(NetworkNodesResponse.class);
 
             // then - should return empty results
             assertThat(actual).isNotNull();
@@ -1694,11 +1673,7 @@ final class NetworkControllerTest extends ControllerTest {
             var nodes = setupNetworkNodeData();
 
             // when - request with limit smaller than total results
-            final var actual = restClient
-                    .get()
-                    .uri("?limit=1")
-                    .retrieve()
-                    .body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("?limit=1").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1712,8 +1687,7 @@ final class NetworkControllerTest extends ControllerTest {
             setupNetworkNodeData();
 
             // when
-            final var actual =
-                    restClient.get().uri("").retrieve().body(org.hiero.mirror.rest.model.NetworkNodesResponse.class);
+            final var actual = restClient.get().uri("").retrieve().body(NetworkNodesResponse.class);
 
             // then
             assertThat(actual).isNotNull();
@@ -1729,7 +1703,7 @@ final class NetworkControllerTest extends ControllerTest {
 
         private List<AddressBookEntry> setupNetworkNodeData() {
             var timestamp = domainBuilder.timestamp();
-            var addressBook = domainBuilder
+            domainBuilder
                     .addressBook()
                     .customize(ab -> ab.startConsensusTimestamp(timestamp))
                     .persist();
@@ -1754,8 +1728,15 @@ final class NetworkControllerTest extends ControllerTest {
             domainBuilder.nodeStake().customize(ns -> ns.nodeId(3L)).persist();
 
             // Add corresponding node data
-            domainBuilder.node().customize(n -> n.nodeId(1L)).persist();
-            domainBuilder.node().customize(n -> n.nodeId(2L)).persist();
+            domainBuilder
+                    .node()
+                    .customize(n -> n.associatedRegisteredNodes(null).nodeId(1L))
+                    .persist();
+            domainBuilder
+                    .node()
+                    .customize(n ->
+                            n.associatedRegisteredNodes(Collections.EMPTY_LIST).nodeId(2L))
+                    .persist();
             domainBuilder.node().customize(n -> n.nodeId(3L)).persist();
 
             return List.of(entry1, entry2, entry3);

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/NetworkNodeMapperTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/mapper/NetworkNodeMapperTest.java
@@ -19,6 +19,7 @@ final class NetworkNodeMapperTest {
     void map() {
         // Given - row with all fields populated
         var row = mock(NetworkNodeDto.class);
+        when(row.associatedRegisteredNodes()).thenReturn(new Long[] {1L, 10L});
         when(row.nodeId()).thenReturn(3L);
         when(row.fileId()).thenReturn(102L);
         when(row.nodeAccountId()).thenReturn(8L);
@@ -37,6 +38,7 @@ final class NetworkNodeMapperTest {
 
         // Then - verify mapped values
         assertThat(result).isNotNull().satisfies(node -> {
+            assertThat(node.getAssociatedRegisteredNodes()).containsExactly(1L, 10L);
             assertThat(node.getNodeId()).isEqualTo(3L);
             assertThat(node.getFileId()).isEqualTo("0.0.102");
             assertThat(node.getNodeAccountId()).isEqualTo("0.0.8");
@@ -60,6 +62,7 @@ final class NetworkNodeMapperTest {
         when(row.startConsensusTimestamp()).thenReturn(null);
         when(row.endConsensusTimestamp()).thenReturn(null);
         when(row.stakingPeriod()).thenReturn(null);
+        when(row.associatedRegisteredNodes()).thenReturn(new Long[] {});
 
         // When
         result = mapper.map(row);
@@ -71,7 +74,21 @@ final class NetworkNodeMapperTest {
             assertThat(node.getNodeCertHash()).isEqualTo("0x");
             assertThat(node.getTimestamp()).isNull();
             assertThat(node.getStakingPeriod()).isNull();
+            assertThat(node.getAssociatedRegisteredNodes()).isEmpty();
         });
+    }
+
+    @Test
+    void mapAssociatedRegisteredNodesNull() {
+        // given
+        final var row = mock(NetworkNodeDto.class);
+        when(row.associatedRegisteredNodes()).thenCallRealMethod();
+
+        // when
+        final var result = mapper.map(row);
+
+        // then
+        assertThat(result.getAssociatedRegisteredNodes()).isEmpty();
     }
 
     private ServiceEndpoint createServiceEndpoint(String ip, int port) {

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/repository/NetworkNodeRepositoryTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/repository/NetworkNodeRepositoryTest.java
@@ -264,7 +264,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
     void findNetworkNodesAllFieldsPopulated() {
         // given
         var timestamp = domainBuilder.timestamp();
-        var addressBook = domainBuilder
+        domainBuilder
                 .addressBook()
                 .customize(ab -> ab.startConsensusTimestamp(timestamp))
                 .persist();
@@ -290,6 +290,7 @@ final class NetworkNodeRepositoryTest extends RestJavaIntegrationTest {
         assertThat(result.startConsensusTimestamp()).isNotNull();
         assertThat(result.endConsensusTimestamp()).isNotNull();
         assertThat(result.adminKey()).isNotNull();
+        assertThat(result.associatedRegisteredNodes()).isNotEmpty();
         assertThat(result.declineReward()).isNotNull();
         assertThat(result.maxStake()).isNotNull();
         assertThat(result.minStake()).isNotNull();

--- a/rest/api/v1/openapi.yml
+++ b/rest/api/v1/openapi.yml
@@ -3022,6 +3022,7 @@ components:
       type: object
       required:
         - admin_key
+        - associated_registered_nodes
         - decline_reward
         - description
         - file_id
@@ -3043,6 +3044,12 @@ components:
       properties:
         admin_key:
           $ref: "#/components/schemas/Key"
+        associated_registered_nodes:
+          type: array
+          items:
+            format: int64
+            minimum: 0
+            type: integer
         decline_reward:
           description: Whether the node wants to receive staking rewards or not.
           nullable: true
@@ -3120,6 +3127,7 @@ components:
         admin_key:
           _type: "ED25519"
           key: "15706b229b3ba33d4a5a41ff54ce1cfe0a3d308672a33ff382f81583e02bd743"
+        associated_registered_nodes: [1, 10]
         decline_reward: false
         description: "address book 1"
         file_id: "0.0.102"


### PR DESCRIPTION
**Description**:

This PR adds `associated_registered_nodes` to the response of endpoint `/api/v1/network/nodes`

**Related issue(s)**:

Fixes #13360 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
