### PR TITLE
Disable collecting k6 test report in script and workflow

### DIFF
--- a/.github/workflows/copy-stackgres-cluster.yml
+++ b/.github/workflows/copy-stackgres-cluster.yml
@@ -8,6 +8,9 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      collect_k6_report:
+        default: false
+        type: boolean
       require_clean_target:
         default: true
         type: boolean
@@ -70,6 +73,11 @@ on:
         required: true
   workflow_dispatch:
     inputs:
+      collect_k6_report:
+        default: false
+        description: "Collect and upload the k6 test report artifact"
+        type: boolean
+        required: false
       require_clean_target:
         default: true
         description: "Require target to be in torn down state"
@@ -151,6 +159,7 @@ jobs:
     runs-on: hiero-mirror-node-linux-medium
     timeout-minutes: 900 # 15 hours
     env:
+      COLLECT_K6_REPORT: ${{ inputs.collect_k6_report }}
       GCP_SNAPSHOT_PROJECT: ${{ inputs.source_project == 'prod' && secrets.GH_ACTIONS_KUBECTL_MAIN_PROJECT_ID || secrets.GH_ACTIONS_KUBECTL_STAGING_PROJECT_ID }}
       GCP_K8S_SOURCE_CLUSTER_NAME: ${{ inputs.source_cluster_name }}
       GCP_K8S_SOURCE_CLUSTER_REGION: ${{ inputs.source_cluster_location }}
@@ -298,7 +307,7 @@ jobs:
           ./copy-live-environment.sh
 
       - name: Upload k6 test report
-        if: ${{ inputs.run_k6_test == true }}
+        if: ${{ inputs.run_k6_test == true && inputs.collect_k6_report == true }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: k6-test-report

--- a/tools/cluster-management/copy-live-environment.sh
+++ b/tools/cluster-management/copy-live-environment.sh
@@ -8,6 +8,7 @@ source ./utils/utils.sh
 source ./utils/input-utils.sh
 source ./utils/snapshot-utils.sh
 
+COLLECT_K6_REPORT="${COLLECT_K6_REPORT:-false}"
 CREATE_NEW_BACKUPS="${CREATE_NEW_BACKUPS:-true}"
 DEFAULT_POOL_MAX_PER_ZONE="${DEFAULT_POOL_MAX_PER_ZONE:-5}"
 DEFAULT_POOL_NAME="${DEFAULT_POOL_NAME:-default-pool}"
@@ -654,22 +655,31 @@ function waitForK6PodExecution() {
     sleep 1
   done
 
-  log "downloading artifacts for job ${job}"
-  until {
-    rm -f artifacts/report.md 2>/dev/null || true
-    testkube download artifacts "${job}"  >/dev/null 2>&1
-    [[ -s artifacts/report.md ]]
-  }; do
-    log "Waiting for artifacts to be available"
-    sleep 5
-  done
-
-  cat artifacts/report.md
-  mkdir -p "${K6_TEST_REPORT_DIR}"
-  cp artifacts/report.md "${K6_TEST_REPORT_DIR}/${testName}.md"
-  rm -fr artifacts
-
   scaleHpaMin "${targetNamespace}" "${hpaName}"
+
+  if [[ "${COLLECT_K6_REPORT}" == "true" ]]; then
+    log "downloading artifacts for job ${job}"
+    local deadline=$((SECONDS + 60))
+    rm -f artifacts/report.md 2>/dev/null || true
+    while true; do
+      testkube download artifacts "${job}"  >/dev/null 2>&1
+      if [[ -s artifacts/report.md ]]; then
+        cat artifacts/report.md
+        mkdir -p "${K6_TEST_REPORT_DIR}"
+        cp artifacts/report.md "${K6_TEST_REPORT_DIR}/${testName}.md"
+        rm -fr artifacts
+        break
+      fi
+
+      if (( SECONDS >= deadline )); then
+        log "Timed out waiting for artifacts after 60s"
+        break
+      fi
+
+      log "Waiting for artifacts to be available"
+      sleep 5
+    done
+  fi
 }
 
 function waitForHelmReleaseReady() {


### PR DESCRIPTION
**Description**:

This PR disables collecting k6 test report since the test has switch to push metrics.
 
**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
