### PR TITLE
Change solo cluster config in CI to run k6 tests

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -222,7 +222,7 @@ jobs:
       - name: Run k6 tests
         if: ${{ matrix.stream-type != 'BLOCK' }}
         env:
-          BASE_URL: "http://127.0.0.1:8081"
+          BASE_URL: "http://127.0.0.1:38081"
           DEFAULT_DURATION: "3s"
           DEFAULT_GRACEFUL_STOP: "1s"
           DEFAULT_VUS: 2


### PR DESCRIPTION
**Description**:
Update the correct ingress solo port in CI workflow in order to get the k6 tests to pass.

Fixes #13485 
