### PR TITLE
Fix k6 tests constant name

### DIFF
--- a/tools/k6/src/rest-java/libex/constants.js
+++ b/tools/k6/src/rest-java/libex/constants.js
@@ -5,4 +5,4 @@ export const airdrops = 'airdrops';
 export const hooks = 'hooks';
 export const hookStorage = 'storage';
 export const nodeListName = 'nodes';
-export const registeredNodes = 'registered-nodes';
+export const registeredNodes = 'registered_nodes';


### PR DESCRIPTION
**Description**:
Modify k6 constant from "registered-node" to "registered_node" to match the property in the registered nodes endpoint response.

### **k6 tests configuration and results:**

DEFAULT_DURATION=30s \
DEFAULT_LIMIT=100 \
DEFAULT_VUS=1 \
DEFAULT_START_ACCOUNT=0.0.2 k6 run -v src/rest-java/test/networkRegisteredNodes.js

 █ TOTAL RESULTS 

    checks_total.......: 8406    280.182759/s
    checks_succeeded...: 100.00% 8406 out of 8406
    checks_failed......: 0.00%   0 out of 8406

    ✓ Network Registered Nodes OK

    HTTP
    http_req_duration..............: avg=1.82ms min=1.21ms med=1.72ms max=30.28ms p(90)=2.07ms p(95)=2.6ms 
      { expected_response:true }...: avg=1.82ms min=1.21ms med=1.72ms max=30.28ms p(90)=2.07ms p(95)=2.6ms 
    http_req_failed................: 0.00%  0 out of 8406
    http_reqs......................: 8406   280.182759/s

    EXECUTION
    iteration_duration.............: avg=3.56ms min=2.43ms med=3.46ms max=33.36ms p(90)=4.08ms p(95)=4.44ms
    iterations.....................: 8406   280.182759/s
    vus............................: 1      min=1         max=1
    vus_max........................: 1      min=1         max=1

    NETWORK
    data_received..................: 357 MB 12 MB/s
    data_sent......................: 1.1 MB 36 kB/s

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
