### PR TITLE
HIP-1056 Allow empty record stream file (0.153)

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/reader/block/record/AbstractRecordFileItemReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/block/record/AbstractRecordFileItemReader.java
@@ -65,12 +65,14 @@ abstract class AbstractRecordFileItemReader implements RecordFileItemReader {
 
             // Set other common fields. Note metadata hash calculation is skipped because there is only signature for
             // file hash in SignedRecordFileProof
+            final long creationTimestamp = DomainUtils.timestampInNanosMax(recordFileItem.getCreationTime());
             final var items = context.items();
             final var recordFile = context.recordFile();
             final byte[] bytes = bos.toByteArray();
             recordFile.setBytes(bytes);
-            recordFile.setConsensusEnd(items.getLast().getConsensusTimestamp());
-            recordFile.setConsensusStart(items.getFirst().getConsensusTimestamp());
+            recordFile.setConsensusEnd(!items.isEmpty() ? items.getLast().getConsensusTimestamp() : creationTimestamp);
+            recordFile.setConsensusStart(
+                    !items.isEmpty() ? items.getFirst().getConsensusTimestamp() : creationTimestamp);
             recordFile.setCount((long) items.size());
             recordFile.setDigestAlgorithm(DigestAlgorithm.SHA_384);
             recordFile.setFileHash(Hex.encodeHexString(context.fileDigest().digest()));

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -31,7 +32,7 @@ import org.springframework.data.util.Version;
 
 @CustomLog
 @Named
-public class ProtoRecordFileReader implements RecordFileReader {
+public final class ProtoRecordFileReader implements RecordFileReader {
 
     public static final int VERSION = 6;
 
@@ -55,10 +56,21 @@ public class ProtoRecordFileReader implements RecordFileReader {
                         endHashAlgorithm);
             }
 
+            var items = readItems(recordStreamFile);
+            final long consensusStart;
+            final long consensusEnd;
+            if (!items.isEmpty()) {
+                consensusStart = items.getFirst().getConsensusTimestamp();
+                consensusEnd = items.getLast().getConsensusTimestamp();
+            } else {
+                final long fileTimestamp = DomainUtils.convertToNanosMax(
+                        streamFileData.getStreamFilename().getInstant());
+                consensusStart = fileTimestamp;
+                consensusEnd = fileTimestamp;
+            }
+
             var bytes = streamFileData.getBytes();
-            var items = readItems(filename, recordStreamFile);
             int count = items.size();
-            long consensusEnd = items.get(count - 1).getConsensusTimestamp();
             var digestAlgorithm = getDigestAlgorithm(filename, startHashAlgorithm, endHashAlgorithm);
             var hapiProtoVersion = recordStreamFile.getHapiProtoVersion();
             var majorVersion = hapiProtoVersion.getMajor();
@@ -68,7 +80,7 @@ public class ProtoRecordFileReader implements RecordFileReader {
 
             return RecordFile.builder()
                     .bytes(bytes)
-                    .consensusStart(items.get(0).getConsensusTimestamp())
+                    .consensusStart(consensusStart)
                     .consensusEnd(consensusEnd)
                     .count((long) count)
                     .digestAlgorithm(digestAlgorithm)
@@ -157,10 +169,10 @@ public class ProtoRecordFileReader implements RecordFileReader {
         }
     }
 
-    private List<RecordItem> readItems(String filename, RecordStreamFile recordStreamFile) {
-        int count = recordStreamFile.getRecordStreamItemsCount();
+    private List<RecordItem> readItems(final RecordStreamFile recordStreamFile) {
+        final int count = recordStreamFile.getRecordStreamItemsCount();
         if (count == 0) {
-            throw new InvalidStreamFileException("No record stream objects in record file " + filename);
+            return Collections.emptyList();
         }
 
         var hapiProtoVersion = recordStreamFile.getHapiProtoVersion();

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/block/record/CompositeRecordFileItemReaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/block/record/CompositeRecordFileItemReaderTest.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.importer.reader.block.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.hiero.mirror.common.util.DomainUtils.createSha384Digest;
 import static org.hiero.mirror.importer.reader.block.record.WrappedRecordBlockTestUtils.EXPECTED_RECORD_FILES;
 import static org.hiero.mirror.importer.reader.block.record.WrappedRecordBlockTestUtils.readWrappedRecordBlocks;
@@ -29,6 +30,7 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -96,6 +98,30 @@ final class CompositeRecordFileItemReaderTest {
         assertThatThrownBy(() -> reader.read(RecordFileItem.getDefaultInstance(), 0))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Unsupported record file version 0");
+    }
+
+    @Test
+    void readWithNoTransactions() {
+        // given
+        final long creationTime = DomainUtils.convertToNanosMax(Instant.now());
+        final var recordFileItem = RecordFileItem.newBuilder()
+                .setCreationTime(TestUtils.toTimestamp(creationTime))
+                .setRecordFileContents(RecordStreamFile.newBuilder()
+                        .setStartObjectRunningHash(hashObject())
+                        .setEndObjectRunningHash(hashObject())
+                        .build())
+                .build();
+
+        // when
+        final var recordFile = reader.read(recordFileItem, 6);
+
+        // then
+        assertThat(recordFile)
+                .returns(creationTime, RecordFile::getConsensusEnd)
+                .returns(creationTime, RecordFile::getConsensusStart)
+                .returns(0L, RecordFile::getCount)
+                .extracting(RecordFile::getItems, LIST)
+                .isEmpty();
     }
 
     @Test
@@ -173,9 +199,7 @@ final class CompositeRecordFileItemReaderTest {
                         .setSidecars(
                                 0,
                                 SidecarMetadata.newBuilder()
-                                        .setHash(HashObject.newBuilder()
-                                                .setAlgorithm(HashAlgorithm.SHA_384)
-                                                .setHash(ByteString.copyFrom(TestUtils.generateRandomByteArray(48))))
+                                        .setHash(hashObject())
                                         .setId(1)
                                         .build()))
                 .build();
@@ -348,12 +372,27 @@ final class CompositeRecordFileItemReaderTest {
                                 .satisfies(sidecarFileAssertion));
     }
 
+    private static RecordFileItem createRecordFileItemWithAmendments(
+            final List<RecordStreamItem> items, final List<RecordStreamItem> amendments) {
+        final var recordStreamFile = RecordStreamFile.newBuilder()
+                .setHapiProtoVersion(SemanticVersion.newBuilder().setMinor(64))
+                .setStartObjectRunningHash(hashObject(TestUtils.generateRandomByteArray(48)))
+                .addAllRecordStreamItems(items)
+                .setEndObjectRunningHash(hashObject(TestUtils.generateRandomByteArray(48)))
+                .setBlockNumber(1L)
+                .build();
+        return RecordFileItem.newBuilder()
+                .setCreationTime(items.getFirst().getRecord().getConsensusTimestamp())
+                .setRecordFileContents(recordStreamFile)
+                .addAllAmendments(amendments)
+                .build();
+    }
+
     private static RecordFileItem createRecordFileItemWithSidecar() {
         final var consensusStart = TestUtils.toTimestamp(1754103314210243000L);
         final var consensusEnd = TestUtils.toTimestamp(1754103314210243287L);
 
         final var sidecarDigest = createSha384Digest();
-        final var hashObjectBuilder = HashObject.newBuilder().setAlgorithm(HashAlgorithm.SHA_384);
         final var sidecarRecordBuilder = TransactionSidecarRecord.newBuilder().setConsensusTimestamp(consensusStart);
         final var sidecarFiles = List.of(
                 com.hedera.services.stream.proto.SidecarFile.newBuilder()
@@ -373,9 +412,7 @@ final class CompositeRecordFileItemReaderTest {
                         .build());
         final var recordStreamFile = RecordStreamFile.newBuilder()
                 .setHapiProtoVersion(SemanticVersion.newBuilder().setMinor(64))
-                .setStartObjectRunningHash(hashObjectBuilder
-                        .setHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48)))
-                        .build())
+                .setStartObjectRunningHash(hashObject())
                 .addAllRecordStreamItems(List.of(
                         RecordStreamItem.newBuilder()
                                 .setTransaction(DEFAULT_TRANSACTION)
@@ -385,24 +422,18 @@ final class CompositeRecordFileItemReaderTest {
                                 .setTransaction(DEFAULT_TRANSACTION)
                                 .setRecord(TransactionRecord.newBuilder().setConsensusTimestamp(consensusEnd))
                                 .build()))
-                .setEndObjectRunningHash(hashObjectBuilder
-                        .setHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48)))
-                        .build())
+                .setEndObjectRunningHash(hashObject())
                 .setBlockNumber(82697486L)
                 .addAllSidecars(List.of(
                         SidecarMetadata.newBuilder()
-                                .setHash(hashObjectBuilder
-                                        .setHash(DomainUtils.fromBytes(sidecarDigest.digest(
-                                                sidecarFiles.getFirst().toByteArray())))
-                                        .build())
+                                .setHash(hashObject(sidecarDigest.digest(
+                                        sidecarFiles.getFirst().toByteArray())))
                                 .setId(1)
                                 .addAllTypes(List.of(SidecarType.CONTRACT_STATE_CHANGE, SidecarType.CONTRACT_ACTION))
                                 .build(),
                         SidecarMetadata.newBuilder()
-                                .setHash(hashObjectBuilder
-                                        .setHash(DomainUtils.fromBytes(sidecarDigest.digest(
-                                                sidecarFiles.getLast().toByteArray())))
-                                        .build())
+                                .setHash(hashObject(sidecarDigest.digest(
+                                        sidecarFiles.getLast().toByteArray())))
                                 .setId(2)
                                 .addTypes(SidecarType.CONTRACT_BYTECODE)
                                 .build()))
@@ -411,6 +442,17 @@ final class CompositeRecordFileItemReaderTest {
                 .setCreationTime(consensusStart)
                 .setRecordFileContents(recordStreamFile)
                 .addAllSidecarFileContents(sidecarFiles)
+                .build();
+    }
+
+    private static HashObject hashObject() {
+        return hashObject(TestUtils.generateRandomByteArray(48));
+    }
+
+    private static HashObject hashObject(final byte[] hash) {
+        return HashObject.newBuilder()
+                .setAlgorithm(HashAlgorithm.SHA_384)
+                .setHash(DomainUtils.fromBytes(hash))
                 .build();
     }
 
@@ -425,27 +467,6 @@ final class CompositeRecordFileItemReaderTest {
                 .setRecord(TransactionRecord.newBuilder()
                         .setConsensusTimestamp(consensusTimestamp)
                         .setTransactionHash(transactionHash))
-                .build();
-    }
-
-    private static RecordFileItem createRecordFileItemWithAmendments(
-            final List<RecordStreamItem> items, final List<RecordStreamItem> amendments) {
-        final var hashObjectBuilder = HashObject.newBuilder().setAlgorithm(HashAlgorithm.SHA_384);
-        final var recordStreamFile = RecordStreamFile.newBuilder()
-                .setHapiProtoVersion(SemanticVersion.newBuilder().setMinor(64))
-                .setStartObjectRunningHash(hashObjectBuilder
-                        .setHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48)))
-                        .build())
-                .addAllRecordStreamItems(items)
-                .setEndObjectRunningHash(hashObjectBuilder
-                        .setHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48)))
-                        .build())
-                .setBlockNumber(1L)
-                .build();
-        return RecordFileItem.newBuilder()
-                .setCreationTime(items.getFirst().getRecord().getConsensusTimestamp())
-                .setRecordFileContents(recordStreamFile)
-                .addAllAmendments(amendments)
                 .build();
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.importer.reader.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.hiero.mirror.importer.TestUtils.gzip;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,17 +20,22 @@ import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.time.Instant;
 import java.util.function.Function;
+import org.apache.commons.lang3.Strings;
 import org.hiero.mirror.common.domain.DigestAlgorithm;
+import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.TestUtils;
 import org.hiero.mirror.importer.domain.StreamFileData;
 import org.hiero.mirror.importer.exception.InvalidStreamFileException;
 import org.junit.jupiter.api.Test;
 
-class ProtoRecordFileReaderTest extends AbstractRecordFileReaderTest {
+final class ProtoRecordFileReaderTest extends AbstractRecordFileReaderTest {
 
     private static final String FILENAME = "2022-06-21T09_15_38.325469003Z.rcd.gz";
+    private static final long FILE_TIMESTAMP = DomainUtils.convertToNanosMax(
+            Instant.parse(Strings.CS.removeEnd(FILENAME, ".rcd.gz").replace("_", ":")));
 
     @Override
     protected RecordFileReader getRecordFileReader() {
@@ -46,9 +52,14 @@ class ProtoRecordFileReaderTest extends AbstractRecordFileReaderTest {
         var bytes = gzip(ProtoRecordStreamFile.of(RecordStreamFile.Builder::clearRecordStreamItems));
         var reader = new ProtoRecordFileReader();
         var streamFileData = StreamFileData.from(FILENAME, bytes);
-        var exception = assertThrows(InvalidStreamFileException.class, () -> reader.read(streamFileData));
-        var expected = "No record stream objects in record file " + FILENAME;
-        assertEquals(expected, exception.getMessage());
+        final var recordFile = reader.read(streamFileData);
+        assertThat(recordFile)
+                .returns(FILE_TIMESTAMP, RecordFile::getConsensusEnd)
+                .returns(FILE_TIMESTAMP, RecordFile::getConsensusStart)
+                .returns(0L, RecordFile::getCount)
+                .returns(FILENAME, RecordFile::getName)
+                .extracting(RecordFile::getItems, LIST)
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR cherry-picks the changes to `release/0.153`

- Allow empty record stream files in ProtoRecordFileReader
- Allow empty WRBs in AbstractRecordFileItemReader
- Use file creation time / consensus timestamp from filename for consensus start / end when empty

**Related issue(s)**:

Fixes #13398 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
