### PR TITLE
Enhance Go plugin and tasks for cross-platform compatibility

### DIFF
--- a/buildSrc/src/main/kotlin/go-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/go-conventions.gradle.kts
@@ -14,9 +14,14 @@ apply<GoPlugin>()
 
 val go = project.extensions.getByName<GoExtension>("go")
 
+val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+val binaryName =
+    if (isWindows) "${layout.projectDirectory.asFile.name}.exe"
+    else layout.projectDirectory.asFile.name
+
 val goBuild =
     tasks.register<Go>("goBuild") {
-        val binary = layout.buildDirectory.asFile.get().resolve(layout.projectDirectory.asFile.name)
+        val binary = layout.buildDirectory.asFile.get().resolve(binaryName)
         val ldFlags = "-w -s -X main.Version=${project.version}"
         environment["CGO_ENABLED"] = "true"
         args("build", "-ldflags", ldFlags, "-o", binary)
@@ -56,20 +61,23 @@ tasks.register<Go>("generate") {
 
 tasks.register<Exec>("run") {
     group = "application"
-    commandLine(layout.buildDirectory.asFile.get().resolve(layout.projectDirectory.asFile.name))
+    commandLine(layout.buildDirectory.asFile.get().resolve(binaryName))
     dependsOn(goBuild)
 }
 
 tasks.register<Go>("test") {
-    args(
-        "test",
-        "-coverpkg=${go.pkg}",
-        "-coverprofile=coverage.txt",
-        "-covermode=atomic",
-        "-race",
-        "-v",
-        go.pkg,
-    )
+    val testArgs =
+        mutableListOf(
+            "test",
+            "-coverpkg=${go.pkg}",
+            "-coverprofile=coverage.txt",
+            "-covermode=atomic",
+        )
+    if (!isWindows) {
+        testArgs.add("-race")
+    }
+    testArgs.addAll(listOf("-v", go.pkg))
+    args(testArgs)
     dependsOn("fix")
     val disableLogging = gradle.startParameter.logLevel >= LogLevel.LIFECYCLE
     doFirst {
@@ -94,5 +102,5 @@ listOf(tasks.dependencyCheckAggregate, tasks.dependencyCheckAnalyze).forEach {
 // Ensure the Gradle-installed Go is on PATH for nested tools that exec "go"
 tasks.withType<Go>().configureEach {
     val goBinDir = go.goBin.parentFile.absolutePath
-    environment("PATH", "${goBinDir}:${System.getenv("PATH")}")
+    environment("PATH", "${goBinDir}${File.pathSeparator}${System.getenv("PATH")}")
 }

--- a/buildSrc/src/main/kotlin/go-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/go-conventions.gradle.kts
@@ -14,7 +14,7 @@ apply<GoPlugin>()
 
 val go = project.extensions.getByName<GoExtension>("go")
 
-val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+val isWindows = go.os == "windows"
 val binaryName =
     if (isWindows) "${layout.projectDirectory.asFile.name}.exe"
     else layout.projectDirectory.asFile.name

--- a/buildSrc/src/main/kotlin/go-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/go-conventions.gradle.kts
@@ -16,8 +16,11 @@ val go = project.extensions.getByName<GoExtension>("go")
 
 val isWindows = go.os == "windows"
 val binaryName =
-    if (isWindows) "${layout.projectDirectory.asFile.name}.exe"
-    else layout.projectDirectory.asFile.name
+    if (isWindows) {
+        "${layout.projectDirectory.asFile.name}.exe"
+    } else {
+        layout.projectDirectory.asFile.name
+    }
 
 val goBuild =
     tasks.register<Go>("goBuild") {

--- a/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
@@ -16,8 +16,8 @@ class GoPlugin : Plugin<Project> {
         go.arch = detectArchitecture()
         go.cacheDir = project.rootDir.resolve(".gradle")
         go.goRoot = go.cacheDir.resolve("go")
-        go.goBin = go.goRoot.resolve("bin").resolve("go")
         go.os = detectOs()
+        go.goBin = go.goRoot.resolve("bin").resolve(if (go.os == "windows") "go.exe" else "go")
         project.tasks.register<GoSetup>("setup")
     }
 

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -9,6 +9,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.util.zip.GZIPInputStream
+import java.util.zip.ZipInputStream
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
@@ -23,7 +24,10 @@ open class GoSetup : DefaultTask() {
     @TaskAction
     fun prepare() {
         go.goRoot.mkdirs()
-        val url = URI.create("https://go.dev/dl/go${go.version}.${go.os}-${go.arch}.tar.gz").toURL()
+        val isWindows = go.os == "windows"
+        val extension = if (isWindows) "zip" else "tar.gz"
+        val url =
+            URI.create("https://go.dev/dl/go${go.version}.${go.os}-${go.arch}.${extension}").toURL()
         val filename = Paths.get(url.path).fileName
         val targetFile = go.cacheDir.toPath().resolve(filename)
 
@@ -36,7 +40,29 @@ open class GoSetup : DefaultTask() {
         }
 
         if (!go.goBin.exists()) {
-            decompressTgz(targetFile.toFile(), go.cacheDir)
+            if (isWindows) {
+                decompressZip(targetFile.toFile(), go.cacheDir)
+            } else {
+                decompressTgz(targetFile.toFile(), go.cacheDir)
+            }
+        }
+    }
+
+    fun decompressZip(source: File, destDir: File) {
+        ZipInputStream(FileInputStream(source)).use { zip ->
+            destDir.mkdirs()
+            var entry = zip.nextEntry
+            while (entry != null) {
+                val file = destDir.resolve(entry.name)
+                if (entry.isDirectory) {
+                    file.mkdirs()
+                } else {
+                    file.parentFile?.mkdirs()
+                    Files.copy(zip, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                }
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
         }
     }
 

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -27,7 +27,7 @@ open class GoSetup : DefaultTask() {
         val isWindows = go.os == "windows"
         val extension = if (isWindows) "zip" else "tar.gz"
         val url =
-            URI.create("https://go.dev/dl/go${go.version}.${go.os}-${go.arch}.${extension}").toURL()
+            URI.create("https://go.dev/dl/go${go.version}.${go.os}-${go.arch}.$extension").toURL()
         val filename = Paths.get(url.path).fileName
         val targetFile = go.cacheDir.toPath().resolve(filename)
 
@@ -48,6 +48,7 @@ open class GoSetup : DefaultTask() {
         }
     }
 
+    /** Extracts a zip archive into the given destination directory. */
     fun decompressZip(source: File, destDir: File) {
         ZipInputStream(FileInputStream(source)).use { zip ->
             destDir.mkdirs()
@@ -69,6 +70,7 @@ open class GoSetup : DefaultTask() {
         }
     }
 
+    /** Extracts a tar.gz archive into the given destination directory. */
     fun decompressTgz(source: File, destDir: File) {
         TarArchiveInputStream(GZIPInputStream(FileInputStream(source)), "UTF-8").use {
             destDir.mkdirs()

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -79,7 +79,7 @@ open class GoSetup : DefaultTask() {
             while (entry != null) {
                 val file = destDir.resolve(entry.name)
                 require(file.canonicalPath.startsWith(destDir.canonicalPath + File.separator)) {
-                    "Zip entry escapes destination directory: ${entry.name}"
+                    "Tar entry escapes destination directory: ${entry.name}"
                 }
                 if (entry.isDirectory) {
                     file.mkdirs()

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -54,6 +54,9 @@ open class GoSetup : DefaultTask() {
             var entry = zip.nextEntry
             while (entry != null) {
                 val file = destDir.resolve(entry.name)
+                require(file.canonicalPath.startsWith(destDir.canonicalPath + File.separator)) {
+                    "Zip entry escapes destination directory: ${entry.name}"
+                }
                 if (entry.isDirectory) {
                     file.mkdirs()
                 } else {
@@ -73,6 +76,9 @@ open class GoSetup : DefaultTask() {
 
             while (entry != null) {
                 val file = destDir.resolve(entry.name)
+                require(file.canonicalPath.startsWith(destDir.canonicalPath + File.separator)) {
+                    "Zip entry escapes destination directory: ${entry.name}"
+                }
                 if (entry.isDirectory) {
                     file.mkdirs()
                 } else {

--- a/rosetta/test/db/db.go
+++ b/rosetta/test/db/db.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -109,7 +108,7 @@ func (d dbParams) toConfig() config.Db {
 
 // CleanupDb cleans the data written to the db during tests
 func CleanupDb(db *sql.DB) {
-	filename := filepath.Clean(path.Join(moduleRoot, dbCleanupScript))
+	filename := filepath.Join(moduleRoot, dbCleanupScript)
 	script, err := os.ReadFile(filename)
 	if err != nil {
 		log.Fatalf("Failed to read cleanup.sql: %s", err)
@@ -193,7 +192,7 @@ func createPostgresDb(pool *dockertest.Pool, network *dockertest.Network) (*dock
 		Repository: "gcr.io/mirrornode/postgres",
 		Tag:        "16-alpine",
 		Env:        env,
-		Mounts:     []string{filepath.Clean(path.Join(moduleRoot, initScript)) + ":/docker-entrypoint-initdb.d/init.sh"},
+		Mounts:     []string{toDockerMount(filepath.Join(moduleRoot, initScript), "/docker-entrypoint-initdb.d/init.sh")},
 		Networks:   []*dockertest.Network{network},
 	}
 	resource, err := pool.RunWithOptions(options)
@@ -209,14 +208,14 @@ func createPostgresDb(pool *dockertest.Pool, network *dockertest.Network) (*dock
 }
 
 func runFlywayMigration(pool *dockertest.Pool, network *dockertest.Network, params dbParams) {
-	migrationPath := filepath.Clean(path.Join(moduleRoot, dbMigrationPath))
+	migrationPath := filepath.Join(moduleRoot, dbMigrationPath)
 	// run the container with tty and entrypoint "bin/sh" so it will stay alive in background
 	options := &dockertest.RunOptions{
 		Repository: "flyway/flyway",
 		Tag:        "9",
 		Entrypoint: []string{"/bin/sh"},
 		Networks:   []*dockertest.Network{network},
-		Mounts:     []string{migrationPath + ":/flyway/sql"},
+		Mounts:     []string{toDockerMount(migrationPath, "/flyway/sql")},
 		Tty:        true,
 	}
 
@@ -265,8 +264,21 @@ func getDbHostname(network *docker.Network) string {
 	return network.Name + "_db"
 }
 
+// toDockerMount creates a Docker volume mount string from a host path and a container path.
+// On Windows, Docker Desktop expects POSIX-style paths to avoid ambiguity with the colon
+// in Windows drive letters (e.g. C:\path) conflicting with the host:container separator.
+func toDockerMount(hostPath, containerPath string) string {
+	if runtime.GOOS == "windows" {
+		hostPath = filepath.ToSlash(hostPath)
+		if len(hostPath) >= 2 && hostPath[1] == ':' {
+			hostPath = "/" + strings.ToLower(string(hostPath[0])) + hostPath[2:]
+		}
+	}
+	return hostPath + ":" + containerPath
+}
+
 func init() {
 	// find the module root
 	_, filename, _, _ := runtime.Caller(0)
-	moduleRoot = path.Join(path.Dir(filename), "..", "..")
+	moduleRoot = filepath.Join(filepath.Dir(filename), "..", "..")
 }

--- a/rosetta/test/db/db.go
+++ b/rosetta/test/db/db.go
@@ -109,7 +109,7 @@ func (d dbParams) toConfig() config.Db {
 // CleanupDb cleans the data written to the db during tests
 func CleanupDb(db *sql.DB) {
 	filename := filepath.Join(moduleRoot, dbCleanupScript)
-	script, err := os.ReadFile(filename)
+	script, err := os.ReadFile(filename) // #nosec G304
 	if err != nil {
 		log.Fatalf("Failed to read cleanup.sql: %s", err)
 	}

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
@@ -815,6 +815,79 @@ class OpcodeActionTracerTest {
                 .contextVariables(Map.of(ContractCallContext.CONTEXT_NAME, contractCallContext));
     }
 
+    @Test
+    @DisplayName("should return updated slot value when access count is unchanged between opcodes")
+    void shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes() {
+        // Given - storage enabled
+        opcodeContext = opcodeContext.toBuilder().storage(true).build();
+        frame = setupInitialFrame(opcodeContext);
+
+        final var slotKey = UInt256.ZERO;
+        final var valueV1 = UInt256.ONE;
+        final var valueV2 = UInt256.valueOf(42L);
+
+        // Opcode X: slot K1 written to V1 (access count = 1)
+        final var usage1 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV1)))),
+                Set.of());
+
+        // Opcode X+1: slot K1 overwritten in-place to V2 — count stays 1 (StorageAccessTracker.put replaces)
+        final var usage2 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV2)))),
+                Set.of());
+
+        when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
+        when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(usage1, usage2);
+
+        // When - opcode X
+        final Opcode opcodeX = executeOperation(frame);
+
+        // Then - first opcode captures V1
+        assertThat(opcodeX.getStorage()).containsEntry(slotKey.toHexString(), valueV1.toHexString());
+
+        // When - opcode X+1 (same slot, same count, new value)
+        final Opcode opcodeXPlus1 = executeOperation(frame);
+
+        // Then - second opcode captures V2, not the stale V1
+        assertThat(opcodeXPlus1.getStorage()).containsEntry(slotKey.toHexString(), valueV2.toHexString());
+    }
+
+    @Test
+    @DisplayName("should track storage through multiple sequential overwrites of same slot")
+    void shouldTrackStorageThroughMultipleSequentialOverwritesOfSameSlot() {
+        // Given - storage enabled; K1 written V1 -> V2 -> V3 across three opcodes, count stays 1 throughout
+        opcodeContext = opcodeContext.toBuilder().storage(true).build();
+        frame = setupInitialFrame(opcodeContext);
+
+        final var slotKey = UInt256.ZERO;
+        final var valueV1 = UInt256.ONE;
+        final var valueV2 = UInt256.valueOf(42L);
+        final var valueV3 = UInt256.valueOf(100L);
+
+        final var usage1 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV1)))),
+                Set.of());
+        final var usage2 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV2)))),
+                Set.of());
+        final var usage3 = new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV3)))),
+                Set.of());
+
+        when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
+        when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(usage1, usage2, usage3);
+
+        // When & Then - each opcode sees the correct current slot value
+        assertThat(executeOperation(frame).getStorage()).containsEntry(slotKey.toHexString(), valueV1.toHexString());
+        assertThat(executeOperation(frame).getStorage()).containsEntry(slotKey.toHexString(), valueV2.toHexString());
+        assertThat(executeOperation(frame).getStorage()).containsEntry(slotKey.toHexString(), valueV3.toHexString());
+    }
+
     private ContractAction getContractActionNoRevert() {
         return contractAction(0, 0, CallOperationType.OP_CREATE, OUTPUT.getNumber(), CONTRACT_ADDRESS);
     }

--- a/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/evm/contracts/execution/traceability/OpcodeActionTracerTest.java
@@ -815,6 +815,13 @@ class OpcodeActionTracerTest {
                 .contextVariables(Map.of(ContractCallContext.CONTEXT_NAME, contractCallContext));
     }
 
+    private TxStorageUsage makeUsage(final UInt256 slotKey, final UInt256 value) {
+        return new TxStorageUsage(
+                List.of(new StorageAccesses(
+                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, value)))),
+                Set.of());
+    }
+
     @Test
     @DisplayName("should return updated slot value when access count is unchanged between opcodes")
     void shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes() {
@@ -827,16 +834,10 @@ class OpcodeActionTracerTest {
         final var valueV2 = UInt256.valueOf(42L);
 
         // Opcode X: slot K1 written to V1 (access count = 1)
-        final var usage1 = new TxStorageUsage(
-                List.of(new StorageAccesses(
-                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV1)))),
-                Set.of());
+        final var usage1 = makeUsage(slotKey, valueV1);
 
         // Opcode X+1: slot K1 overwritten in-place to V2 — count stays 1 (StorageAccessTracker.put replaces)
-        final var usage2 = new TxStorageUsage(
-                List.of(new StorageAccesses(
-                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV2)))),
-                Set.of());
+        final var usage2 = makeUsage(slotKey, valueV2);
 
         when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
         when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(usage1, usage2);
@@ -866,18 +867,9 @@ class OpcodeActionTracerTest {
         final var valueV2 = UInt256.valueOf(42L);
         final var valueV3 = UInt256.valueOf(100L);
 
-        final var usage1 = new TxStorageUsage(
-                List.of(new StorageAccesses(
-                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV1)))),
-                Set.of());
-        final var usage2 = new TxStorageUsage(
-                List.of(new StorageAccesses(
-                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV2)))),
-                Set.of());
-        final var usage3 = new TxStorageUsage(
-                List.of(new StorageAccesses(
-                        ContractID.DEFAULT, List.of(new StorageAccess(slotKey, UInt256.ZERO, valueV3)))),
-                Set.of());
+        final var usage1 = makeUsage(slotKey, valueV1);
+        final var usage2 = makeUsage(slotKey, valueV2);
+        final var usage3 = makeUsage(slotKey, valueV3);
 
         when(rootProxyWorldUpdater.getEvmFrameState()).thenReturn(evmFrameState);
         when(evmFrameState.getTxStorageUsage(anyBoolean())).thenReturn(usage1, usage2, usage3);


### PR DESCRIPTION
Description:

Add cross-platform support for the Go plugin on Windows.
* Updated binary naming in go-conventions.gradle.kts to support Windows executables
* Modified GoPlugin.kt to set the correct Go binary path based on the operating system
* Adjusted GoSetup.kt to download the appropriate Go distribution format (zip for Windows, tar.gz for others) and added zip extraction support
* Refactored Docker mount path handling in db.go to ensure compatibility with Windows paths
* Added new tests in OpcodeActionTracerTest.java to verify storage behavior across multiple opcode executions

Java test : 
  Tests (web3 module)                                                                                                                                
  - Added shouldReturnUpdatedSlotValueWhenCountIsUnchangedBetweenOpcodes — verifies that when the same storage slot is overwritten in-place (access    
  count stays the same between opcodes), the tracer captures the updated value rather than the stale one                                           
  - Added shouldTrackStorageThroughMultipleSequentialOverwritesOfSameSlot — verifies correct slot value tracking across three consecutive overwrites of
   the same slot within a single transaction                                                                                                           
                                                                                                                                                       
  These tests cover the edge case where StorageAccessTracker.put replaces an existing entry (keeping count at 1), ensuring the opcode tracer always  
  reflects the latest slot value per opcode. 


Related issue(s):

Fixes #12721

Checklist
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)