### PR TITLE
feat(web3): add delegation_address to EVM account state for HIP-1340

### DIFF
--- a/web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
+++ b/web3/src/main/java/com/hedera/hapi/node/state/token/Account.java
@@ -108,6 +108,7 @@ import java.util.function.Supplier;
 public record Account(
         @Nullable AccountID accountId,
         @Nonnull Bytes alias,
+        @Nonnull Bytes delegationAddress,
         @Nullable Key key,
         long expirationSecond,
         Supplier<Long> tinybarBalanceSupplier,
@@ -157,6 +158,7 @@ public record Account(
     public Account(
             AccountID accountId,
             Bytes alias,
+            Bytes delegationAddress,
             Key key,
             long expirationSecond,
             long tinybarBalance,
@@ -195,6 +197,7 @@ public record Account(
         this(
                 accountId,
                 alias,
+                delegationAddress,
                 key,
                 expirationSecond,
                 () -> tinybarBalance,
@@ -253,6 +256,9 @@ public record Account(
         }
         if (!alias.equals(DEFAULT.alias)) {
             result = 31 * result + alias.hashCode();
+        }
+        if (!delegationAddress.equals(DEFAULT.delegationAddress)) {
+            result = 31 * result + delegationAddress.hashCode();
         }
         if (key != null && !key.equals(DEFAULT.key)) {
             result = 31 * result + key.hashCode();
@@ -411,6 +417,9 @@ public record Account(
             return false;
         }
         if (!alias.equals(thatObj.alias)) {
+            return false;
+        }
+        if (!delegationAddress.equals(thatObj.delegationAddress)) {
             return false;
         }
         if (key == null && thatObj.key != null) {
@@ -909,6 +918,7 @@ public record Account(
         return new Builder(
                 accountId,
                 alias,
+                delegationAddress,
                 key,
                 expirationSecond,
                 tinybarBalanceSupplier,
@@ -1073,6 +1083,9 @@ public record Account(
         @Nonnull
         private Bytes alias = Bytes.EMPTY;
 
+        @Nonnull
+        private Bytes delegationAddress = Bytes.EMPTY;
+
         @Nullable
         private Key key = null;
 
@@ -1221,6 +1234,7 @@ public record Account(
         public Builder(
                 AccountID accountId,
                 Bytes alias,
+                Bytes delegationAddress,
                 Key key,
                 long expirationSecond,
                 Supplier<Long> tinybarBalanceSupplier,
@@ -1258,6 +1272,7 @@ public record Account(
                 long numberLambdaStorageSlots) {
             this.accountId = accountId;
             this.alias = alias != null ? alias : Bytes.EMPTY;
+            this.delegationAddress = delegationAddress != null ? delegationAddress : Bytes.EMPTY;
             this.key = key;
             this.expirationSecond = expirationSecond;
             this.tinybarBalanceSupplier = tinybarBalanceSupplier;
@@ -1308,6 +1323,7 @@ public record Account(
             return new Account(
                     accountId,
                     alias,
+                    delegationAddress,
                     key,
                     expirationSecond,
                     tinybarBalanceSupplier,
@@ -1375,6 +1391,17 @@ public record Account(
          */
         public Builder alias(@Nonnull Bytes alias) {
             this.alias = alias;
+            return this;
+        }
+
+        /**
+         * <b>(2a)</b> The delegation address for this account, if any.
+         *
+         * @param delegationAddress value to set
+         * @return builder to continue building with
+         */
+        public Builder delegationAddress(@Nonnull Bytes delegationAddress) {
+            this.delegationAddress = delegationAddress;
             return this;
         }
 

--- a/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AbstractAliasedAccountReadableKVState.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/state/keyvalue/AbstractAliasedAccountReadableKVState.java
@@ -83,9 +83,12 @@ public abstract class AbstractAliasedAccountReadableKVState<K, V> extends Abstra
         }
         final boolean isSmartContract = CONTRACT.equals(entity.getType());
 
+        byte[] delegationAddress = entity.getDelegationAddress() != null ? entity.getDelegationAddress() : new byte[0];
+
         return Account.newBuilder()
                 .accountId(EntityIdUtils.toAccountId(entity.toEntityId()))
                 .alias(Bytes.wrap(alias))
+                .delegationAddress(Bytes.wrap(delegationAddress))
                 .approveForAllNftAllowances(getApproveForAllNfts(entity.getId(), timestamp))
                 .autoRenewAccountId(toAccountId(entity.getAutoRenewAccountId()))
                 .autoRenewSeconds(Objects.requireNonNullElse(entity.getAutoRenewPeriod(), DEFAULT_AUTO_RENEW_PERIOD))

--- a/web3/src/test/java/com/hedera/hapi/node/state/token/AccountTest.java
+++ b/web3/src/test/java/com/hedera/hapi/node/state/token/AccountTest.java
@@ -46,6 +46,7 @@ class AccountTest {
     static {
         final var accountIdList = AccountIDTest.ARGUMENTS;
         final var aliasList = BYTES_TESTS_LIST;
+        final var delegationAddressList = BYTES_TESTS_LIST;
         final var keyList = KeyTest.ARGUMENTS;
         final var expirationSecondList = LONG_TESTS_LIST;
         final var tinybarBalanceList = LONG_TESTS_LIST;
@@ -54,7 +55,7 @@ class AccountTest {
         final var stakedToMeList = LONG_TESTS_LIST;
         final var stakePeriodStartList = LONG_TESTS_LIST;
         final var stakedIdList = Stream.of(
-                        List.of(new OneOf<>(Account.StakedIdOneOfType.UNSET, null)),
+                        List.<OneOf<Account.StakedIdOneOfType>>of(new OneOf<>(Account.StakedIdOneOfType.UNSET, null)),
                         AccountIDTest.ARGUMENTS.stream()
                                 .map(value -> new OneOf<>(Account.StakedIdOneOfType.STAKED_ACCOUNT_ID, value))
                                 .toList(),
@@ -137,6 +138,7 @@ class AccountTest {
                 .mapToObj(i -> new Account(
                         accountIdList.get(Math.min(i, accountIdList.size() - 1)),
                         aliasList.get(Math.min(i, aliasList.size() - 1)),
+                        delegationAddressList.get(Math.min(i, delegationAddressList.size() - 1)),
                         keyList.get(Math.min(i, keyList.size() - 1)),
                         expirationSecondList.get(Math.min(i, expirationSecondList.size() - 1)),
                         tinybarBalanceList.get(Math.min(i, tinybarBalanceList.size() - 1)),

--- a/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateIntegrationTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateIntegrationTest.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.state.keyvalue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.web3.Web3IntegrationTest;
+import org.hiero.mirror.web3.common.ContractCallContext;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+class AccountReadableKVStateIntegrationTest extends Web3IntegrationTest {
+
+    private final AccountReadableKVState accountReadableKVState;
+
+    @Test
+    void delegationAddressMatchesEntityField() {
+        final var rawDelegationAddress = new byte[] {0x01, 0x02, 0x03, 0x04};
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.delegationAddress(rawDelegationAddress))
+                .persist();
+        final var accountId = new AccountID(
+                entity.getShard(), entity.getRealm(), new OneOf<>(AccountOneOfType.ACCOUNT_NUM, entity.getNum()));
+
+        final Account account = ContractCallContext.run(ctx -> accountReadableKVState.get(accountId));
+
+        assertThat(account).isNotNull();
+        assertThat(account.delegationAddress()).isEqualTo(Bytes.wrap(rawDelegationAddress));
+    }
+
+    @Test
+    void delegationAddressIsEmptyWhenNotSet() {
+        final var entity =
+                domainBuilder.entity().customize(e -> e.delegationAddress(null)).persist();
+        final var accountId = new AccountID(
+                entity.getShard(), entity.getRealm(), new OneOf<>(AccountOneOfType.ACCOUNT_NUM, entity.getNum()));
+
+        final Account account = ContractCallContext.run(ctx -> accountReadableKVState.get(accountId));
+
+        assertThat(account).isNotNull();
+        assertThat(account.delegationAddress()).isEqualTo(Bytes.EMPTY);
+    }
+}

--- a/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/state/keyvalue/AccountReadableKVStateTest.java
@@ -307,6 +307,25 @@ class AccountReadableKVStateTest {
     }
 
     @Test
+    void delegationAddressMatchesEntityField() {
+        final var rawDelegationAddress = "0xabcdefabcdefabcdefbabcdefabcdefabcdef01".getBytes();
+        entity.setDelegationAddress(rawDelegationAddress);
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(ACCOUNT_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        assertThat(accountReadableKVState.get(ACCOUNT_ID)).satisfies(account -> assertThat(account)
+                .returns(Bytes.wrap(rawDelegationAddress), Account::delegationAddress));
+    }
+
+    @Test
+    void delegationAddressIsEmptyWhenNotSet() {
+        entity.setDelegationAddress(null);
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(ACCOUNT_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        assertThat(accountReadableKVState.get(ACCOUNT_ID))
+                .satisfies(account -> assertThat(account).returns(Bytes.EMPTY, Account::delegationAddress));
+    }
+
+    @Test
     void whenExpirationTimestampIsNullThenExpiryIsBasedOnCreatedAndRenewTimestamps() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
         when(commonEntityAccessor.get(ACCOUNT_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));


### PR DESCRIPTION
**Description**:
Adds `delegation_address` to the EVM account state layer as required by HIP-1340 (Pectra).
- `Account.java`: added `delegationAddress` as a record component alongside alias. Updated the canonical constructor, Builder (field, constructor, setter), `hashCode()`, and `equals()` to include the new field.
- `AbstractAliasedAccountReadableKVState.accountFromEntity()`: fetches `delegationAddress` from the Entity domain object and sets it on the Account builder via `Bytes.wrap(...)`, consistent with how alias and `evmAddress` are handled.

**Related issue(s)**:
Fixes #12613 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
