### PR TITLE
Separate streaming and request backends

### DIFF
--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -53,10 +53,9 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
@@ -14,3 +14,18 @@ spec:
     kind: {{ .Values.gateway.target.kind }}
     name: {{ include "hedera-mirror-grpc.fullname" . }}
 {{- end }}
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) }}
+---
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.streamingBackendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+{{- end }}

--- a/charts/hedera-mirror-grpc/templates/service.yaml
+++ b/charts/hedera-mirror-grpc/templates/service.yaml
@@ -19,3 +19,21 @@ spec:
       name: http
   selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
+{{ if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.streamingBackendPolicy)) -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}-streaming
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -66,10 +66,17 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
+    streamingBackendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 9999999
     enabled: true
     healthCheckPolicy:
       config:
@@ -82,11 +89,17 @@ gateway:
     - backendRefs:
         - group: "{{ .Values.gateway.target.group }}"
           kind: "{{ .Values.gateway.target.kind }}"
-          name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}"
+          name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}-streaming"
           port: 5600
       matches:
         - method:
             service: com.hedera.mirror.api.proto.ConsensusService
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}"
+          port: 5600
+      matches:
         - method:
             service: com.hedera.mirror.api.proto.NetworkService
         - method:

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -53,10 +53,9 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -53,10 +53,9 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -53,10 +53,9 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -53,10 +53,9 @@ gateway:
         drainingTimeoutSec: 10
       logging:
         enabled: false
-      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
       sessionAffinity:
         type: CLIENT_IP
-      timeoutSec: 20
+      timeoutSec: 15
     enabled: true
     healthCheckPolicy:
       config:


### PR DESCRIPTION
**Description**:

* Add a new streaming backend for gRPC API with a timeout of 9999999
* Adjust timeout from 20s to 15s in request/response APIs
* Remove unknown field `maxRatePerEndpoint` from API gateway

**Related issue(s)**:

Fixes #13459

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
