### PR TITLE
Add 'upgrade started' notifications to previewnet/testnet/mainnet

### DIFF
--- a/clusters/mainnet-eu/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/mainnet-eu/flux-system/alert-slack-upgrades.yaml
@@ -1,0 +1,22 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  eventMetadata:
+    summary: "Helm chart version upgrade started | environment: mainnet | cluster: mainnet-eu"
+  eventSeverity: info
+  eventSources:
+    - kind: HelmChart
+      name: '*'
+      namespace: common
+    - kind: HelmChart
+      name: '*'
+      namespace: mainnet-citus
+  exclusionList:
+    - .*Internal error.*
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"
+  providerRef:
+    name: slack-upgrades

--- a/clusters/mainnet-eu/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/mainnet-eu/flux-system/alert-slack-upgrades.yaml
@@ -10,9 +10,6 @@ spec:
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: common
-    - kind: HelmChart
-      name: '*'
       namespace: mainnet-citus
   exclusionList:
     - .*Internal error.*

--- a/clusters/mainnet-eu/flux-system/kustomization.yaml
+++ b/clusters/mainnet-eu/flux-system/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - alert-slack.yaml
+- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-slack.yaml
+- provider-slack-upgrades.yaml
 - sealed-secret-slack.yaml

--- a/clusters/mainnet-eu/flux-system/provider-slack-upgrades.yaml
+++ b/clusters/mainnet-eu/flux-system/provider-slack-upgrades.yaml
@@ -1,0 +1,10 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  type: slack
+  channel: hashio-alerting
+  secretRef:
+    name: slack

--- a/clusters/mainnet-na/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/mainnet-na/flux-system/alert-slack-upgrades.yaml
@@ -1,0 +1,22 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  eventMetadata:
+    summary: "Helm chart version upgrade started | environment: mainnet | cluster: mainnet-na"
+  eventSeverity: info
+  eventSources:
+    - kind: HelmChart
+      name: '*'
+      namespace: common
+    - kind: HelmChart
+      name: '*'
+      namespace: mainnet-citus
+  exclusionList:
+    - .*Internal error.*
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"
+  providerRef:
+    name: slack-upgrades

--- a/clusters/mainnet-na/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/mainnet-na/flux-system/alert-slack-upgrades.yaml
@@ -10,9 +10,6 @@ spec:
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: common
-    - kind: HelmChart
-      name: '*'
       namespace: mainnet-citus
   exclusionList:
     - .*Internal error.*

--- a/clusters/mainnet-na/flux-system/kustomization.yaml
+++ b/clusters/mainnet-na/flux-system/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 resources:
 - alert-github-dispatch.yaml
 - alert-slack.yaml
+- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-github-dispatch.yaml
 - provider-slack.yaml
+- provider-slack-upgrades.yaml
 - sealed-secret-github-dispatch.yaml
 - sealed-secret-slack.yaml

--- a/clusters/mainnet-na/flux-system/provider-slack-upgrades.yaml
+++ b/clusters/mainnet-na/flux-system/provider-slack-upgrades.yaml
@@ -1,0 +1,10 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  type: slack
+  channel: hashio-alerting
+  secretRef:
+    name: slack

--- a/clusters/preprod/flux-system/kustomization.yaml
+++ b/clusters/preprod/flux-system/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
 - alert-github.yaml
 - alert-slack.yaml
-- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-github.yaml

--- a/clusters/previewnet/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/previewnet/flux-system/alert-slack-upgrades.yaml
@@ -5,17 +5,18 @@ metadata:
   namespace: flux-system
 spec:
   eventMetadata:
-    summary: "Helm chart version upgrade started"
-    cluster: preprod
-    environment: integration
+    summary: "Helm chart version upgrade started | environment: previewnet | cluster: previewnet"
   eventSeverity: info
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: integration
+      namespace: common
+    - kind: HelmChart
+      name: '*'
+      namespace: previewnet-citus
   exclusionList:
     - .*Internal error.*
   inclusionList:
     - "^packaged 'hedera-mirror' chart with version"
   providerRef:
-    name: slack
+    name: slack-upgrades

--- a/clusters/previewnet/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/previewnet/flux-system/alert-slack-upgrades.yaml
@@ -10,9 +10,6 @@ spec:
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: common
-    - kind: HelmChart
-      name: '*'
       namespace: previewnet-citus
   exclusionList:
     - .*Internal error.*

--- a/clusters/previewnet/flux-system/kustomization.yaml
+++ b/clusters/previewnet/flux-system/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - alert-slack.yaml
+- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-slack.yaml
+- provider-slack-upgrades.yaml
 - sealed-secret-slack.yaml
 

--- a/clusters/previewnet/flux-system/provider-slack-upgrades.yaml
+++ b/clusters/previewnet/flux-system/provider-slack-upgrades.yaml
@@ -1,0 +1,10 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  type: slack
+  channel: hashio-alerting
+  secretRef:
+    name: slack

--- a/clusters/testnet-eu/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/testnet-eu/flux-system/alert-slack-upgrades.yaml
@@ -10,9 +10,6 @@ spec:
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: common
-    - kind: HelmChart
-      name: '*'
       namespace: testnet-citus
   exclusionList:
     - .*Internal error.*

--- a/clusters/testnet-eu/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/testnet-eu/flux-system/alert-slack-upgrades.yaml
@@ -1,0 +1,22 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  eventMetadata:
+    summary: "Helm chart version upgrade started | environment: testnet | cluster: testnet-eu"
+  eventSeverity: info
+  eventSources:
+    - kind: HelmChart
+      name: '*'
+      namespace: common
+    - kind: HelmChart
+      name: '*'
+      namespace: testnet-citus
+  exclusionList:
+    - .*Internal error.*
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"
+  providerRef:
+    name: slack-upgrades

--- a/clusters/testnet-eu/flux-system/kustomization.yaml
+++ b/clusters/testnet-eu/flux-system/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - alert-slack.yaml
+- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-slack.yaml
+- provider-slack-upgrades.yaml
 - sealed-secret-slack.yaml
 

--- a/clusters/testnet-eu/flux-system/provider-slack-upgrades.yaml
+++ b/clusters/testnet-eu/flux-system/provider-slack-upgrades.yaml
@@ -1,0 +1,10 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  type: slack
+  channel: hashio-alerting
+  secretRef:
+    name: slack

--- a/clusters/testnet-na/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/testnet-na/flux-system/alert-slack-upgrades.yaml
@@ -10,9 +10,6 @@ spec:
   eventSources:
     - kind: HelmChart
       name: '*'
-      namespace: common
-    - kind: HelmChart
-      name: '*'
       namespace: testnet-citus
   exclusionList:
     - .*Internal error.*

--- a/clusters/testnet-na/flux-system/alert-slack-upgrades.yaml
+++ b/clusters/testnet-na/flux-system/alert-slack-upgrades.yaml
@@ -1,0 +1,22 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  eventMetadata:
+    summary: "Helm chart version upgrade started | environment: testnet | cluster: testnet-na"
+  eventSeverity: info
+  eventSources:
+    - kind: HelmChart
+      name: '*'
+      namespace: common
+    - kind: HelmChart
+      name: '*'
+      namespace: testnet-citus
+  exclusionList:
+    - .*Internal error.*
+  inclusionList:
+    - "^packaged 'hedera-mirror' chart with version"
+  providerRef:
+    name: slack-upgrades

--- a/clusters/testnet-na/flux-system/kustomization.yaml
+++ b/clusters/testnet-na/flux-system/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 resources:
 - alert-github-dispatch.yaml
 - alert-slack.yaml
+- alert-slack-upgrades.yaml
 - gotk-components.yaml
 - gotk-sync.yaml
 - provider-github-dispatch.yaml
 - provider-slack.yaml
+- provider-slack-upgrades.yaml
 - sealed-secret-github-dispatch.yaml
 - sealed-secret-slack.yaml

--- a/clusters/testnet-na/flux-system/provider-slack-upgrades.yaml
+++ b/clusters/testnet-na/flux-system/provider-slack-upgrades.yaml
@@ -1,0 +1,10 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: slack-upgrades
+  namespace: flux-system
+spec:
+  type: slack
+  channel: hashio-alerting
+  secretRef:
+    name: slack


### PR DESCRIPTION
**Description**:
- Removed the `integration` env test notification
- Added providers, alerts, and updated kustomization.yaml files for each env to include the new files
- Modified the notification content as requested by Steven: removed `cluster` and `environment` fields and included their content in the `summary` field.

**Related issue(s)**:
- Fixes #13455 

**Notes for reviewer**:
Following Fernando's request to have these notifications sent to `hashio-alerting`, I've set everything up in this PR.
Note: I have added the `Mirror Node Alerts` bot to the channel.

**Checklist**

- Previously tested against `integration` and found to be working correctly.
