### PR TITLE
feat: Implement Zstandard compression codec for gRPC

### DIFF
--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")
     protobuf("org.hiero.block-node:protobuf-sources:$blockNodeVersion")
-    runtimeOnly("com.github.luben:zstd-jni")
+    implementation("com.github.luben:zstd-jni")
     runtimeOnly("io.grpc:grpc-netty")
     testImplementation(project(path = ":common", configuration = "testClasses"))
     testImplementation("com.asarkar.grpc:grpc-test")

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ManagedChannelBuilderProviderImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ManagedChannelBuilderProviderImpl.java
@@ -2,17 +2,19 @@
 
 package org.hiero.mirror.importer.downloader.block;
 
-import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ManagedChannelBuilder;
 import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
 
 @Named
+@RequiredArgsConstructor
 final class ManagedChannelBuilderProviderImpl implements ManagedChannelBuilderProvider {
+
+    private final ZstdCodec zstdCodec;
 
     @Override
     public ManagedChannelBuilder<?> get(final String host, final int port, final boolean useTls) {
-        final var zstdCodec = new ZstdCodec();
         final var builder = ManagedChannelBuilder.forAddress(host, port);
         if (useTls) {
             builder.useTransportSecurity();
@@ -21,7 +23,6 @@ final class ManagedChannelBuilderProviderImpl implements ManagedChannelBuilderPr
         }
 
         builder.decompressorRegistry(DecompressorRegistry.getDefaultInstance().with(zstdCodec, true));
-        builder.compressorRegistry(CompressorRegistry.getDefaultInstance().with(zstdCodec));
         return builder;
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ManagedChannelBuilderProviderImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ManagedChannelBuilderProviderImpl.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.downloader.block;
 
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
 import io.grpc.ManagedChannelBuilder;
 import jakarta.inject.Named;
 
@@ -10,6 +12,7 @@ final class ManagedChannelBuilderProviderImpl implements ManagedChannelBuilderPr
 
     @Override
     public ManagedChannelBuilder<?> get(final String host, final int port, final boolean useTls) {
+        final var zstdCodec = new ZstdCodec();
         final var builder = ManagedChannelBuilder.forAddress(host, port);
         if (useTls) {
             builder.useTransportSecurity();
@@ -17,6 +20,8 @@ final class ManagedChannelBuilderProviderImpl implements ManagedChannelBuilderPr
             builder.usePlaintext();
         }
 
+        builder.decompressorRegistry(DecompressorRegistry.getDefaultInstance().with(zstdCodec, true));
+        builder.compressorRegistry(CompressorRegistry.getDefaultInstance().with(zstdCodec));
         return builder;
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
@@ -5,11 +5,15 @@ package org.hiero.mirror.importer.downloader.block;
 import com.github.luben.zstd.ZstdInputStream;
 import com.github.luben.zstd.ZstdOutputStream;
 import io.grpc.Codec;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import lombok.RequiredArgsConstructor;
 
-class ZstdCodec implements Codec {
+@Named
+@RequiredArgsConstructor
+final class ZstdCodec implements Codec {
 
     @Override
     public String getMessageEncoding() {

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
@@ -9,10 +9,8 @@ import jakarta.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import lombok.RequiredArgsConstructor;
 
 @Named
-@RequiredArgsConstructor
 final class ZstdCodec implements Codec {
 
     @Override

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/ZstdCodec.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+import io.grpc.Codec;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+class ZstdCodec implements Codec {
+
+    @Override
+    public String getMessageEncoding() {
+        return "zstd";
+    }
+
+    @Override
+    public OutputStream compress(OutputStream os) throws IOException {
+        return new ZstdOutputStream(os);
+    }
+
+    @Override
+    public InputStream decompress(InputStream is) throws IOException {
+        return new ZstdInputStream(is);
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/ZstdCodecTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/ZstdCodecTest.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.downloader.block;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ZstdCodecTest {
+
+    private final ZstdCodec codec = new ZstdCodec();
+
+    @Test
+    void getMessageEncoding() {
+        assertThat(codec.getMessageEncoding()).isEqualTo("zstd");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideData")
+    void roundtrip(byte[] data) throws Exception {
+        var compressed = new ByteArrayOutputStream();
+        try (var compressor = codec.compress(compressed)) {
+            compressor.write(data);
+        }
+
+        var decompressed = new ByteArrayOutputStream();
+        try (var decompressor = codec.decompress(new ByteArrayInputStream(compressed.toByteArray()))) {
+            decompressor.transferTo(decompressed);
+        }
+
+        assertThat(decompressed.toByteArray()).isEqualTo(data);
+    }
+
+    private static Stream<Arguments> provideData() {
+        return Stream.of(
+                Arguments.of(new byte[0]),
+                Arguments.of("hello world".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of(new byte[1000]),
+                Arguments.of(new byte[100000]));
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/ZstdCodecTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/ZstdCodecTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class ZstdCodecTest {
+final class ZstdCodecTest {
 
     private final ZstdCodec codec = new ZstdCodec();
 


### PR DESCRIPTION
- Added ZstdCodec class for compressing and decompressing data using Zstandard.
- Updated ManagedChannelBuilderProviderImpl to utilize ZstdCodec for gRPC compression and decompression.
- Changed zstd-jni dependency from runtimeOnly to implementation in build.gradle.kts.
- Added unit tests for ZstdCodec to ensure correct functionality.

**Description**:
feat: Implement Zstandard compression codec for gRPC (#13265)
- Add a ZstdCodec implementing gRPC's Codec interface to enable Zstandard (zstd) compression for gRPC communication with block nodes. The codec is registered with both the compressor and decompressor registries in ManagedChannelBuilderProviderImpl.

 Changes:
- New ZstdCodec class wrapping ZstdInputStream/ZstdOutputStream for gRPC compression/decompression
- Register Zstd codec on the gRPC ManagedChannel in ManagedChannelBuilderProviderImpl
- Promote zstd-jni from runtimeOnly to implementation scope in build config
- Add unit tests verifying roundtrip compress/decompress for empty, small, and large payloads
- #13265 