### PR TITLE
fix(importer): remove duplicate synthetic transfer contract logs surviving migration

### DIFF
--- a/importer/src/main/resources/db/migration/v1/V1.122.1__remove_duplicated_transfer_synthetic_contract_logs.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.122.1__remove_duplicated_transfer_synthetic_contract_logs.sql
@@ -1,0 +1,49 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+DELETE FROM contract_log cl_dup
+WHERE cl_dup.consensus_timestamp > 1772316000000000000
+AND cl_dup.topic0 = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+AND LENGTH(cl_dup.data) != 32
+  AND EXISTS (
+    SELECT 1
+    FROM contract_log cl_orig
+    WHERE cl_orig.consensus_timestamp = cl_dup.consensus_timestamp
+      AND cl_orig.consensus_timestamp > 1772316000000000000
+      AND cl_orig.topic0 = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+      AND cl_orig.contract_id = cl_dup.contract_id
+      AND cl_orig.transaction_hash != cl_dup.transaction_hash
+      AND cl_orig.bloom != cl_dup.bloom
+      AND LENGTH(cl_orig.data) = 32
+      AND LTRIM(encode(cl_orig.data, 'hex'), '0') = LTRIM(encode(cl_dup.data, 'hex'), '0')
+      AND (
+        cl_orig.topic1 IS NOT DISTINCT FROM cl_dup.topic1
+        OR trim(leading '\x00'::bytea from cl_orig.topic1) = trim(leading '\x00'::bytea from cl_dup.topic1)
+        OR (
+          octet_length(trim(leading '\x00'::bytea from cl_dup.topic1)) <= 8
+          AND EXISTS (
+            SELECT 1 FROM entity e
+            WHERE e.id = ('x' || lpad(encode(trim(leading '\x00'::bytea from cl_dup.topic1), 'hex'), 16, '0'))::bit(64)::bigint
+              AND (
+                trim(leading '\x00'::bytea from e.evm_address) = trim(leading '\x00'::bytea from cl_orig.topic1)
+                OR trim(leading '\x00'::bytea from e.alias) = trim(leading '\x00'::bytea from cl_orig.topic1)
+              )
+          )
+        )
+      )
+      AND (
+        cl_orig.topic2 IS NOT DISTINCT FROM cl_dup.topic2
+        OR trim(leading '\x00'::bytea from cl_orig.topic2) = trim(leading '\x00'::bytea from cl_dup.topic2)
+        OR (
+          octet_length(trim(leading '\x00'::bytea from cl_dup.topic2)) <= 8
+          AND EXISTS (
+            SELECT 1 FROM entity e
+            WHERE e.id = ('x' || lpad(encode(trim(leading '\x00'::bytea from cl_dup.topic2), 'hex'), 16, '0'))::bit(64)::bigint
+              AND (
+                trim(leading '\x00'::bytea from e.evm_address) = trim(leading '\x00'::bytea from cl_orig.topic2)
+                OR trim(leading '\x00'::bytea from e.alias) = trim(leading '\x00'::bytea from cl_orig.topic2)
+              )
+          )
+        )
+      )
+      AND cl_orig.topic3 IS NOT DISTINCT FROM cl_dup.topic3
+);

--- a/importer/src/main/resources/db/migration/v2/V2.27.1__remove_duplicated_transfer_synthetic_contract_logs.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.27.1__remove_duplicated_transfer_synthetic_contract_logs.sql
@@ -1,0 +1,49 @@
+-- SPDX-License-Identifier: Apache-2.0
+
+DELETE FROM contract_log cl_dup
+WHERE cl_dup.consensus_timestamp > 1772316000000000000
+AND cl_dup.topic0 = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+AND LENGTH(cl_dup.data) != 32
+  AND EXISTS (
+    SELECT 1
+    FROM contract_log cl_orig
+    WHERE cl_orig.consensus_timestamp = cl_dup.consensus_timestamp
+      AND cl_orig.consensus_timestamp > 1772316000000000000
+      AND cl_orig.topic0 = '\xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+      AND cl_orig.contract_id = cl_dup.contract_id
+      AND cl_orig.transaction_hash != cl_dup.transaction_hash
+      AND cl_orig.bloom != cl_dup.bloom
+      AND LENGTH(cl_orig.data) = 32
+      AND LTRIM(encode(cl_orig.data, 'hex'), '0') = LTRIM(encode(cl_dup.data, 'hex'), '0')
+      AND (
+        cl_orig.topic1 IS NOT DISTINCT FROM cl_dup.topic1
+        OR trim(leading '\x00'::bytea from cl_orig.topic1) = trim(leading '\x00'::bytea from cl_dup.topic1)
+        OR (
+          octet_length(trim(leading '\x00'::bytea from cl_dup.topic1)) <= 8
+          AND EXISTS (
+            SELECT 1 FROM entity e
+            WHERE e.id = ('x' || lpad(encode(trim(leading '\x00'::bytea from cl_dup.topic1), 'hex'), 16, '0'))::bit(64)::bigint
+              AND (
+                trim(leading '\x00'::bytea from e.evm_address) = trim(leading '\x00'::bytea from cl_orig.topic1)
+                OR trim(leading '\x00'::bytea from e.alias) = trim(leading '\x00'::bytea from cl_orig.topic1)
+              )
+          )
+        )
+      )
+      AND (
+        cl_orig.topic2 IS NOT DISTINCT FROM cl_dup.topic2
+        OR trim(leading '\x00'::bytea from cl_orig.topic2) = trim(leading '\x00'::bytea from cl_dup.topic2)
+        OR (
+          octet_length(trim(leading '\x00'::bytea from cl_dup.topic2)) <= 8
+          AND EXISTS (
+            SELECT 1 FROM entity e
+            WHERE e.id = ('x' || lpad(encode(trim(leading '\x00'::bytea from cl_dup.topic2), 'hex'), 16, '0'))::bit(64)::bigint
+              AND (
+                trim(leading '\x00'::bytea from e.evm_address) = trim(leading '\x00'::bytea from cl_orig.topic2)
+                OR trim(leading '\x00'::bytea from e.alias) = trim(leading '\x00'::bytea from cl_orig.topic2)
+              )
+          )
+        )
+      )
+      AND cl_orig.topic3 IS NOT DISTINCT FROM cl_dup.topic3
+);

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/RemoveDuplicatedTransferSyntheticContractLogsMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/RemoveDuplicatedTransferSyntheticContractLogsMigrationTest.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.DisableRepeatableSqlMigration;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.repository.ContractLogRepository;
@@ -26,7 +27,7 @@ class RemoveDuplicatedTransferSyntheticContractLogsMigrationTest extends Importe
 
     private static final long MIGRATION_TIMESTAMP_THRESHOLD = 1772316000000000000L;
 
-    @Value("classpath:db/migration/v1/V1.122.0__remove_duplicated_transfer_synthetic_contract_logs.sql")
+    @Value("classpath:db/migration/v1/V1.122.1__remove_duplicated_transfer_synthetic_contract_logs.sql")
     private final Resource migrationSql;
 
     private final ContractLogRepository contractLogRepository;
@@ -464,6 +465,82 @@ class RemoveDuplicatedTransferSyntheticContractLogsMigrationTest extends Importe
                         .bloom(domainBuilder.bytes(256))
                         .transactionHash(domainBuilder.bytes(32))
                         .transactionIndex(2))
+                .persist();
+
+        runMigration();
+
+        assertThat(contractLogRepository.findAll()).hasSize(1).containsExactly(originalLog);
+    }
+
+    @Test
+    void removeDuplicateWithAliasVsNumTopicFormat() throws DecoderException {
+        var recordFile = domainBuilder
+                .recordFile()
+                .customize(rf -> rf.hapiVersionMajor(0)
+                        .hapiVersionMinor(71)
+                        .hapiVersionPatch(0)
+                        .consensusStart(MIGRATION_TIMESTAMP_THRESHOLD + 1000))
+                .persist();
+
+        var consensusTimestamp = recordFile.getConsensusStart() + 100;
+        var contractId = domainBuilder.entityId();
+        var topic0 = Hex.decodeHex("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+        // Create sender and receiver entities with EVM addresses
+        var sender = domainBuilder
+                .entity()
+                .customize(e -> e.evmAddress(domainBuilder.bytes(20)))
+                .persist();
+        var receiver = domainBuilder
+                .entity()
+                .customize(e -> e.evmAddress(domainBuilder.bytes(20)))
+                .persist();
+
+        // cl_orig topic1/topic2 have EVM addresses (from consensus node)
+        // Pad the 20-byte evm address to 32 bytes on the left
+        var topic1Orig = DomainUtils.leftPadBytes(sender.getEvmAddress(), 32);
+        var topic2Orig = DomainUtils.leftPadBytes(receiver.getEvmAddress(), 32);
+
+        // cl_dup topic1/topic2 have trimmed account numbers (from MN synthetic)
+        var topic1Dup = DomainUtils.trim(DomainUtils.toEvmAddress(sender.toEntityId()));
+        var topic2Dup = DomainUtils.trim(DomainUtils.toEvmAddress(receiver.toEntityId()));
+
+        byte[] topic3 = null;
+        var originalData = Hex.decodeHex("0000000000000000000000000000000000000000000000000000000000000064");
+        var duplicateData = Hex.decodeHex("64");
+        var bloomOriginal = domainBuilder.bytes(256);
+        var bloomDuplicate = domainBuilder.bytes(256);
+        var transactionHashOriginal = domainBuilder.bytes(32);
+        var transactionHashDuplicate = domainBuilder.bytes(32);
+
+        var originalLog = domainBuilder
+                .contractLog()
+                .customize(cl -> cl.consensusTimestamp(consensusTimestamp)
+                        .contractId(contractId)
+                        .index(0)
+                        .topic0(topic0)
+                        .topic1(topic1Orig)
+                        .topic2(topic2Orig)
+                        .topic3(topic3)
+                        .data(originalData)
+                        .bloom(bloomOriginal)
+                        .transactionHash(transactionHashOriginal)
+                        .transactionIndex(0))
+                .persist();
+
+        domainBuilder
+                .contractLog()
+                .customize(cl -> cl.consensusTimestamp(consensusTimestamp)
+                        .contractId(contractId)
+                        .index(1)
+                        .topic0(topic0)
+                        .topic1(topic1Dup)
+                        .topic2(topic2Dup)
+                        .topic3(topic3)
+                        .data(duplicateData)
+                        .bloom(bloomDuplicate)
+                        .transactionHash(transactionHashDuplicate)
+                        .transactionIndex(1))
                 .persist();
 
         runMigration();


### PR DESCRIPTION
Remove historical duplicate synthetic contract transfer logs that survive the cleanup migration on mirror-node due to EVM address alias vs account number topic mismatches.

* Add follow-up migration scripts V1.122.1 and V2.27.1 to clean up remaining duplicates using a robust, native PostgreSQL trimmed-bytea comparison.
* Resolve EVM address / alias matches when duplicate topics are in a trimmed account number format (<= 8 bytes).
* Update `RemoveDuplicatedTransferSyntheticContractLogsMigrationTest` to load the new v1 migration resource and add a dedicated `removeDuplicateWithAliasVsNumTopicFormat` integration test case.

**Related issue(s)**:

Fixes #13492

**Notes for reviewer**:
All 10 migration integration test cases compile cleanly and pass successfully:

```xml
<testsuite name="org.hiero.mirror.importer.migration.RemoveDuplicatedTransferSyntheticContractLogsMigrationTest" tests="10" failures="0" errors="0">
  <testcase name="removeDuplicateWithAliasVsNumTopicFormat()" time="1.734"/>
  <testcase name="keepBothWhenDifferentData()" time="0.118"/>
  <testcase name="keepBothWhenDifferentTopic1()" time="0.13"/>
  <testcase name="noDuplicates()" time="0.1"/>
  <testcase name="empty()" time="0.082"/>
  <testcase name="removeDuplicateWithSameTopicsAndData()" time="0.105"/>
  <testcase name="skipWhenTimestampBelowThreshold()" time="0.106"/>
  <testcase name="removeMultipleDuplicates()" time="0.109"/>
  <testcase name="keepBothWhenSameTransactionHash()" time="0.103"/>
  <testcase name="removeDuplicateWithNullTopics()" time="0.099"/>
</testsuite>
