### PR TITLE
Update remote write to keep volume stat metric

### DIFF
--- a/clusters/mainnet-eu/common/helmrelease.yaml
+++ b/clusters/mainnet-eu/common/helmrelease.yaml
@@ -61,8 +61,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [job]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [__name__]

--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -61,8 +61,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [ job ]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [ __name__ ]

--- a/clusters/mainnet-staging-na/common/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/common/helmrelease.yaml
@@ -60,8 +60,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [job]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [__name__]

--- a/clusters/previewnet/common/helmrelease.yaml
+++ b/clusters/previewnet/common/helmrelease.yaml
@@ -53,8 +53,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [job]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [__name__]

--- a/clusters/testnet-eu/common/helmrelease.yaml
+++ b/clusters/testnet-eu/common/helmrelease.yaml
@@ -53,8 +53,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [job]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [__name__]

--- a/clusters/testnet-na/common/helmrelease.yaml
+++ b/clusters/testnet-na/common/helmrelease.yaml
@@ -51,8 +51,9 @@ spec:
               url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
               writeRelabelConfigs:
                 - action: keep
-                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3)$
-                  sourceLabels: [job]
+                  regex: .*(graphql|grpc|importer|monitor|postgres-exporter|rest|restjava|rosetta|traefik|web3);.+|kubelet;kubelet_volume_stats_(used|capacity)_bytes
+                  separator: ;
+                  sourceLabels: [job, __name__]
                 - action: drop
                   regex: (api_.+_bucket|executor.*|lettuce_.*_bucket|traefik_.+_bucket)
                   sourceLabels: [__name__]


### PR DESCRIPTION
**Description**:
- Updated the `remoteWrite` keep filter to pass `kubelet_volume_stats_(used|capacity)_bytes`, so the
`DatabaseStorageFull` alert can evaluate in Grafana Cloud once migrated.

**Related issue(s)**:
- #13446 

**Notes for reviewer**:
This PR enables the remote-writing of data that's missing for an alert-rule in the new `Database` alert-group (the alert-group is in `rules.tf` and will be PRed separately.

This PR needs to be merged first in order to start remotely-writing the missing metrics the alert-rule relies on.

**Checklist**

- Syntax tested using `promtool check config` on a sample `remote_write` block that includes the same keep and drop regex added in this PR.
- kubelet metric names verified by port-forwarding from prometheus in a live cluster and querying with these commands and having values returned:

```
curl -sG 'http://localhost:9090/api/v1/query' \ 
--data-urlencode 'query=count by (job) (kubelet_volume_stats_used_bytes)' | jq '.data.result'

curl -sG 'http://localhost:9090/api/v1/query' \ 
--data-urlencode 'query=count by (node) (kubelet_volume_stats_used_bytes{node=~".*(worker|coord).*"})' | jq '.data.result'
```
