### PR TITLE
feat: Add contractsIdStateTimestamp test scenario

### DIFF
--- a/tools/k6/src/rest/test/contractsIdStateTimestamp.js
+++ b/tools/k6/src/rest/test/contractsIdStateTimestamp.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import {isValidListResponse, RestTestScenarioBuilder} from '../libex/common.js';
+import {stateListName} from '../libex/constants.js';
+
+const urlTag = '/contracts/{id}/state?timestamp=';
+
+const getUrl = (testParameters) =>
+  `/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/state?timestamp=${testParameters['DEFAULT_CONTRACT_TIMESTAMP']}&limit=${testParameters['DEFAULT_LIMIT']}`;
+
+const {options, run, setup} = new RestTestScenarioBuilder()
+  .name('contractsIdStateTimestamp') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL_PREFIX']}${getUrl(testParameters)}`;
+    return http.get(url);
+  })
+  .requiredParameters('DEFAULT_CONTRACT_ID', 'DEFAULT_CONTRACT_TIMESTAMP')
+  .check('Contracts id state with timestamp OK', (r) => isValidListResponse(r, stateListName))
+  .build();
+
+export {getUrl, options, run, setup};

--- a/tools/k6/src/rest/test/index.js
+++ b/tools/k6/src/rest/test/index.js
@@ -30,6 +30,7 @@ import * as contractsIdResults from './contractsIdResults.js';
 import * as contractsIdResultsLogs from './contractsIdResultsLogs.js';
 import * as contractsIdResultsTimestamp from './contractsIdResultsTimestamp.js';
 import * as contractsIdState from './contractsIdState.js';
+import * as contractsIdStateTimestamp from './contractsIdStateTimestamp.js';
 import * as contractsResults from './contractsResult.js';
 import * as contractsResultsId from './contractsResultsId.js';
 import * as contractsResultsIdActions from './contractsResultsIdActions.js';
@@ -90,6 +91,7 @@ const tests = {
   contractsIdResultsLogs,
   contractsIdResultsTimestamp,
   contractsIdState,
+  contractsIdStateTimestamp,
   contractsResults,
   contractsResultsId,
   contractsResultsIdActions,


### PR DESCRIPTION
**Description**:                                                                                                                                 
- Introduced a new k6 test scenario for fetching contract state with a timestamp.
- Implemented URL generation and validation checks for the response.
- Updated index.js to include the new test scenario in the test suite.      
                                                                                                                                                                                                                                                                                                              
Fixes #13373

**Notes for reviewer**:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/46dbcd34-01d5-4965-b06e-5c11fbd393cf" />


