### PR TITLE
Disable staging monitor by setting replicas to 0

### DIFF
--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -63,6 +63,7 @@ spec:
           enabled: false
         MonitorSubscribeLatency:
           enabled: false
+      replicas: 0
     rest:
       env:
         HIERO_MIRROR_REST_CACHE_RESPONSE_ENABLED: "false"


### PR DESCRIPTION
**Description**:

This PR sets staging monitor replicas to 0

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

We have changed to restore an old database snapshot and not run importer to catch up, there's no value to enable monitor and submit transactions to the network.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
