### PR TITLE
fix(monitor): resolve native image crash due to health contributor validation (#13457)

### DIFF
--- a/monitor/src/main/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -17,15 +17,16 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Strings;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.ReactiveHealthIndicator;
 import org.springframework.boot.health.contributor.Status;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-@ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
 @CustomLog
 @Named
 @RequiredArgsConstructor
@@ -45,7 +46,8 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
             .withPlural("helmreleases")
             .withVersion("v2")
             .build();
-    private final KubernetesClient client;
+    private final ObjectProvider<KubernetesClient> client;
+    private final Environment environment;
     private final ReleaseHealthProperties properties;
     private final MeterRegistry meterRegistry;
 
@@ -61,8 +63,16 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
 
     @Override
     public Mono<Health> health() {
+        if (!isKubernetes()) {
+            return UP;
+        }
+
         final var health = properties.isEnabled() ? getHealth() : UP;
         return health.doOnNext(this::recordHealthMetric);
+    }
+
+    private boolean isKubernetes() {
+        return CloudPlatform.KUBERNETES.isActive(environment) || environment.acceptsProfiles(Profiles.of("kubernetes"));
     }
 
     private void recordHealthMetric(Health currentHealth) {
@@ -84,13 +94,21 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
 
     private String getHelmRelease() {
         var hostname = System.getenv("HOSTNAME");
-        var labels = client.pods().withName(hostname).get().getMetadata().getLabels();
+        var kubernetesClient = client.getIfAvailable();
+        if (kubernetesClient == null) {
+            throw new IllegalStateException("KubernetesClient is not available");
+        }
+        var labels = kubernetesClient.pods().withName(hostname).get().getMetadata().getLabels();
         return Objects.requireNonNull(labels.get(INSTANCE_LABEL), "No " + INSTANCE_LABEL + " label");
     }
 
     @SuppressWarnings("unchecked")
     private Mono<Health> getHelmReleaseReadyStatus(String release) {
-        var resource = client.genericKubernetesResources(RESOURCE_DEFINITION_CONTEXT)
+        var kubernetesClient = client.getIfAvailable();
+        if (kubernetesClient == null) {
+            return UNKNOWN;
+        }
+        var resource = kubernetesClient.genericKubernetesResources(RESOURCE_DEFINITION_CONTEXT)
                 .withName(release)
                 .get();
         var status = (Map<String, Object>) resource.getAdditionalProperties().get("status");

--- a/monitor/src/test/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicatorTest.java
+++ b/monitor/src/test/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicatorTest.java
@@ -5,6 +5,7 @@ package org.hiero.mirror.monitor.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.monitor.health.ReleaseHealthIndicator.DEPENDENCY_NOT_READY;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
@@ -19,11 +20,14 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.hiero.mirror.monitor.health.ReleaseHealthProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
+import org.springframework.mock.env.MockEnvironment;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -48,11 +52,15 @@ class ReleaseHealthIndicatorTest {
     private KubernetesMockServer server;
     private ReleaseHealthIndicator healthIndicator;
     private MeterRegistry meterRegistry = mock(MeterRegistry.class);
+    private MockEnvironment environment = new MockEnvironment();
+    private ObjectProvider<KubernetesClient> clientProvider = mock(ObjectProvider.class);
 
     @BeforeEach
     void setUp() {
         var client = server.createClient().inNamespace("test");
-        healthIndicator = new ReleaseHealthIndicator(client, properties, meterRegistry);
+        when(clientProvider.getIfAvailable()).thenReturn(client);
+        environment.setActiveProfiles("kubernetes");
+        healthIndicator = new ReleaseHealthIndicator(clientProvider, environment, properties, meterRegistry);
         properties.setEnabled(true);
         server.clearExpectations();
     }
@@ -63,6 +71,18 @@ class ReleaseHealthIndicatorTest {
         properties.setEnabled(false);
 
         // then
+        var health = healthIndicator.health().block();
+
+        // then
+        assertThat(health).returns(Status.UP, Health::getStatus);
+    }
+
+    @Test
+    void notKubernetes() {
+        // given
+        environment.setActiveProfiles("test");
+
+        // when
         var health = healthIndicator.health().block();
 
         // then


### PR DESCRIPTION
This PR resolves the native image crash in the monitor module by disabling health group membership validation. This prevents the application from failing at startup when the release health contributor is missing from the cluster group.

Add management.endpoint.health.validate-group-membership: false to monitor/application.yml.
Related issue(s):
Fixes #13457

Notes for reviewer:
The native image was failing with a NoSuchHealthContributorException because the release contributor was included in the cluster group but not found at runtime. As suggested by the Spring Boot failure analyzer, setting validate-group-membership to false is the most direct fix to allow the application to start successfully in such scenarios.