### PR TITLE
feat: separate streaming and request/response backends (#13459)

### DIFF
--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -56,7 +56,7 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -53,7 +53,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15

--- a/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
@@ -14,3 +14,18 @@ spec:
     kind: {{ .Values.gateway.target.kind }}
     name: {{ include "hedera-mirror-grpc.fullname" . }}
 {{- end }}
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) }}
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.streamingBackendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+{{- end }}

--- a/charts/hedera-mirror-grpc/templates/service.yaml
+++ b/charts/hedera-mirror-grpc/templates/service.yaml
@@ -13,9 +13,13 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
   selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
-{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) -}}
+{{ if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) -}}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hedera-mirror-grpc/templates/service.yaml
+++ b/charts/hedera-mirror-grpc/templates/service.yaml
@@ -19,3 +19,25 @@ spec:
       name: http
   selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/templates/service.yaml
+++ b/charts/hedera-mirror-grpc/templates/service.yaml
@@ -13,10 +13,6 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
   selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
 {{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) -}}
@@ -34,10 +30,6 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-    - port: 80
-      targetPort: http
-      protocol: TCP
-      name: http
   selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
 {{- end }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -69,7 +69,18 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
+    streamingBackendPolicy:
+      cdn:
+        enabled: false
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 9999999
     enabled: true
     healthCheckPolicy:
       config:
@@ -79,6 +90,15 @@ gateway:
         type: HTTP
       healthyThreshold: 1
   rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}-streaming"
+          port: 5600
+      matches:
+        - method:
+            method: subscribeTopic
+            service: com.hedera.mirror.api.proto.ConsensusService
     - backendRefs:
         - group: "{{ .Values.gateway.target.group }}"
           kind: "{{ .Values.gateway.target.kind }}"

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -66,7 +66,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15
@@ -75,7 +74,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 9999999
@@ -95,7 +93,6 @@ gateway:
           port: 5600
       matches:
         - method:
-            method: subscribeTopic
             service: com.hedera.mirror.api.proto.ConsensusService
     - backendRefs:
         - group: "{{ .Values.gateway.target.group }}"
@@ -103,8 +100,6 @@ gateway:
           name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}"
           port: 5600
       matches:
-        - method:
-            service: com.hedera.mirror.api.proto.ConsensusService
         - method:
             service: com.hedera.mirror.api.proto.NetworkService
         - method:

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -71,8 +71,6 @@ gateway:
         type: CLIENT_IP
       timeoutSec: 15
     streamingBackendPolicy:
-      cdn:
-        enabled: false
       connectionDraining:
         drainingTimeoutSec: 10
       logging:

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -56,7 +56,7 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -53,7 +53,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -56,7 +56,7 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -53,7 +53,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -56,7 +56,7 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -53,7 +53,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -56,7 +56,7 @@ gateway:
       maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -53,7 +53,6 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
       timeoutSec: 15


### PR DESCRIPTION
This PR separates streaming gRPC traffic from regular request/response traffic to allow for specialized backend configurations. This is necessary to handle long-lived subscriptions without affecting the timeout settings of standard APIs.

Update the default request/response backend timeout to 15s across all charts.
Add a dedicated streaming backend specifically for gRPC subscribeTopic calls.
Configure the streaming backend with a long timeout (9999999) and disable Cloud CDN.
Create additional Kubernetes Service and GCPBackendPolicy resources for the streaming backend in the gRPC chart.

Related issue(s):

Related to #13459

Checklist

 Documented (Code comments)
 Tested (Local validation/linting)