### PR TITLE
Reduce jar size by excluding transitive dependencies

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -10,7 +10,6 @@ configurations.all {
 
 dependencies {
     val testClasses by configurations.registering
-    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
     api("com.github.ben-manes.caffeine:caffeine")
@@ -25,10 +24,14 @@ dependencies {
     api("org.apache.tuweni:tuweni-units")
     api("org.bouncycastle:bcprov-jdk18on")
     api("org.slf4j:jcl-over-slf4j")
+    api("org.springframework.boot:spring-boot-hibernate")
     api("org.springframework.boot:spring-boot-jackson2")
-    api("org.springframework.boot:spring-boot-starter-data-jpa")
+    api("org.springframework.boot:spring-boot-persistence")
+    api("org.springframework.boot:spring-boot-starter-jdbc")
+    api("org.springframework.data:spring-data-commons")
     api("org.springframework.boot:spring-boot-starter-micrometer-metrics")
     api("org.springframework.boot:spring-boot-starter-validation")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("jakarta.inject:jakarta.inject-api")
     testImplementation("io.micrometer:micrometer-core")
     testImplementation("org.junit.platform:junit-platform-launcher")

--- a/common/src/main/java/org/hiero/mirror/common/domain/entity/AbstractEntity.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/entity/AbstractEntity.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Range;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.sql.Date;
@@ -124,7 +122,6 @@ public abstract class AbstractEntity implements History {
 
     private Range<Long> timestampRange;
 
-    @Enumerated(EnumType.STRING)
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private EntityType type;
 

--- a/graphql/build.gradle.kts
+++ b/graphql/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
         exclude(group = "org.springframework.security")
     }
     implementation(project(":common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.graphql-java:graphql-java-extended-scalars")
     implementation("com.graphql-java:graphql-java-extended-validation")
     implementation("io.github.mweirauch:micrometer-jvm-extras")

--- a/grpc/build.gradle.kts
+++ b/grpc/build.gradle.kts
@@ -5,7 +5,10 @@ description = "Hiero Mirror Node gRPC API"
 plugins { id("spring-conventions") }
 
 dependencies {
-    implementation(project(":common"))
+    implementation(project(":common")) {
+        exclude(group = "org.springframework.boot", module = "spring-boot-starter-data-jpa")
+        exclude(group = "org.hibernate.orm")
+    }
     implementation(project(":protobuf"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.ongres.scram:client")
@@ -15,11 +18,14 @@ dependencies {
     implementation("io.projectreactor.addons:reactor-extra")
     implementation("io.projectreactor:reactor-core-micrometer")
     implementation("jakarta.inject:jakarta.inject-api")
+    implementation("jakarta.persistence:jakarta.persistence-api")
+    compileOnly("org.hibernate.orm:hibernate-core")
     implementation("org.msgpack:jackson-dataformat-msgpack")
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-health")
     implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.grpc:spring-grpc-spring-boot-starter")

--- a/grpc/src/main/java/org/hiero/mirror/grpc/GrpcApplication.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/GrpcApplication.java
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @Import(CommonConfiguration.class)
-@SpringBootApplication
+@SpringBootApplication(excludeName = {"org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration"})
 public class GrpcApplication {
 
     public static void main(String[] args) {

--- a/grpc/src/main/java/org/hiero/mirror/grpc/repository/AddressBookEntryRepository.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/repository/AddressBookEntryRepository.java
@@ -8,7 +8,7 @@ import static org.hiero.mirror.grpc.config.CacheConfiguration.CACHE_NAME;
 import java.util.List;
 import org.hiero.mirror.common.domain.addressbook.AddressBookEntry;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AddressBookEntryRepository extends CrudRepository<AddressBookEntry, AddressBookEntry.Id> {
@@ -32,6 +32,6 @@ public interface AddressBookEntryRepository extends CrudRepository<AddressBookEn
           and abe.node_id >= ?
         order by abe.node_id asc
         limit ?
-        """, nativeQuery = true)
+        """)
     List<AddressBookEntry> findByConsensusTimestampAndNodeId(long consensusTimestamp, long nodeId, int limit);
 }

--- a/grpc/src/main/java/org/hiero/mirror/grpc/repository/AddressBookRepository.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/repository/AddressBookRepository.java
@@ -4,11 +4,11 @@ package org.hiero.mirror.grpc.repository;
 
 import java.util.Optional;
 import org.hiero.mirror.common.domain.addressbook.AddressBook;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface AddressBookRepository extends CrudRepository<AddressBook, Long> {
 
-    @Query(value = "select max(start_consensus_timestamp) from address_book where file_id = ?", nativeQuery = true)
+    @Query(value = "select max(start_consensus_timestamp) from address_book where file_id = ?")
     Optional<Long> findLatestTimestamp(long fileId);
 }

--- a/grpc/src/main/java/org/hiero/mirror/grpc/repository/NodeStakeRepository.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/repository/NodeStakeRepository.java
@@ -11,11 +11,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.hiero.mirror.common.domain.addressbook.NodeStake;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface NodeStakeRepository extends CrudRepository<NodeStake, NodeStake.Id> {
-    @Query(value = "select max(consensus_timestamp) from node_stake", nativeQuery = true)
+    @Query(value = "select max(consensus_timestamp) from node_stake")
     Optional<Long> findLatestTimestamp();
 
     List<NodeStake> findAllByConsensusTimestamp(long consensusTimestamp);

--- a/grpc/src/main/java/org/hiero/mirror/grpc/repository/TopicMessageRepository.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/repository/TopicMessageRepository.java
@@ -4,7 +4,7 @@ package org.hiero.mirror.grpc.repository;
 
 import java.util.List;
 import org.hiero.mirror.common.domain.topic.TopicMessage;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface TopicMessageRepository extends CrudRepository<TopicMessage, Long>, TopicMessageRepositoryCustom {
@@ -21,6 +21,6 @@ public interface TopicMessageRepository extends CrudRepository<TopicMessage, Lon
        from topic_message as t
        join related_transaction using (topic_id, consensus_timestamp)
        order by t.consensus_timestamp
-       """, nativeQuery = true)
+       """)
     List<TopicMessage> findLatest(long consensusTimestamp, int limit);
 }

--- a/grpc/src/main/java/org/hiero/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
@@ -3,60 +3,57 @@
 package org.hiero.mirror.grpc.repository;
 
 import jakarta.inject.Named;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.jpa.HibernateHints;
 import org.hiero.mirror.common.domain.topic.TopicMessage;
 import org.hiero.mirror.grpc.domain.TopicMessageFilter;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
 @CustomLog
 @Named
 @RequiredArgsConstructor
 public class TopicMessageRepositoryCustomImpl implements TopicMessageRepositoryCustom {
 
-    private static final String CONSENSUS_TIMESTAMP = "consensusTimestamp";
-    private static final String TOPIC_ID = "topicId";
-    // make the cost estimation of using the index on (topic_id, consensus_timestamp) lower than that of
-    // the primary key so pg planner will choose the better index when querying topic messages by id
+    private static final String COLUMN_CONSENSUS_TIMESTAMP = "consensus_timestamp";
+    private static final String COLUMN_TOPIC_ID = "topic_id";
     private static final String TOPIC_MESSAGES_BY_ID_QUERY_HINT = "set local random_page_cost = 0";
+    private static final RowMapper<TopicMessage> ROW_MAPPER = new BeanPropertyRowMapper<>(TopicMessage.class);
 
-    private final EntityManager entityManager;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public Stream<TopicMessage> findByFilter(TopicMessageFilter filter) {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<TopicMessage> query = cb.createQuery(TopicMessage.class);
-        Root<TopicMessage> root = query.from(TopicMessage.class);
+        StringBuilder sql = new StringBuilder("select * from topic_message where ")
+                .append(COLUMN_TOPIC_ID)
+                .append(" = ? and ")
+                .append(COLUMN_CONSENSUS_TIMESTAMP)
+                .append(" >= ?");
 
-        Predicate predicate = cb.and(
-                cb.equal(root.get(TOPIC_ID), filter.getTopicId()),
-                cb.greaterThanOrEqualTo(root.get(CONSENSUS_TIMESTAMP), filter.getStartTime()));
+        List<Object> params = new ArrayList<>();
+        params.add(filter.getTopicId());
+        params.add(filter.getStartTime());
 
         if (filter.getEndTime() != null) {
-            predicate = cb.and(predicate, cb.lessThan(root.get(CONSENSUS_TIMESTAMP), filter.getEndTime()));
+            sql.append(" and ").append(COLUMN_CONSENSUS_TIMESTAMP).append(" < ?");
+            params.add(filter.getEndTime());
         }
 
-        query = query.select(root).where(predicate).orderBy(cb.asc(root.get(CONSENSUS_TIMESTAMP)));
-
-        TypedQuery<TopicMessage> typedQuery = entityManager.createQuery(query);
-        typedQuery.setHint(HibernateHints.HINT_READ_ONLY, true);
+        sql.append(" order by ").append(COLUMN_CONSENSUS_TIMESTAMP).append(" asc");
 
         if (filter.hasLimit()) {
-            typedQuery.setMaxResults((int) filter.getLimit());
+            sql.append(" limit ?");
+            params.add(filter.getLimit());
         }
 
         if (filter.getLimit() != 1) {
-            // only apply the hint when limit is not 1
-            entityManager.createNativeQuery(TOPIC_MESSAGES_BY_ID_QUERY_HINT).executeUpdate();
+            jdbcTemplate.execute(TOPIC_MESSAGES_BY_ID_QUERY_HINT);
         }
 
-        return typedQuery.getResultList().stream(); // getResultStream()'s cursor doesn't work with reactive streams
+        return jdbcTemplate.query(sql.toString(), ROW_MAPPER, params.toArray()).stream();
     }
 }

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     implementation(platform("software.amazon.awssdk:bom"))
     implementation(project(":common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.esaulpaugh:headlong")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
     implementation("com.hedera.cryptography:hedera-cryptography-wraps")

--- a/rest-java/build.gradle.kts
+++ b/rest-java/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
         exclude(group = "io.opentelemetry")
         exclude(group = "io.prometheus")
         exclude(group = "org.assertj")
+        exclude(group = "org.eclipse.collections")
         exclude("org.junit")
     }
     implementation("com.hedera.hashgraph:app-service-entity-id-impl") {

--- a/rest-java/build.gradle.kts
+++ b/rest-java/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor")
     implementation(project(":common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.hedera.hashgraph:app") {
         exclude(group = "io.netty")
         exclude(group = "io.opentelemetry")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -70,7 +70,6 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
     @Given("I successfully create contract by Legacy ethereum transaction")
     public void createContract() {
-
         deployedParentContract = ethereumContractCreate(PARENT_CONTRACT);
 
         gasConsumedSelector = Objects.requireNonNull(mirrorClient

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/EthereumFeature.java
@@ -70,6 +70,7 @@ public class EthereumFeature extends AbstractEstimateFeature {
 
     @Given("I successfully create contract by Legacy ethereum transaction")
     public void createContract() {
+
         deployedParentContract = ethereumContractCreate(PARENT_CONTRACT);
 
         gasConsumedSelector = Objects.requireNonNull(mirrorClient

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
         exclude(group = "io.opentelemetry")
         exclude(group = "io.prometheus")
         exclude(group = "org.assertj")
+        exclude(group = "org.eclipse.collections")
         exclude("org.junit")
     }
     implementation("com.hedera.hashgraph:app-service-entity-id-impl") {

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -18,6 +18,7 @@ configurations.all {
 
 dependencies {
     implementation(project(":common"))
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.bucket4j:bucket4j-core")
     implementation("com.hedera.hashgraph:app") {
         exclude(group = "io.netty")


### PR DESCRIPTION
**Description**:

_Note_: Grpc module is depending on the common module which uses jpa as well, so removing jpa from grpc module is not enough.

- Exclude org.eclipse.collections transitive dependency from rest-java and web3 modules to reduce jar size with 12.5MB each.
- Replace Spring JPA with Spring JDBC in grpc module

Fixes #13042

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
