### PR TITLE
Feat/13455 flux slack upgrade alert

### DIFF
--- a/infrastructure/kubernetes/integration/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/integration/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/integration/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/integration/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#mirror-node-prod"
+  secretRef:
+    name: slack-url

--- a/infrastructure/kubernetes/mainnet-eu/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/mainnet-eu/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/mainnet-eu/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/mainnet-eu/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#network-operations"
+  secretRef:
+    name: slack-url

--- a/infrastructure/kubernetes/mainnet-na/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/mainnet-na/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/mainnet-na/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/mainnet-na/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#network-operations"
+  secretRef:
+    name: slack-url

--- a/infrastructure/kubernetes/previewnet/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/previewnet/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/previewnet/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/previewnet/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#network-operations"
+  secretRef:
+    name: slack-url

--- a/infrastructure/kubernetes/testnet-eu/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/testnet-eu/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/testnet-eu/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/testnet-eu/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#network-operations"
+  secretRef:
+    name: slack-url

--- a/infrastructure/kubernetes/testnet-na/flux-system/slack-alert.yaml
+++ b/infrastructure/kubernetes/testnet-na/flux-system/slack-alert.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  providerRef:
+    name: slack
+  eventSeverity: info
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"

--- a/infrastructure/kubernetes/testnet-na/flux-system/slack-provider.yaml
+++ b/infrastructure/kubernetes/testnet-na/flux-system/slack-provider.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack
+  namespace: flux-system
+spec:
+  type: slack
+  channel: "#network-operations"
+  secretRef:
+    name: slack-url


### PR DESCRIPTION
**Description**:
Add automated Slack notifications using Flux CD to trigger when a version upgrade starts for `hiero-mirror-node`. This captures logs emitted to the notification-controller.
* Add Flux `Provider` configured for `#mirror-node-prod` in `integration`
* Add Flux `Provider` configured for `#network-operations` in `mainnet-eu`, `mainnet-na`, `previewnet`, `testnet-eu`, and `testnet-na`
* Add Flux `Alert` to match the regex `^packaged 'hedera-mirror' chart with version` via `inclusionList` for all environments
**Related issue(s)**:
Fixes #13455
**Notes for reviewer**:
Regex parsing (`^packaged 'hedera-mirror' chart with version`) and YAML manifest structures have been manually validated locally using Spotless and Go's regex engine. 
**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)