### PR TITLE
fix(rest-java): pass shard/realm to AppEntityIdFactory in FeeEstimationService (0.153)

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/service/fee/FeeEstimationFeeContext.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/service/fee/FeeEstimationFeeContext.java
@@ -42,13 +42,21 @@ import com.swirlds.config.api.Configuration;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.common.CommonProperties;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 @RequiredArgsConstructor
 final class FeeEstimationFeeContext implements FeeContext {
 
-    private static final ConfigProviderImpl CONFIG_PROVIDER = new ConfigProviderImpl(false, null, Map.of());
+    private static final ConfigProviderImpl CONFIG_PROVIDER = new ConfigProviderImpl(
+            false,
+            null,
+            Map.of(
+                    "hedera.shard",
+                            String.valueOf(CommonProperties.getInstance().getShard()),
+                    "hedera.realm",
+                            String.valueOf(CommonProperties.getInstance().getRealm())));
     static final Configuration CONFIGURATION = CONFIG_PROVIDER.getConfiguration();
     private static final Authorizer FEE_AUTHORIZER =
             new AuthorizerImpl(CONFIG_PROVIDER, new PrivilegesVerifier(CONFIG_PROVIDER));

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/service/fee/FeeEstimationServiceTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/service/fee/FeeEstimationServiceTest.java
@@ -12,12 +12,15 @@ import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.hiero.hapi.fees.HighVolumePricingCalculator;
@@ -303,6 +306,15 @@ final class FeeEstimationServiceTest extends RestJavaIntegrationTest {
         final var second = service.estimateFees(txn, FeeEstimateMode.STATE, 0);
         assertThat(second.getServiceBaseFeeTinycents()).isEqualTo(baseFee20x);
         assertThat(second.totalTinycents()).isGreaterThan(first.totalTinycents());
+    }
+
+    @Test
+    void configurationContainsNetworkShardAndRealm() {
+        final var config = new ConfigProviderImpl(false, null, Map.of("hedera.shard", "5", "hedera.realm", "7"))
+                .getConfiguration()
+                .getConfigData(HederaConfig.class);
+        assertThat(config.shard()).isEqualTo(5L);
+        assertThat(config.realm()).isEqualTo(7L);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR cherry-picks the fix to `release/0.153`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
