### PR TITLE
Fix RegisteredNodeCreateTransformer unable to get new registered node id

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/StateChangeContext.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/StateChangeContext.java
@@ -320,11 +320,11 @@ public final class StateChangeContext {
     }
 
     private void processRegisteredNodeChange(final MapUpdateChange mapUpdate) {
-        if (!mapUpdate.getKey().hasNodeIdKey()) {
+        if (!mapUpdate.getKey().hasEntityNumberKey()) {
             return;
         }
 
-        registeredNodeIds.add(mapUpdate.getKey().getNodeIdKey().getId());
+        registeredNodeIds.add(mapUpdate.getKey().getEntityNumberKey().getValue());
     }
 
     private void processTokenStateChange(MapUpdateChange mapUpdate) {

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/StateChangeContextTest.java
@@ -379,8 +379,7 @@ final class StateChangeContextTest {
         final var registeredNodeStateChanges = LongStream.range(1, 3)
                 .boxed()
                 .map(id -> MapUpdateChange.newBuilder()
-                        .setKey(MapChangeKey.newBuilder()
-                                .setNodeIdKey(NodeId.newBuilder().setId(id)))
+                        .setKey(MapChangeKey.newBuilder().setEntityNumberKey(UInt64Value.of(id)))
                         .setValue(MapChangeValue.newBuilder()
                                 .setRegisteredNodeValue(
                                         RegisteredNode.newBuilder().setRegisteredNodeId(id)))

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/RegisteredNodeCreateTransformer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/RegisteredNodeCreateTransformer.java
@@ -24,7 +24,8 @@ final class RegisteredNodeCreateTransformer extends AbstractBlockTransactionTran
         receiptBuilder.setRegisteredNodeId(blockTransaction
                 .getStateChangeContext()
                 .getNewRegisteredNodeId()
-                .orElseThrow());
+                // Fallback to an invalid registered node id
+                .orElse(-1L));
     }
 
     @Override

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandler.java
@@ -8,6 +8,7 @@ import org.hiero.mirror.common.domain.node.RegisteredNode;
 import org.hiero.mirror.common.domain.transaction.RecordItem;
 import org.hiero.mirror.common.domain.transaction.TransactionType;
 import org.hiero.mirror.importer.parser.record.entity.EntityListener;
+import org.hiero.mirror.importer.util.Utility;
 import org.springframework.context.ApplicationEventPublisher;
 
 @Named
@@ -38,6 +39,13 @@ final class RegisteredNodeCreateTransactionHandler extends AbstractRegisteredNod
         final long consensusTimestamp = recordItem.getConsensusTimestamp();
         final long registeredNodeId =
                 recordItem.getTransactionRecord().getReceipt().getRegisteredNodeId();
+
+        if (registeredNodeId < 0) {
+            Utility.handleRecoverableError(
+                    "Invalid registered node id %d from RegisteredNodeCreateTransaction receipt at %d",
+                    registeredNodeId, consensusTimestamp);
+            return null;
+        }
 
         final var adminKey = nodeCreate.hasAdminKey() ? nodeCreate.getAdminKey().toByteArray() : null;
         final var builder = RegisteredNode.builder();

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/domain/BlockTransactionBuilder.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/domain/BlockTransactionBuilder.java
@@ -46,7 +46,6 @@ import com.hedera.hapi.block.stream.trace.protoc.ExecutedInitcode;
 import com.hedera.hapi.block.stream.trace.protoc.InitcodeBookends;
 import com.hedera.hapi.block.stream.trace.protoc.SlotRead;
 import com.hedera.hapi.block.stream.trace.protoc.TraceData;
-import com.hedera.hapi.platform.state.legacy.NodeId;
 import com.hedera.services.stream.proto.ContractStateChanges;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import com.hederahashgraph.api.proto.java.Account;
@@ -556,7 +555,7 @@ public class BlockTransactionBuilder {
         final long registeredNodeId =
                 recordItem.getTransactionRecord().getReceipt().getRegisteredNodeId();
         final var key = MapChangeKey.newBuilder()
-                .setNodeIdKey(NodeId.newBuilder().setId(registeredNodeId))
+                .setEntityNumberKey(UInt64Value.of(registeredNodeId))
                 .build();
         final var value = MapChangeValue.newBuilder()
                 .setRegisteredNodeValue(RegisteredNode.newBuilder().setRegisteredNodeId(registeredNodeId))

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandlerTest.java
@@ -114,6 +114,25 @@ final class RegisteredNodeCreateTransactionHandlerTest extends AbstractTransacti
     }
 
     @Test
+    void updateTransactionInvalidRegisteredNodeId() {
+        // given
+        final var recordItem = recordItemBuilder
+                .registeredNodeCreate()
+                .receipt(r -> r.setRegisteredNodeId(-1))
+                .build();
+        final var transaction = domainBuilder.transaction().get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        verifyNoInteractions(entityListener);
+        verifyNoInteractions(applicationEventPublisher);
+        assertThat(recordItem.getEntityTransactions())
+                .containsExactlyInAnyOrderEntriesOf(getExpectedEntityTransactions(recordItem, transaction));
+    }
+
+    @Test
     void updateTransactionWithNoServiceEndpointsDoesNotPublishEvent() {
         // given
         final var recordItem = recordItemBuilder


### PR DESCRIPTION
**Description**:

This PR fixes the bug:

- Use correct MapUpdateChange key type `EntityNumberKey` for registered node id
- Fallback to invalid id -1 and skip processing in `RegisteredNodeCreateTransactionHandler`

**Related issue(s)**:

Fixes #13480 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
