### PR TITLE
Fix native image startup crashes

### DIFF
--- a/monitor/src/main/java/org/hiero/mirror/monitor/config/MonitorConfiguration.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/config/MonitorConfiguration.java
@@ -17,9 +17,7 @@ import org.hiero.mirror.monitor.publish.TransactionPublisher;
 import org.hiero.mirror.monitor.publish.generator.TransactionGenerator;
 import org.hiero.mirror.monitor.subscribe.MirrorSubscriber;
 import org.hiero.mirror.monitor.subscribe.SubscribeMetrics;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import reactor.core.Disposable;
@@ -49,7 +47,6 @@ final class MonitorConfiguration {
     private final TransactionPublisher transactionPublisher;
 
     @Bean
-    @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
     KubernetesClient kubernetesClient() {
         return new KubernetesClientBuilder().build();
     }

--- a/monitor/src/main/java/org/hiero/mirror/monitor/config/RuntimeHintsConfiguration.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/config/RuntimeHintsConfiguration.java
@@ -2,9 +2,16 @@
 
 package org.hiero.mirror.monitor.config;
 
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_AND_FIELDS;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_ONLY;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerReflectionTypes;
+
 import com.google.protobuf.GeneratedMessageLite;
 import com.hedera.hashgraph.sdk.Transaction;
 import lombok.CustomLog;
+import org.hibernate.validator.internal.constraintvalidators.hv.time.DurationMaxValidator;
+import org.hibernate.validator.internal.util.logging.Log_$logger;
+import org.hibernate.validator.internal.util.logging.Messages_$bundle;
 import org.hiero.mirror.monitor.config.RuntimeHintsConfiguration.CustomRuntimeHints;
 import org.hiero.mirror.monitor.publish.transaction.TransactionSupplier;
 import org.hiero.mirror.rest.model.NetworkNodesResponse;
@@ -30,21 +37,9 @@ final class RuntimeHintsConfiguration {
             registerOpenApi(hints);
             registerProtobufs(hints);
             registerTransactionSuppliers(hints);
-            registerHibernateValidator(hints);
-        }
-
-        // native-gradle-plugin 1.1.0 reachability metadata is incomplete for hibernate-validator
-        private void registerHibernateValidator(RuntimeHints hints) {
-            final var scanner = new ClassPathScanningCandidateComponentProvider(false);
-            scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
-            scanner.findCandidateComponents("org.hibernate.validator").forEach(b -> hints.reflection()
-                    .registerType(
-                            TypeReference.of(b.getBeanClassName()),
-                            MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
-                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-                            MemberCategory.INVOKE_PUBLIC_METHODS,
-                            MemberCategory.INVOKE_DECLARED_METHODS,
-                            MemberCategory.ACCESS_DECLARED_FIELDS));
+            registerReflectionTypes(hints, CONSTRUCTORS_ONLY, Log_$logger.class);
+            registerReflectionTypes(hints, CONSTRUCTORS_AND_FIELDS, Messages_$bundle.class);
+            registerReflectionTypes(hints, CONSTRUCTORS_ONLY, DurationMaxValidator.class);
         }
 
         /**

--- a/monitor/src/main/java/org/hiero/mirror/monitor/config/RuntimeHintsConfiguration.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/config/RuntimeHintsConfiguration.java
@@ -30,6 +30,21 @@ final class RuntimeHintsConfiguration {
             registerOpenApi(hints);
             registerProtobufs(hints);
             registerTransactionSuppliers(hints);
+            registerHibernateValidator(hints);
+        }
+
+        // native-gradle-plugin 1.1.0 reachability metadata is incomplete for hibernate-validator
+        private void registerHibernateValidator(RuntimeHints hints) {
+            final var scanner = new ClassPathScanningCandidateComponentProvider(false);
+            scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
+            scanner.findCandidateComponents("org.hibernate.validator").forEach(b -> hints.reflection()
+                    .registerType(
+                            TypeReference.of(b.getBeanClassName()),
+                            MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
+                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                            MemberCategory.INVOKE_PUBLIC_METHODS,
+                            MemberCategory.INVOKE_DECLARED_METHODS,
+                            MemberCategory.ACCESS_DECLARED_FIELDS));
         }
 
         /**

--- a/monitor/src/main/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -17,15 +17,13 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Strings;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
-import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.ReactiveHealthIndicator;
 import org.springframework.boot.health.contributor.Status;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-@ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
 @CustomLog
 @Named
 @RequiredArgsConstructor
@@ -45,7 +43,7 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
             .withPlural("helmreleases")
             .withVersion("v2")
             .build();
-    private final KubernetesClient client;
+    private final ObjectProvider<KubernetesClient> kubernetesClientProvider;
     private final ReleaseHealthProperties properties;
     private final MeterRegistry meterRegistry;
 
@@ -71,30 +69,37 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
     }
 
     private Mono<Health> createHelmReleaseHealth() {
-        return Mono.fromCallable(this::getHelmRelease)
+        final var kubernetesClient = kubernetesClientProvider.getIfAvailable();
+        if (kubernetesClient == null) {
+            return UNKNOWN;
+        }
+        return Mono.fromCallable(() -> getHelmRelease(kubernetesClient))
                 .cacheInvalidateIf(v -> false)
                 .doOnError(e -> log.error("Unable to get helm release", e))
                 .onErrorComplete()
-                .flatMap(this::getHelmReleaseReadyStatus)
+                .flatMap(release -> getHelmReleaseReadyStatus(kubernetesClient, release))
                 .doOnError(e -> log.error("Unable to get helm release ready status", e))
                 .onErrorComplete()
                 .switchIfEmpty(UNKNOWN)
                 .cache(properties.getCacheExpiry(), Schedulers.newSingle("helmrelease-health-cache"));
     }
 
-    private String getHelmRelease() {
-        var hostname = System.getenv("HOSTNAME");
-        var labels = client.pods().withName(hostname).get().getMetadata().getLabels();
+    private String getHelmRelease(KubernetesClient kubernetesClient) {
+        final var hostname = System.getenv("HOSTNAME");
+        final var labels =
+                kubernetesClient.pods().withName(hostname).get().getMetadata().getLabels();
         return Objects.requireNonNull(labels.get(INSTANCE_LABEL), "No " + INSTANCE_LABEL + " label");
     }
 
     @SuppressWarnings("unchecked")
-    private Mono<Health> getHelmReleaseReadyStatus(String release) {
-        var resource = client.genericKubernetesResources(RESOURCE_DEFINITION_CONTEXT)
+    private Mono<Health> getHelmReleaseReadyStatus(KubernetesClient kubernetesClient, String release) {
+        final var resource = kubernetesClient
+                .genericKubernetesResources(RESOURCE_DEFINITION_CONTEXT)
                 .withName(release)
                 .get();
-        var status = (Map<String, Object>) resource.getAdditionalProperties().get("status");
-        var conditions = (List<Map<String, String>>) status.get("conditions");
+        final var status =
+                (Map<String, Object>) resource.getAdditionalProperties().get("status");
+        final var conditions = (List<Map<String, String>>) status.get("conditions");
         return conditions.stream()
                 .filter(condition -> Strings.CS.equals(condition.get("type"), "Ready"))
                 .findFirst()
@@ -104,12 +109,12 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
     }
 
     private Mono<Health> mapStatus(Map<String, String> condition) {
-        var status = condition.get("status");
+        final var status = condition.get("status");
         if ("True".equals(status)) {
             return UP;
         }
 
-        var reason = condition.get("reason");
+        final var reason = condition.get("reason");
         if (DEPENDENCY_NOT_READY.equals(reason)) {
             return UNKNOWN;
         }

--- a/monitor/src/test/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicatorTest.java
+++ b/monitor/src/test/java/org/hiero/mirror/monitor/health/ReleaseHealthIndicatorTest.java
@@ -5,6 +5,8 @@ package org.hiero.mirror.monitor.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.monitor.health.ReleaseHealthIndicator.DEPENDENCY_NOT_READY;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.api.model.ConditionBuilder;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
@@ -12,6 +14,7 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -22,6 +25,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
 import reactor.core.publisher.Flux;
@@ -49,10 +53,14 @@ class ReleaseHealthIndicatorTest {
     private ReleaseHealthIndicator healthIndicator;
     private MeterRegistry meterRegistry = mock(MeterRegistry.class);
 
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<KubernetesClient> kubernetesClientProvider = mock(ObjectProvider.class);
+
     @BeforeEach
     void setUp() {
         var client = server.createClient().inNamespace("test");
-        healthIndicator = new ReleaseHealthIndicator(client, properties, meterRegistry);
+        when(kubernetesClientProvider.getIfAvailable()).thenReturn(client);
+        healthIndicator = new ReleaseHealthIndicator(kubernetesClientProvider, properties, meterRegistry);
         properties.setEnabled(true);
         server.clearExpectations();
     }
@@ -62,11 +70,25 @@ class ReleaseHealthIndicatorTest {
         // given
         properties.setEnabled(false);
 
-        // then
+        // when
         var health = healthIndicator.health().block();
 
         // then
         assertThat(health).returns(Status.UP, Health::getStatus);
+        verifyNoInteractions(kubernetesClientProvider);
+    }
+
+    @Test
+    void kubernetesClientUnavailable() {
+        // given
+        when(kubernetesClientProvider.getIfAvailable()).thenReturn(null);
+
+        // when
+        var health = healthIndicator.health().block();
+
+        // then
+        assertThat(health).returns(Status.UNKNOWN, Health::getStatus);
+        assertThat(server.getRequestCount()).isZero();
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Fixes two native image startup crashes:

- `NoSuchHealthContributorException` — removed `@ConditionalOnCloudPlatform` from `ReleaseHealthIndicator` and `kubernetesClient() `so both beans are always included in the native image.
- `Hibernate` Validator reflection failures — `native-gradle-plugin 1.1.0` ships incomplete reachability metadata for hibernate-validator. Added missing reflection hints for `Log_$logger`, `Messages_$bundle`, and `DurationMaxValidator` in `RuntimeHintsConfiguration`.

**Related issue(s)**:

Fixes #13457 

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
