### PR TITLE
Log web3 request for server errors

### DIFF
--- a/monitor/src/main/java/org/hiero/mirror/monitor/subscribe/rest/RestApiClient.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/subscribe/rest/RestApiClient.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 @Named
 public class RestApiClient {
 
+    private static final String NETWORK = "/network/";
     private static final String PREFIX = "/api/v1";
 
     private final WebClient webClientRest;
@@ -43,7 +44,8 @@ public class RestApiClient {
     }
 
     public <T> Mono<T> retrieve(Class<T> responseClass, String uri, Object... parameters) {
-        return webClientRest
+        final var webClient = uri.contains(NETWORK) ? webClientRestJava : webClientRest;
+        return webClient
                 .get()
                 .uri(uri.replace(PREFIX, StringUtils.EMPTY), parameters)
                 .retrieve()

--- a/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +30,9 @@ import org.springframework.web.util.WebUtils;
 class LoggingFilter extends OncePerRequestFilter {
 
     private static final String ACTUATOR_PATH = "/actuator/";
-    private static final String BRACE = "}";
-    private static final String COMMA = ",";
-    private static final String DATA_FIELD = "\"data\"";
+    private static final Pattern DATA_PATTERN = Pattern.compile("(\"data\":.*?),(.+)(}[^}]*)$");
     private static final String LOG_FORMAT = "{} {} {} in {} ms : {} {} - {}";
     private static final String SUCCESS = "Success";
-
     private final Web3Properties web3Properties;
 
     @Override
@@ -88,10 +86,8 @@ class LoggingFilter extends OncePerRequestFilter {
             content = StringUtils.deleteWhitespace(wrapper.getContentAsString());
         }
 
-        content = reorderFields(content);
-
         if (content.length() > maxPayloadLogSize) {
-            final var bos = new ByteArrayOutputStream();
+            final var bos = new ByteArrayOutputStream(content.length() / 4);
             try (final var out = new GZIPOutputStream(bos)) {
                 out.write(content.getBytes(StandardCharsets.UTF_8));
                 out.finish();
@@ -107,6 +103,7 @@ class LoggingFilter extends OncePerRequestFilter {
 
         // Truncate log message size unless it's a 5xx error
         if (content.length() > maxPayloadLogSize && status < HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            content = reorderFields(content);
             content = StringUtils.substring(content, 0, maxPayloadLogSize);
         }
 
@@ -130,26 +127,6 @@ class LoggingFilter extends OncePerRequestFilter {
 
     // Move data field to the end of the JSON so shorter fields are not truncated.
     private String reorderFields(String json) {
-        final int start = json.indexOf(DATA_FIELD);
-        if (start == -1) {
-            return json;
-        }
-
-        // data field already at the end
-        final int end = json.indexOf(COMMA, start);
-        if (end == -1) {
-            return json;
-        }
-
-        final int brace = json.indexOf(BRACE, end);
-        if (brace == -1) {
-            return json;
-        }
-
-        final var dataField = json.substring(start, end);
-        final var prefix = json.substring(0, start);
-        final var suffix = json.substring(end + 1, brace);
-
-        return prefix + suffix + COMMA + dataField + BRACE;
+        return DATA_PATTERN.matcher(json).replaceFirst("$2,$1$3");
     }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
@@ -130,17 +130,26 @@ class LoggingFilter extends OncePerRequestFilter {
 
     // Move data field to the end of the JSON so shorter fields are not truncated.
     private String reorderFields(String json) {
-        int start = json.indexOf(DATA_FIELD);
+        final int start = json.indexOf(DATA_FIELD);
         if (start == -1) {
             return json;
         }
 
-        int end = json.indexOf(COMMA, start);
+        // data field already at the end
+        final int end = json.indexOf(COMMA, start);
         if (end == -1) {
             return json;
         }
 
-        String dataField = json.substring(start, end);
-        return json.replace(COMMA + dataField, StringUtils.EMPTY).replace(BRACE, COMMA + dataField + BRACE);
+        final int brace = json.indexOf(BRACE, end);
+        if (brace == -1) {
+            return json;
+        }
+
+        final var dataField = json.substring(start, end);
+        final var prefix = json.substring(0, start);
+        final var suffix = json.substring(end + 1, brace);
+
+        return prefix + suffix + COMMA + dataField + BRACE;
     }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/config/LoggingFilter.java
@@ -29,6 +29,9 @@ import org.springframework.web.util.WebUtils;
 class LoggingFilter extends OncePerRequestFilter {
 
     private static final String ACTUATOR_PATH = "/actuator/";
+    private static final String BRACE = "}";
+    private static final String COMMA = ",";
+    private static final String DATA_FIELD = "\"data\"";
     private static final String LOG_FORMAT = "{} {} {} in {} ms : {} {} - {}";
     private static final String SUCCESS = "Success";
 
@@ -61,9 +64,9 @@ class LoggingFilter extends OncePerRequestFilter {
         }
 
         long elapsed = System.currentTimeMillis() - startTime;
-        var content = getContent(request);
-        var message = getMessage(request, e);
         int status = response.getStatus();
+        var content = getContent(request, status);
+        var message = getMessage(request, e);
         var params =
                 new Object[] {request.getRemoteAddr(), request.getMethod(), uri, elapsed, status, message, content};
 
@@ -76,21 +79,23 @@ class LoggingFilter extends OncePerRequestFilter {
         }
     }
 
-    private String getContent(HttpServletRequest request) {
+    private String getContent(HttpServletRequest request, int status) {
         var content = StringUtils.EMPTY;
-        int maxPayloadLogSize = web3Properties.getMaxPayloadLogSize();
-        var wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        final int maxPayloadLogSize = web3Properties.getMaxPayloadLogSize();
+        final var wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
 
         if (wrapper != null) {
             content = StringUtils.deleteWhitespace(wrapper.getContentAsString());
         }
 
+        content = reorderFields(content);
+
         if (content.length() > maxPayloadLogSize) {
-            var bos = new ByteArrayOutputStream();
-            try (var out = new GZIPOutputStream(bos)) {
+            final var bos = new ByteArrayOutputStream();
+            try (final var out = new GZIPOutputStream(bos)) {
                 out.write(content.getBytes(StandardCharsets.UTF_8));
                 out.finish();
-                var compressed = Base64.getEncoder().encodeToString(bos.toByteArray());
+                final var compressed = Base64.getEncoder().encodeToString(bos.toByteArray());
 
                 if (compressed.length() <= maxPayloadLogSize) {
                     content = compressed;
@@ -100,7 +105,8 @@ class LoggingFilter extends OncePerRequestFilter {
             }
         }
 
-        if (content.length() > maxPayloadLogSize) {
+        // Truncate log message size unless it's a 5xx error
+        if (content.length() > maxPayloadLogSize && status < HttpStatus.INTERNAL_SERVER_ERROR.value()) {
             content = StringUtils.substring(content, 0, maxPayloadLogSize);
         }
 
@@ -120,5 +126,21 @@ class LoggingFilter extends OncePerRequestFilter {
         }
 
         return SUCCESS;
+    }
+
+    // Move data field to the end of the JSON so shorter fields are not truncated.
+    private String reorderFields(String json) {
+        int start = json.indexOf(DATA_FIELD);
+        if (start == -1) {
+            return json;
+        }
+
+        int end = json.indexOf(COMMA, start);
+        if (end == -1) {
+            return json;
+        }
+
+        String dataField = json.substring(start, end);
+        return json.replace(COMMA + dataField, StringUtils.EMPTY).replace(BRACE, COMMA + dataField + BRACE);
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
@@ -160,17 +160,20 @@ final class LoggingFilterTest {
     }
 
     @CsvSource(delimiter = '|', textBlock = """
-            {"data":"0x01","block":"latest"}         | {"block":"latest","data":"0x01"}
-            {"gas":0,"data":"0x01","block":"latest"} | {"gas":0,"block":"latest","data":"0x01"}
-            {"block":"latest", "data":"0x01"}        | {"block":"latest","data":"0x01"}
-            {"data":"0x01"}                          | {"data":"0x01"}
-            {,"data":"0x01"}                         | {,"data":"0x01"}
+            {"data":"0x01","block":"latest"}          | {"block":"latest","data":"0x01"}
+            {"gas":0,"data":"0x01","block":"latest"}  | {"gas":0,"block":"latest","data":"0x01"}
+            {"block": "latest","data": "0x01"}        | {"block":"latest","data":"0x01"}
+            {"data":"0x01"}                           | {"data":"0x01"}
+            {,"data":"0x01"}                          | {,"data":"0x01"}
+            {"data":"0x01","block":"latest","foo":{}} | {"block":"latest","foo":{},"data":"0x01"}
             """)
     @ParameterizedTest
     @SneakyThrows
     void dataFieldMoved(String request, String expected, CapturedOutput output) {
+        int maxSize = web3Properties.getMaxPayloadLogSize();
+        var content = request + RandomStringUtils.secure().next(maxSize + 100, "abcdef0123456789");
         final var servletRequest = new MockHttpServletRequest("POST", "/");
-        servletRequest.setContent(request.getBytes(StandardCharsets.UTF_8));
+        servletRequest.setContent(content.getBytes(StandardCharsets.UTF_8));
         response.setStatus(HttpStatus.OK.value());
 
         loggingFilter.doFilter(servletRequest, response, (req, res) -> IOUtils.toString(req.getReader()));
@@ -236,7 +239,6 @@ final class LoggingFilterTest {
     @NullAndEmptySource
     @SneakyThrows
     void getFullExceptionMessageChildErrorsEmpty(final LinkedList<String> childErrors, CapturedOutput output) {
-        int maxSize = web3Properties.getMaxPayloadLogSize();
         var content = "abcdef0123456789";
         var request = new MockHttpServletRequest("POST", "/");
         request.setContent(content.getBytes(StandardCharsets.UTF_8));

--- a/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
@@ -30,7 +30,7 @@ import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.util.WebUtils;
 
 @ExtendWith(OutputCaptureExtension.class)
-class LoggingFilterTest {
+final class LoggingFilterTest {
 
     private final Web3Properties web3Properties = new Web3Properties();
     private final LoggingFilter loggingFilter = new LoggingFilter(web3Properties);
@@ -160,8 +160,21 @@ class LoggingFilterTest {
 
     @Test
     @SneakyThrows
-    void getFullExceptionMessage(CapturedOutput output) {
+    void errorPayloadNotTruncated(CapturedOutput output) {
         int maxSize = web3Properties.getMaxPayloadLogSize();
+        var content = RandomStringUtils.secure().next(maxSize + 100, "abcdef0123456789");
+        var request = new MockHttpServletRequest("POST", "/");
+        request.setContent(content.getBytes(StandardCharsets.UTF_8));
+        response.setStatus(HttpStatus.BAD_GATEWAY.value());
+
+        loggingFilter.doFilter(request, response, (req, res) -> IOUtils.toString(req.getReader()));
+
+        assertThat(output.getOut()).contains(content);
+    }
+
+    @Test
+    @SneakyThrows
+    void getFullExceptionMessage(CapturedOutput output) {
         var content = "abcdef0123456789";
         var request = new MockHttpServletRequest("POST", "/");
         request.setContent(content.getBytes(StandardCharsets.UTF_8));

--- a/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/config/LoggingFilterTest.java
@@ -19,6 +19,7 @@ import org.hiero.mirror.web3.exception.MirrorEvmTransactionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -156,6 +157,25 @@ final class LoggingFilterTest {
         loggingFilter.doFilter(request, response, (req, res) -> IOUtils.toString(req.getReader()));
 
         assertThat(output.getOut()).contains(content.substring(0, maxSize)).doesNotContain(content);
+    }
+
+    @CsvSource(delimiter = '|', textBlock = """
+            {"data":"0x01","block":"latest"}         | {"block":"latest","data":"0x01"}
+            {"gas":0,"data":"0x01","block":"latest"} | {"gas":0,"block":"latest","data":"0x01"}
+            {"block":"latest", "data":"0x01"}        | {"block":"latest","data":"0x01"}
+            {"data":"0x01"}                          | {"data":"0x01"}
+            {,"data":"0x01"}                         | {,"data":"0x01"}
+            """)
+    @ParameterizedTest
+    @SneakyThrows
+    void dataFieldMoved(String request, String expected, CapturedOutput output) {
+        final var servletRequest = new MockHttpServletRequest("POST", "/");
+        servletRequest.setContent(request.getBytes(StandardCharsets.UTF_8));
+        response.setStatus(HttpStatus.OK.value());
+
+        loggingFilter.doFilter(servletRequest, response, (req, res) -> IOUtils.toString(req.getReader()));
+
+        assertThat(output.getOut()).contains(expected);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

* Change the contract call API to log the full request for 5xx errors
* Move `data` field to the end of the request when logging truncated requests
* Fix monitor calls to network/nodes

**Related issue(s)**:

Fixes #13366

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
