### PR TITLE
Fix native image builds (0.155)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ extra.apply {
     set("jooq.version", "3.21.3") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
     set("netty.version", "4.2.13.Final") // Temporary until next Spring Boot
-    set("nodeJsVersion", "24.13.0")
+    set("nodeJsVersion", "24.15.0")
     set("postgresql.version", "42.7.11") // Temporary until next Spring Boot
     set("protobufVersion", "4.34.1")
     set("springGrpcVersion", "1.0.3")

--- a/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
@@ -36,11 +36,11 @@ val platform = imagePlatform.ifBlank { null }
 tasks.bootBuildImage {
     // Use digests for deterministic builds.
     val builderImageDigest =
-        "sha256:3c12804ab2b1fd77df0297052c0024cc7915295bc159ed91f19d2321a133a5be" // 0.0.124
+        "sha256:42981edb21bb82d4381d00ada9ae2c14837083aa36e993b64b48cf2cb7eb43dc" // 0.0.138
     val nativeImageDigest =
-        "sha256:f2b2a03e04266d512eb026afe8fab4726955d4557fd3429a46d4644d61d9c55a" // 14.3.0
+        "sha256:41b0b40795f3703f210a38872b36e3ad9e23236a5a81e8e1984ebef2ff94a17c" // 14.5.0
     val runImageDigest =
-        "sha256:18d21d36f4caa29dfcefc38045af61020dd76222d3e76d61f9f0433ac9ad28de" // 0.0.74
+        "sha256:9a4259a3735350bd49a226382dc62f96eec3d2be6ecb45dcf7f460111dfdfb8c" // 0.0.86
 
     val env = System.getenv()
     val repo = env.getOrDefault("GITHUB_REPOSITORY", "hiero-ledger/hiero-mirror-node")

--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm
 
 # Marketplace image still depends upon Helm 3
-ENV HELM_VERSION=4.1.4
+ENV HELM_VERSION=4.2.0
 ENV YQ_VERSION=v4.53.2
 
 # Install yq
@@ -9,8 +9,8 @@ RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linu
     mv yq_linux_amd64 /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
-# Install Helm - temporarily use fork until next Helm version
-RUN wget -q https://github.com/steven-sheehy/helm/releases/download/v${HELM_VERSION}/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | \
+# Install Helm
+RUN wget -q https://github.com/helm/helm/releases/download/v${HELM_VERSION}/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | \
     tar -C /usr/local/bin --strip-components=1 -zxv linux-amd64/helm
 
 # Pull in charts

--- a/common/src/main/java/org/hiero/mirror/common/config/CommonRuntimeHints.java
+++ b/common/src/main/java/org/hiero/mirror/common/config/CommonRuntimeHints.java
@@ -2,14 +2,19 @@
 
 package org.hiero.mirror.common.config;
 
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_AND_FIELDS;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_ONLY;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.METHODS_ONLY;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.UNSAFE_ALLOCATED;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerReflectionType;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerReflectionTypes;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Instant;
 import java.util.List;
+import org.hibernate.validator.internal.util.logging.Log_$logger;
+import org.hibernate.validator.internal.util.logging.Messages_$bundle;
 import org.hiero.mirror.common.util.SpelHelper;
 import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.RuntimeHints;
@@ -29,6 +34,10 @@ public class CommonRuntimeHints implements RuntimeHintsRegistrar {
         registerNode(hints, "PDA");
         registerNode(hints, "PSAMS");
         registerNode(hints, "PSR");
+
+        // Hibernate Validator
+        registerReflectionTypes(hints, CONSTRUCTORS_ONLY, Log_$logger.class);
+        registerReflectionTypes(hints, CONSTRUCTORS_AND_FIELDS, Messages_$bundle.class);
 
         // For ReconciliationJob.timestampStart use as an ID in Hibernate
         registerReflectionType(hints, Instant[].class, UNSAFE_ALLOCATED);

--- a/common/src/main/java/org/hiero/mirror/common/util/RuntimeHintsHelper.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/RuntimeHintsHelper.java
@@ -17,11 +17,6 @@ import org.springframework.core.type.filter.TypeFilter;
 @NullMarked
 public final class RuntimeHintsHelper {
 
-    private static final MemberCategory[] DEFAULT_CATEGORIES = {
-        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-        MemberCategory.INVOKE_DECLARED_METHODS,
-        MemberCategory.ACCESS_DECLARED_FIELDS,
-    };
     public static final MemberCategory[] NONE = {};
     public static final MemberCategory[] UNSAFE_ALLOCATED = {MemberCategory.UNSAFE_ALLOCATED};
     public static final MemberCategory[] METHODS_ONLY = {MemberCategory.INVOKE_DECLARED_METHODS};
@@ -29,8 +24,14 @@ public final class RuntimeHintsHelper {
         MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS
     };
     public static final MemberCategory[] CONSTRUCTORS_ONLY = {MemberCategory.INVOKE_DECLARED_CONSTRUCTORS};
-    public static final MemberCategory[] FIELDS_AND_METHODS = {
-        MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS
+    public static final MemberCategory[] CONSTRUCTORS_AND_FIELDS = {
+        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.ACCESS_DECLARED_FIELDS
+    };
+
+    private static final MemberCategory[] DEFAULT_CATEGORIES = {
+        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+        MemberCategory.INVOKE_DECLARED_METHODS,
+        MemberCategory.ACCESS_DECLARED_FIELDS,
     };
 
     public static void registerReflectionTypes(RuntimeHints hints, String... classNames) {

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/config/RuntimeHintsConfiguration.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/config/RuntimeHintsConfiguration.java
@@ -3,7 +3,6 @@
 package org.hiero.mirror.restjava.config;
 
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_AND_METHODS;
-import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_ONLY;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.NONE;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerAnnotatedPackage;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerPackage;
@@ -20,7 +19,6 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Year;
 import java.util.Objects;
-import org.hibernate.validator.internal.util.logging.Log_$logger;
 import org.hiero.mirror.rest.model.Error;
 import org.hiero.mirror.restjava.config.RuntimeHintsConfiguration.CustomRuntimeHints;
 import org.hiero.mirror.restjava.dto.NetworkNodeRequest;
@@ -69,8 +67,6 @@ final class RuntimeHintsConfiguration {
             registerAnnotatedPackage(hints, loader, "com.hedera.node.config.data", ConfigData.class);
             registerPackage(hints, loader, ThrottleGroup.class.getPackageName());
             registerPackage(hints, loader, NumberRangeParameter.class.getPackageName());
-
-            registerReflectionTypes(hints, CONSTRUCTORS_ONLY, Log_$logger.class);
 
             registerResourcePatterns(
                     hints,

--- a/web3/src/main/java/org/hiero/mirror/web3/config/RuntimeHintsConfiguration.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/config/RuntimeHintsConfiguration.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.web3.config;
 
-import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_ONLY;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.NONE;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerAnnotatedPackage;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerPackage;
@@ -11,7 +10,6 @@ import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerResourcePa
 
 import com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ThrottleGroup;
 import com.swirlds.config.api.ConfigData;
-import org.hibernate.validator.internal.util.logging.Log_$logger;
 import org.hiero.mirror.web3.common.ContractCallContext;
 import org.hiero.mirror.web3.common.TransactionIdOrHashParameter;
 import org.hiero.mirror.web3.viewmodel.ContractCallRequest;
@@ -46,8 +44,6 @@ final class RuntimeHintsConfiguration {
                     "com.esaulpaugh.headlong.abi.Quintuple[]",
                     "com.esaulpaugh.headlong.abi.Sextuple[]",
                     "com.esaulpaugh.headlong.abi.Triple[]");
-
-            registerReflectionTypes(hints, CONSTRUCTORS_ONLY, Log_$logger.class);
 
             registerReflectionTypes(
                     hints,


### PR DESCRIPTION
**Description**:

* Bump node.js version in Gradle to match container
* Bump native Java builder images
* Fix broken native images caused by missing Hibernate Validator reflection hints
* Revert to official Helm release in Marketplace

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
