### PR TITLE
Fix two noisy Database alert rules

### DIFF
--- a/charts/hedera-mirror-common/alerts/rules.tf
+++ b/charts/hedera-mirror-common/alerts/rules.tf
@@ -1916,8 +1916,8 @@ resource "grafana_rule_group" "rule_group_database" {
       model          = "{\"editorMode\":\"code\",\"expr\":\"sum by (cluster, namespace, pod) (pg_exporter_last_scrape_error) == 1\",\"instant\":true,\"intervalMs\":1000,\"legendFormat\":\"__auto\",\"maxDataPoints\":43200,\"range\":false,\"refId\":\"A\"}"
     }
 
-    no_data_state  = "NoData"
-    exec_err_state = "Error"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
     for            = "10m"
     annotations = {
       description = "{{ $labels.cluster }}: postgres-exporter is not running or is showing errors for {{ $labels.namespace }}/{{ $labels.pod }}"
@@ -2036,8 +2036,8 @@ resource "grafana_rule_group" "rule_group_database" {
       model          = "{\"editorMode\":\"code\",\"expr\":\"sum by (cluster, namespace, pod) (pgbouncer_show_pools_cl_waiting) > 0\",\"instant\":true,\"intervalMs\":1000,\"legendFormat\":\"__auto\",\"maxDataPoints\":43200,\"range\":false,\"refId\":\"A\"}"
     }
 
-    no_data_state  = "NoData"
-    exec_err_state = "Error"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
     for            = "5m"
     annotations = {
       description = "{{ $labels.cluster }}: PgBouncer {{ $labels.namespace }}/{{ $labels.pod }} has {{ (index $values \"A\").Value }} waiting clients"


### PR DESCRIPTION
**Description**:
- Fix two noisy `Database` alert rules: set `no_data_state` and `exec_err_state` to "OK" on `DatabaseExporterErrors` and `DatabaseWaitingClients`.


**Related issue(s)**:

- #13446 

**Notes for reviewer**:
The two rules have been generating synthetic `DatasourceNoData` and firing because Grafana's `no_data_state = "NoData"` treats "query went empty after matching" as an alert. 
Setting both fields to "OK" aligns these two rules and stops the noise.

Jenkins sync pipe paused until this PR is merged to `main`, to avoid it rolling back the changes.

**Checklist**

- Tested by manually applying the TF changes and giving it a few minutes, both rules changed to "Normal".
