### PR TITLE
Adjust `record_file` consensus start and end timestamps migration (0.155)

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/migration/RecordFileConsensusTimestampsRecalculateMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/RecordFileConsensusTimestampsRecalculateMigration.java
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import jakarta.inject.Named;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Getter;
+import org.flywaydb.core.api.MigrationVersion;
+import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.ImporterProperties.HederaNetwork;
+import org.hiero.mirror.importer.config.Owner;
+import org.hiero.mirror.importer.db.DBProperties;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Updates {@code record_file.consensus_start} and {@code record_file.consensus_end} with the earliest and latest
+ * timestamp of the transactions that belong to each block.
+ */
+@Named
+final class RecordFileConsensusTimestampsRecalculateMigration extends AsyncJavaMigration<Long> {
+
+    /**
+     * Mainnet: only {@code record_file} rows with {@code consensus_end} strictly after this instant are processed.
+     * Jan 28, 2026 00:00:00 UTC.
+     */
+    private static final long MAINNET_MIN_CONSENSUS_END_TIMESTAMP = 1769558400000000000L;
+
+    /**
+     * Testnet: only {@code record_file} rows with {@code consensus_end} strictly after this instant are processed.
+     * (Dec 29, 2025 00:00:00 UTC).
+     */
+    static final long TESTNET_MIN_CONSENSUS_END_TIMESTAMP = 1766966400000000000L;
+
+    private static final Map<String, Long> DEFAULT_MIN_CONSENSUS_END_TIMESTAMP_BY_NETWORK = Map.of(
+            HederaNetwork.MAINNET, MAINNET_MIN_CONSENSUS_END_TIMESTAMP,
+            HederaNetwork.TESTNET, TESTNET_MIN_CONSENSUS_END_TIMESTAMP);
+
+    static final String MIN_CONSENSUS_END_TIMESTAMP_KEY = "minConsensusEndTimestamp";
+
+    static final long INTERVAL = Duration.ofDays(7).toNanos();
+
+    private static final String CREATE_TEMPORARY_PROCESSED_RECORD_FILE_TABLE = """
+                    create table if not exists processed_record_file_temp(
+                        consensus_end bigint not null
+                    );
+            """;
+
+    private static final String DROP_TEMPORARY_PROCESSED_RECORD_FILE_TABLE = """
+                    drop table if exists processed_record_file_temp;
+            """;
+
+    private static final String SELECT_LAST_PROCESSED_TIMESTAMP = """
+                    select coalesce(
+                      (select consensus_end
+                       from processed_record_file_temp
+                       order by consensus_end asc
+                       limit 1),
+                      (select max(consensus_end)
+                       from record_file
+                       where consensus_end > :minConsensusEndTimestamp),
+                      :minConsensusEndTimestamp
+                    )
+            """;
+
+    private static final String INSERT_SLICE_CHECKPOINT = """
+                    insert into processed_record_file_temp(consensus_end)
+                    values (:consensusEndLowerBound)
+            """;
+
+    private static final String SELECT_RECORD_FILES_IN_SLICE = """
+                    with record_file_slice as (
+                        select rf.consensus_start,
+                            rf.consensus_end,
+                            rf.count
+                        from record_file rf
+                        where rf.consensus_end > :consensusEndLowerBound
+                                and rf.consensus_end <= :consensusEndUpperBound
+                    )
+                    select rf.consensus_start,
+                        rf.consensus_end,
+                        rf.count,
+                        count(t.consensus_timestamp)::bigint as actual_transactions_count
+                    from record_file_slice rf
+                    left join transaction t on t.consensus_timestamp >= rf.consensus_start
+                            and t.consensus_timestamp <= rf.consensus_end
+                            and t.consensus_timestamp > :consensusEndLowerBound - 10_000_000_000
+                            and t.consensus_timestamp <= :consensusEndUpperBound
+                    group by rf.consensus_start, rf.consensus_end, rf.count
+                    having rf.count != count(t.consensus_timestamp)::bigint
+                    order by rf.consensus_end;
+            """;
+
+    private static final String SELECT_PREV_CONSENSUS_END = """
+                    select max(consensus_end)
+                    from record_file
+                    where consensus_end < :consensusStart
+            """;
+
+    // Using the consensus_end from the record_file as it is the primary key instead of searching
+    // by consensus_start directly.
+    private static final String SELECT_NEXT_CONSENSUS_START = """
+                    select consensus_start
+                    from record_file
+                    where consensus_end > :consensusEnd
+                    order by consensus_end
+                    limit 1
+            """;
+
+    private static final String SELECT_MIN_TX_BEFORE_START = """
+                    select min(gap_transactions.consensus_timestamp) as consensus_timestamp,
+                           count(*)::bigint as transaction_count
+                    from (
+                        select t.consensus_timestamp
+                        from transaction t
+                        where t.consensus_timestamp > :prevConsensusEnd
+                          and t.consensus_timestamp < :consensusStart
+                        order by t.consensus_timestamp desc
+                        limit :missingTransactionsCount
+                    ) gap_transactions
+            """;
+
+    private static final String SELECT_MAX_TX_AFTER_END = """
+                    select max(gap_transactions.consensus_timestamp) as consensus_timestamp,
+                           count(*)::bigint as transaction_count
+                    from (
+                        select t.consensus_timestamp
+                        from transaction t
+                        where t.consensus_timestamp > :consensusEnd
+                          and t.consensus_timestamp < :nextConsensusStart
+                        order by t.consensus_timestamp asc
+                        limit :missingTransactionsCount
+                    ) gap_transactions
+            """;
+
+    private static final String UPDATE_SIDECAR_FILES_WITH_CALCULATED_TIMESTAMPS = """
+                    update sidecar_file
+                    set consensus_end = coalesce(:consensusEndCalculated, consensus_end)
+                    where consensus_end = :consensusEnd
+            """;
+
+    private static final String UPDATE_RECORD_FILE_CALCULATED_TIMESTAMPS = """
+                    update record_file
+                    set consensus_start = coalesce(:consensusStartCalculated, consensus_start),
+                        consensus_end = coalesce(:consensusEndCalculated, consensus_end)
+                    where consensus_end = :consensusEnd
+            """;
+
+    private static final DataClassRowMapper<RecordFileSlice> RECORD_FILE_SLICE_ROW_MAPPER =
+            new DataClassRowMapper<>(RecordFileSlice.class);
+    private static final DataClassRowMapper<GapTransactionsResult> GAP_TRANSACTIONS_RESULT_ROW_MAPPER =
+            new DataClassRowMapper<>(GapTransactionsResult.class);
+
+    private final ImporterProperties importerProperties;
+    private final boolean v2;
+
+    @Getter(lazy = true)
+    private final TransactionOperations transactionOperations = transactionOperations();
+
+    private long latestProcessedEndTimestamp;
+
+    protected RecordFileConsensusTimestampsRecalculateMigration(
+            final Environment environment,
+            final DBProperties dbProperties,
+            final ImporterProperties importerProperties,
+            final @Owner ObjectProvider<JdbcOperations> jdbcOperationsProvider) {
+        super(importerProperties.getMigration(), jdbcOperationsProvider, dbProperties.getSchema());
+        this.importerProperties = importerProperties;
+        this.v2 = environment.acceptsProfiles(Profiles.of("v2"));
+    }
+
+    private long getMinConsensusEndTimestamp() {
+        var override = migrationProperties.getParams().get(MIN_CONSENSUS_END_TIMESTAMP_KEY);
+        if (override != null) {
+            return Long.parseLong(override);
+        }
+        return getDefaultMinConsensusEndTimestampForNetwork();
+    }
+
+    private long getDefaultMinConsensusEndTimestampForNetwork() {
+        var network = importerProperties.getNetwork();
+        var minTimestamp = DEFAULT_MIN_CONSENSUS_END_TIMESTAMP_BY_NETWORK.get(network);
+        if (minTimestamp != null) {
+            return minTimestamp;
+        }
+
+        log.info("No minimum consensus_end configured for network {}; processing all record_file rows", network);
+        return 0L;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Recalculate record_file's consensus_start and consensus_end timestamps.";
+    }
+
+    @Override
+    protected MigrationVersion getMinimumVersion() {
+        return v2 ? MigrationVersion.fromVersion("2.27.0") : MigrationVersion.fromVersion("1.122.0");
+    }
+
+    @Override
+    protected boolean performSynchronousSteps() {
+        log.info("Create table processed_record_file_temp if not exists.");
+        getJdbcOperations().execute(CREATE_TEMPORARY_PROCESSED_RECORD_FILE_TABLE);
+        var minEnd = getMinConsensusEndTimestamp();
+        latestProcessedEndTimestamp = Objects.requireNonNull(getNamedParameterJdbcOperations()
+                .queryForObject(
+                        SELECT_LAST_PROCESSED_TIMESTAMP,
+                        new MapSqlParameterSource("minConsensusEndTimestamp", minEnd),
+                        Long.class));
+        return true;
+    }
+
+    @Override
+    protected Long getInitial() {
+        log.info(
+                "Starting record_file timestamp recalculation migration with initial consensus_end upper bound: {}.",
+                latestProcessedEndTimestamp);
+        return latestProcessedEndTimestamp;
+    }
+
+    @NonNull
+    @Override
+    protected Optional<Long> migratePartial(Long consensusEndTimestamp) {
+        final long minEnd = getMinConsensusEndTimestamp();
+        if (consensusEndTimestamp <= minEnd) {
+            log.info(
+                    "Record_file consensus offset migration passed floor consensus_end {}; dropping temporary table.",
+                    minEnd);
+            getJdbcOperations().execute(DROP_TEMPORARY_PROCESSED_RECORD_FILE_TABLE);
+            return Optional.empty();
+        }
+
+        final long consensusEndLowerBound = Math.max(consensusEndTimestamp - INTERVAL, minEnd);
+        final var sliceParams = new MapSqlParameterSource()
+                .addValue("consensusEndLowerBound", consensusEndLowerBound)
+                .addValue("consensusEndUpperBound", consensusEndTimestamp);
+
+        long updated = 0;
+        var jdbc = getNamedParameterJdbcOperations();
+        for (var block : jdbc.query(SELECT_RECORD_FILES_IN_SLICE, sliceParams, RECORD_FILE_SLICE_ROW_MAPPER)) {
+            final long missingTransactionsCount = block.count() - block.actualTransactionsCount();
+            final var beforeStartGapResult = computeStartTimestamp(block);
+            final var consensusStartCalculated = getTimestampOrNull(beforeStartGapResult);
+            final long transactionsCountBeforeStart = getTransactionsCountOrZero(beforeStartGapResult);
+            Long consensusEndCalculated = null;
+            if (missingTransactionsCount > transactionsCountBeforeStart) {
+                // There are some transactions after the block's consensus_end.
+                // Updating the consensus_end means we need to update the block's sidecars as well.
+                final var afterEndGapResult = computeEndTimestamp(block);
+                consensusEndCalculated = getTimestampOrNull(afterEndGapResult);
+                final long transactionsCountAfterEnd = getTransactionsCountOrZero(afterEndGapResult);
+
+                updateSidecarFiles(block, consensusEndCalculated);
+                logFailedRecalculationIfNeeded(block, transactionsCountBeforeStart, transactionsCountAfterEnd);
+            }
+
+            var updateParams = new MapSqlParameterSource()
+                    .addValue("consensusEnd", block.consensusEnd())
+                    .addValue("consensusStartCalculated", consensusStartCalculated)
+                    .addValue("consensusEndCalculated", consensusEndCalculated);
+            jdbc.update(UPDATE_RECORD_FILE_CALCULATED_TIMESTAMPS, updateParams);
+            updated++;
+        }
+
+        jdbc.update(
+                INSERT_SLICE_CHECKPOINT, new MapSqlParameterSource("consensusEndLowerBound", consensusEndLowerBound));
+
+        log.info(
+                "Updated {} record_file row(s) for consensus_end in ({}, {}].",
+                updated,
+                consensusEndLowerBound,
+                consensusEndTimestamp);
+
+        if (consensusEndLowerBound <= minEnd) {
+            log.info(
+                    "Record_file consensus timestamp recalculation migration complete; dropping temporary table processed_record_file_temp.");
+            getJdbcOperations().execute(DROP_TEMPORARY_PROCESSED_RECORD_FILE_TABLE);
+            return Optional.empty();
+        }
+        return Optional.of(consensusEndLowerBound);
+    }
+
+    private void updateSidecarFiles(RecordFileSlice block, Long consensusEndCalculated) {
+        var jdbc = getNamedParameterJdbcOperations();
+        var sidecarUpdateParams = new MapSqlParameterSource()
+                .addValue("consensusEnd", block.consensusEnd())
+                .addValue("consensusEndCalculated", consensusEndCalculated);
+        int updatedSidecars = jdbc.update(UPDATE_SIDECAR_FILES_WITH_CALCULATED_TIMESTAMPS, sidecarUpdateParams);
+        log.info(
+                "Updated {} sidecar_file row(s) for consensus_end {} with calculated timestamp {}.",
+                updatedSidecars,
+                block.consensusEnd(),
+                consensusEndCalculated);
+    }
+
+    @Nullable
+    private Long lookupPrevConsensusEnd(long consensusStart) {
+        return queryForObjectOrNull(
+                SELECT_PREV_CONSENSUS_END, new MapSqlParameterSource("consensusStart", consensusStart), Long.class);
+    }
+
+    @Nullable
+    private Long lookupNextConsensusStart(long consensusEnd) {
+        return queryForObjectOrNull(
+                SELECT_NEXT_CONSENSUS_START, new MapSqlParameterSource("consensusEnd", consensusEnd), Long.class);
+    }
+
+    @Nullable
+    private GapTransactionsResult computeStartTimestamp(RecordFileSlice block) {
+        var prevConsensusEnd = lookupPrevConsensusEnd(block.consensusStart());
+        var params = new MapSqlParameterSource()
+                .addValue("consensusStart", block.consensusStart())
+                .addValue("prevConsensusEnd", prevConsensusEnd != null ? prevConsensusEnd : 0L)
+                .addValue("missingTransactionsCount", block.count() - block.actualTransactionsCount());
+        return queryForObjectOrNull(SELECT_MIN_TX_BEFORE_START, params, GAP_TRANSACTIONS_RESULT_ROW_MAPPER);
+    }
+
+    @Nullable
+    private GapTransactionsResult computeEndTimestamp(RecordFileSlice block) {
+        var nextConsensusStart = lookupNextConsensusStart(block.consensusEnd());
+        var params = new MapSqlParameterSource()
+                .addValue("consensusEnd", block.consensusEnd())
+                .addValue("nextConsensusStart", nextConsensusStart != null ? nextConsensusStart : Long.MAX_VALUE)
+                .addValue("missingTransactionsCount", block.count() - block.actualTransactionsCount());
+        return queryForObjectOrNull(SELECT_MAX_TX_AFTER_END, params, GAP_TRANSACTIONS_RESULT_ROW_MAPPER);
+    }
+
+    private TransactionOperations transactionOperations() {
+        var jdbcTemplate = (JdbcTemplate) getJdbcOperations();
+        var transactionManager = new DataSourceTransactionManager(Objects.requireNonNull(jdbcTemplate.getDataSource()));
+        return new TransactionTemplate(transactionManager);
+    }
+
+    private void logFailedRecalculationIfNeeded(
+            RecordFileSlice block, long transactionsCountBeforeStart, long transactionsCountAfterEnd) {
+        if (transactionsCountBeforeStart + transactionsCountAfterEnd
+                != block.count() - block.actualTransactionsCount()) {
+            log.warn(
+                    "The transactions count before record_file start {} and after end {} does not match the missing"
+                            + "transactions count {} for record_file with consensus_end {}.",
+                    transactionsCountBeforeStart,
+                    transactionsCountAfterEnd,
+                    (block.count() - block.actualTransactionsCount()),
+                    block.consensusEnd());
+        }
+    }
+
+    private @Nullable Long getTimestampOrNull(GapTransactionsResult gapTransactionsResult) {
+        return gapTransactionsResult != null ? gapTransactionsResult.consensusTimestamp() : null;
+    }
+
+    private long getTransactionsCountOrZero(GapTransactionsResult gapTransactionsResult) {
+        return gapTransactionsResult != null ? gapTransactionsResult.transactionCount() : 0L;
+    }
+
+    private record RecordFileSlice(long consensusStart, long consensusEnd, long count, long actualTransactionsCount) {}
+
+    private record GapTransactionsResult(Long consensusTimestamp, long transactionCount) {}
+}

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -28,6 +28,7 @@ import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.domain.StreamFileData;
 import org.hiero.mirror.importer.domain.StreamFilename;
 import org.hiero.mirror.importer.exception.InvalidStreamFileException;
+import org.hiero.mirror.importer.util.Utility;
 import org.springframework.data.util.Version;
 
 @CustomLog
@@ -56,32 +57,23 @@ public final class ProtoRecordFileReader implements RecordFileReader {
                         endHashAlgorithm);
             }
 
-            var items = readItems(recordStreamFile);
-            final long consensusStart;
-            final long consensusEnd;
-            if (!items.isEmpty()) {
-                consensusStart = items.getFirst().getConsensusTimestamp();
-                consensusEnd = items.getLast().getConsensusTimestamp();
-            } else {
-                final long fileTimestamp = DomainUtils.convertToNanosMax(
-                        streamFileData.getStreamFilename().getInstant());
-                consensusStart = fileTimestamp;
-                consensusEnd = fileTimestamp;
-            }
-
+            final long fileTimestamp = DomainUtils.convertToNanosMax(
+                    streamFileData.getStreamFilename().getInstant());
+            final var readItemsResult = readItems(recordStreamFile, fileTimestamp);
             var bytes = streamFileData.getBytes();
-            int count = items.size();
+            int count = readItemsResult.items().size();
             var digestAlgorithm = getDigestAlgorithm(filename, startHashAlgorithm, endHashAlgorithm);
             var hapiProtoVersion = recordStreamFile.getHapiProtoVersion();
             var majorVersion = hapiProtoVersion.getMajor();
             var minorVersion = hapiProtoVersion.getMinor();
             var patchVersion = hapiProtoVersion.getPatch();
-            var sidecars = getSidecars(consensusEnd, recordStreamFile, streamFileData.getStreamFilename());
+            var sidecars =
+                    getSidecars(readItemsResult.consensusEnd(), recordStreamFile, streamFileData.getStreamFilename());
 
             return RecordFile.builder()
                     .bytes(bytes)
-                    .consensusStart(consensusStart)
-                    .consensusEnd(consensusEnd)
+                    .consensusStart(readItemsResult.consensusStart())
+                    .consensusEnd(readItemsResult.consensusEnd())
                     .count((long) count)
                     .digestAlgorithm(digestAlgorithm)
                     .fileHash(getFileHash(streamFileData.getDecompressedBytes()))
@@ -90,7 +82,7 @@ public final class ProtoRecordFileReader implements RecordFileReader {
                     .hapiVersionPatch(patchVersion)
                     .hash(DomainUtils.bytesToHex(DomainUtils.getHashBytes(endObjectRunningHash)))
                     .index(recordStreamFile.getBlockNumber())
-                    .items(items)
+                    .items(readItemsResult.items())
                     .loadStart(loadStart)
                     .metadataHash(getMetadataHash(recordStreamFile))
                     .name(filename)
@@ -169,10 +161,10 @@ public final class ProtoRecordFileReader implements RecordFileReader {
         }
     }
 
-    private List<RecordItem> readItems(final RecordStreamFile recordStreamFile) {
+    private ReadItemsResult readItems(final RecordStreamFile recordStreamFile, long fileTimestamp) {
         final int count = recordStreamFile.getRecordStreamItemsCount();
         if (count == 0) {
-            return Collections.emptyList();
+            return new ReadItemsResult(Collections.emptyList(), fileTimestamp, fileTimestamp);
         }
 
         var hapiProtoVersion = recordStreamFile.getHapiProtoVersion();
@@ -180,6 +172,8 @@ public final class ProtoRecordFileReader implements RecordFileReader {
                 new Version(hapiProtoVersion.getMajor(), hapiProtoVersion.getMinor(), hapiProtoVersion.getPatch());
         var items = new ArrayList<RecordItem>(count);
         RecordItem previousItem = null;
+        long minConsensusTimestamp = Long.MAX_VALUE;
+        long maxConsensusTimestamp = Long.MIN_VALUE;
         for (var recordStreamItem : recordStreamFile.getRecordStreamItemsList()) {
             var recordItem = RecordItem.builder()
                     .hapiVersion(hapiVersion)
@@ -190,9 +184,27 @@ public final class ProtoRecordFileReader implements RecordFileReader {
                     .build();
             items.add(recordItem);
             previousItem = recordItem;
+            minConsensusTimestamp = Math.min(minConsensusTimestamp, recordItem.getConsensusTimestamp());
+            maxConsensusTimestamp = Math.max(maxConsensusTimestamp, recordItem.getConsensusTimestamp());
         }
 
-        return items;
+        if (items.getFirst().getConsensusTimestamp() != minConsensusTimestamp) {
+            Utility.handleRecoverableError(
+                    "Transaction timestamps out of order. First transaction timestamp in record file: {}, "
+                            + "minimum timestamp in record file: {}.",
+                    items.getFirst().getConsensusTimestamp(),
+                    minConsensusTimestamp);
+        }
+
+        if (items.getLast().getConsensusTimestamp() != maxConsensusTimestamp) {
+            Utility.handleRecoverableError(
+                    "Transaction timestamps out of order. Last transaction timestamp in record file: {}, "
+                            + "maximum timestamp in record file: {}.",
+                    items.getLast().getConsensusTimestamp(),
+                    maxConsensusTimestamp);
+        }
+
+        return new ReadItemsResult(items, minConsensusTimestamp, maxConsensusTimestamp);
     }
 
     private RecordStreamFile readRecordStreamFile(String filename, InputStream inputStream) throws IOException {
@@ -206,4 +218,6 @@ public final class ProtoRecordFileReader implements RecordFileReader {
             return RecordStreamFile.parseFrom(dataInputStream);
         }
     }
+
+    private record ReadItemsResult(List<RecordItem> items, long consensusStart, long consensusEnd) {}
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/RecordFileConsensusTimestampsRecalculateMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/RecordFileConsensusTimestampsRecalculateMigrationTest.java
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hiero.mirror.importer.DisableRepeatableSqlMigration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcOperations;
+
+@RequiredArgsConstructor
+@Tag("migration")
+@DisablePartitionMaintenance
+@DisableRepeatableSqlMigration
+class RecordFileConsensusTimestampsRecalculateMigrationTest
+        extends AbstractAsyncJavaMigrationTest<RecordFileConsensusTimestampsRecalculateMigration> {
+
+    private static final String SELECT_LAST_CHECKSUM_SQL = """
+            select (
+              select checksum from flyway_schema_history
+              where description = ?
+              order by installed_rank desc
+              limit 1
+            )
+            """;
+
+    private static final long END_TIMESTAMP =
+            RecordFileConsensusTimestampsRecalculateMigration.TESTNET_MIN_CONSENSUS_END_TIMESTAMP;
+
+    @Getter
+    private final RecordFileConsensusTimestampsRecalculateMigration migration;
+
+    private final JdbcOperations jdbcOperations;
+
+    @BeforeEach
+    void configureMinConsensusEndTimestamp() {
+        migration
+                .migrationProperties
+                .getParams()
+                .put(
+                        RecordFileConsensusTimestampsRecalculateMigration.MIN_CONSENSUS_END_TIMESTAMP_KEY,
+                        String.valueOf(
+                                RecordFileConsensusTimestampsRecalculateMigration.TESTNET_MIN_CONSENSUS_END_TIMESTAMP));
+    }
+
+    @AfterEach
+    void cleanup() {
+        migration
+                .migrationProperties
+                .getParams()
+                .remove(RecordFileConsensusTimestampsRecalculateMigration.MIN_CONSENSUS_END_TIMESTAMP_KEY);
+        jdbcOperations.execute("drop table if exists processed_record_file_temp");
+    }
+
+    @Test
+    void migrationOnEmptyDb() {
+        runMigration();
+        waitForCompletionExtended();
+    }
+
+    @Test
+    void setsStartTimestampToEarliestGapTxBeforeConsensusStart() {
+        long prevStart = END_TIMESTAMP + 100L;
+        long prevEnd = END_TIMESTAMP + 1_000L;
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long earlierInGap = END_TIMESTAMP + 1_100L;
+        long latestInGap = END_TIMESTAMP + 1_900L;
+
+        insertRecordFile(prevStart, prevEnd, 0L);
+        insertRecordFile(currStart, currEnd, 2L);
+        insertTransaction(earlierInGap);
+        insertTransaction(latestInGap);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(startCalculated(currEnd)).isEqualTo(earlierInGap);
+        assertThat(endCalculated(currEnd)).isEqualTo(currEnd);
+        assertThat(startCalculated(prevEnd)).isEqualTo(prevStart);
+        assertThat(endCalculated(prevEnd)).isEqualTo(prevEnd);
+    }
+
+    @Test
+    void setsEndTimestampToLatestGapTxAfterConsensusEnd() {
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long nextStart = END_TIMESTAMP + 4_000L;
+        long nextEnd = END_TIMESTAMP + 5_000L;
+        long earliestAfterEnd = END_TIMESTAMP + 3_100L;
+        long latestAfterEnd = END_TIMESTAMP + 3_900L;
+
+        insertRecordFile(currStart, currEnd, 2L);
+        insertRecordFile(nextStart, nextEnd, 0L);
+        insertTransaction(earliestAfterEnd);
+        insertTransaction(latestAfterEnd);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(endCalculated(latestAfterEnd)).isEqualTo(latestAfterEnd);
+        assertThat(startCalculated(latestAfterEnd)).isEqualTo(currStart);
+        assertThat(startCalculated(nextEnd)).isEqualTo(nextStart);
+        assertThat(endCalculated(nextEnd)).isEqualTo(nextEnd);
+    }
+
+    @Test
+    void setsStartAndEndTimestampForGapTransactionsAroundCurrentBlock() {
+        long prevStart = END_TIMESTAMP + 100L;
+        long prevEnd = END_TIMESTAMP + 1_000L;
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long nextStart = END_TIMESTAMP + 4_000L;
+        long nextEnd = END_TIMESTAMP + 5_000L;
+        long earliestBeforeStart = END_TIMESTAMP + 1_100L;
+        long latestBeforeStart = END_TIMESTAMP + 1_900L;
+        long earliestAfterEnd = END_TIMESTAMP + 3_100L;
+        long latestAfterEnd = END_TIMESTAMP + 3_900L;
+
+        insertRecordFile(prevStart, prevEnd, 0L);
+        insertRecordFile(currStart, currEnd, 4L);
+        insertRecordFile(nextStart, nextEnd, 0L);
+        insertTransaction(earliestBeforeStart);
+        insertTransaction(latestBeforeStart);
+        insertTransaction(earliestAfterEnd);
+        insertTransaction(latestAfterEnd);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(startCalculated(latestAfterEnd)).isEqualTo(earliestBeforeStart);
+        assertThat(endCalculated(latestAfterEnd)).isEqualTo(latestAfterEnd);
+        assertThat(startCalculated(prevEnd)).isEqualTo(prevStart);
+        assertThat(endCalculated(prevEnd)).isEqualTo(prevEnd);
+        assertThat(startCalculated(nextEnd)).isEqualTo(nextStart);
+        assertThat(endCalculated(nextEnd)).isEqualTo(nextEnd);
+    }
+
+    @Test
+    void setsStartAndEndTimestampForGapTransactionsBeforeBlockStartAndAfterPrevEnd() {
+        long prevStart = END_TIMESTAMP + 100L;
+        long prevEnd = END_TIMESTAMP + 1_000L;
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long earliestPrevAfterEnd = END_TIMESTAMP + 1_100L;
+        long latestPrevAfterEnd = END_TIMESTAMP + 1_200L;
+        long earliestCurrBeforeStart = END_TIMESTAMP + 1_500L;
+        long latestCurrBeforeStart = END_TIMESTAMP + 1_900L;
+
+        insertRecordFile(prevStart, prevEnd, 2L);
+        insertRecordFile(currStart, currEnd, 2L);
+        insertTransaction(earliestPrevAfterEnd);
+        insertTransaction(latestPrevAfterEnd);
+        insertTransaction(earliestCurrBeforeStart);
+        insertTransaction(latestCurrBeforeStart);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(startCalculated(currEnd)).isEqualTo(earliestCurrBeforeStart);
+        assertThat(endCalculated(currEnd)).isEqualTo(currEnd);
+        assertThat(startCalculated(latestPrevAfterEnd)).isEqualTo(prevStart);
+        assertThat(endCalculated(latestPrevAfterEnd)).isEqualTo(latestPrevAfterEnd);
+    }
+
+    @Test
+    void updatesSidecarFilesWhenConsensusEndIsRecalculated() {
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long nextStart = END_TIMESTAMP + 4_000L;
+        long nextEnd = END_TIMESTAMP + 5_000L;
+        long currAfterEnd = END_TIMESTAMP + 3_900L;
+
+        insertRecordFile(currStart, currEnd, 1L);
+        insertRecordFile(nextStart, nextEnd, 0L);
+        insertSidecarFile(currEnd, 0);
+        insertTransaction(currAfterEnd);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(endCalculated(currAfterEnd)).isEqualTo(currAfterEnd);
+        assertThat(sidecarConsensusEnd(currAfterEnd, 0)).isEqualTo(currAfterEnd);
+    }
+
+    @Test
+    void doesNotUpdateSidecarFilesWhenOnlyConsensusStartChanges() {
+        long prevStart = END_TIMESTAMP + 100L;
+        long prevEnd = END_TIMESTAMP + 1_000L;
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long earlierInGap = END_TIMESTAMP + 1_100L;
+
+        insertRecordFile(prevStart, prevEnd, 0L);
+        insertRecordFile(currStart, currEnd, 1L);
+        insertSidecarFile(currEnd, 0);
+        insertSidecarFile(currEnd, 1);
+        insertTransaction(earlierInGap);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(startCalculated(currEnd)).isEqualTo(earlierInGap);
+        assertThat(endCalculated(currEnd)).isEqualTo(currEnd);
+        assertThat(sidecarConsensusEnd(currEnd, 0)).isEqualTo(currEnd);
+        assertThat(sidecarConsensusEnd(currEnd, 1)).isEqualTo(currEnd);
+    }
+
+    @Test
+    void updatesAllSidecarFilesForRecordFileWhenConsensusEndIsRecalculated() {
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long nextStart = END_TIMESTAMP + 4_000L;
+        long nextEnd = END_TIMESTAMP + 5_000L;
+        long earliestAfterEnd = END_TIMESTAMP + 3_100L;
+        long latestAfterEnd = END_TIMESTAMP + 3_900L;
+
+        insertRecordFile(currStart, currEnd, 2L);
+        insertRecordFile(nextStart, nextEnd, 0L);
+        insertSidecarFile(currEnd, 0);
+        insertSidecarFile(currEnd, 1);
+        insertTransaction(earliestAfterEnd);
+        insertTransaction(latestAfterEnd);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(endCalculated(latestAfterEnd)).isEqualTo(latestAfterEnd);
+        assertThat(sidecarConsensusEnd(latestAfterEnd, 0)).isEqualTo(latestAfterEnd);
+        assertThat(sidecarConsensusEnd(latestAfterEnd, 1)).isEqualTo(latestAfterEnd);
+    }
+
+    @Test
+    void doesNotUpdateSidecarFilesForOtherRecordFiles() {
+        long currStart = END_TIMESTAMP + 2_000L;
+        long currEnd = END_TIMESTAMP + 3_000L;
+        long nextStart = END_TIMESTAMP + 4_000L;
+        long nextEnd = END_TIMESTAMP + 5_000L;
+        long latestCurrAfterEnd = END_TIMESTAMP + 3_900L;
+
+        insertRecordFile(currStart, currEnd, 1L);
+        insertRecordFile(nextStart, nextEnd, 0L);
+        insertSidecarFile(currEnd, 0);
+        insertSidecarFile(nextEnd, 0);
+        insertTransaction(latestCurrAfterEnd);
+
+        runMigration();
+        waitForCompletionExtended();
+
+        assertThat(sidecarConsensusEnd(latestCurrAfterEnd, 0)).isEqualTo(latestCurrAfterEnd);
+        assertThat(sidecarConsensusEnd(nextEnd, 0)).isEqualTo(nextEnd);
+    }
+
+    private void waitForCompletionExtended() {
+        await().atMost(Duration.ofMinutes(2))
+                .pollDelay(Duration.ofMillis(100))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> assertThat(isMigrationCompleted()).isTrue());
+    }
+
+    private boolean isMigrationCompleted() {
+        var actual = jdbcOperations.queryForObject(SELECT_LAST_CHECKSUM_SQL, Integer.class, migration.getDescription());
+        return Objects.equals(actual, migration.getSuccessChecksum());
+    }
+
+    private Long startCalculated(long consensusEnd) {
+        return jdbcOperations.queryForObject(
+                "select consensus_start from record_file where consensus_end = ?", Long.class, consensusEnd);
+    }
+
+    private Long endCalculated(long consensusEnd) {
+        return jdbcOperations.queryForObject(
+                "select consensus_end from record_file where consensus_end = ?", Long.class, consensusEnd);
+    }
+
+    private Long sidecarConsensusEnd(long consensusEnd, int id) {
+        return jdbcOperations.queryForObject(
+                "select consensus_end from sidecar_file where consensus_end = ? and id = ?",
+                Long.class,
+                consensusEnd,
+                id);
+    }
+
+    private void insertRecordFile(long consensusStart, long consensusEnd, long count) {
+        jdbcOperations.update(
+                """
+                        insert into record_file (
+                          consensus_start, consensus_end, count, digest_algorithm, file_hash, hash, index, load_start,
+                          load_end, name, prev_hash, version
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                consensusStart,
+                consensusEnd,
+                count,
+                0,
+                Long.toHexString(consensusEnd),
+                Long.toHexString(consensusEnd),
+                consensusEnd,
+                consensusEnd,
+                consensusEnd,
+                consensusEnd + ".rcd",
+                Long.toHexString(consensusStart),
+                6);
+    }
+
+    private void insertTransaction(long consensusTimestamp) {
+        jdbcOperations.update("""
+                        insert into transaction (
+                          consensus_timestamp, nonce, payer_account_id, result, scheduled, type, valid_start_ns
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?)
+                        """, consensusTimestamp, 0, 100, 22, false, 14, consensusTimestamp);
+    }
+
+    private void insertSidecarFile(long consensusEnd, int id) {
+        jdbcOperations.update("""
+                        insert into sidecar_file (
+                          consensus_end, hash_algorithm, hash, id, name, size, types
+                        )
+                        values (?, ?, ?, ?, ?, ?, ?::int[])
+                        """, consensusEnd, 0, new byte[48], id, consensusEnd + "_" + id + ".rcd.gz", 256, "{1}");
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
@@ -17,6 +17,7 @@ import com.hedera.services.stream.proto.RecordStreamItem;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.SemanticVersion;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
@@ -90,6 +91,68 @@ final class ProtoRecordFileReaderTest extends AbstractRecordFileReaderTest {
         var recordFile = reader.read(streamFileData);
 
         assertThat(recordFile.getDigestAlgorithm()).isEqualTo(DigestAlgorithm.SHA_384);
+    }
+
+    @Test
+    void verifyRecordFileStartAndEndTimestampsOnOutOfOrderItems() {
+        final long earliest = 1_000_000_000L;
+        final long middle = 2_000_000_000L;
+        final long latest = 3_000_000_000L;
+        var bytes = gzip(ProtoRecordStreamFile.of(b -> {
+            b.clearRecordStreamItems();
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(latest));
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(earliest));
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(middle));
+            return b;
+        }));
+
+        var recordFile = new ProtoRecordFileReader().read(StreamFileData.from(FILENAME, bytes));
+
+        assertThat(recordFile)
+                .returns(earliest, RecordFile::getConsensusStart)
+                .returns(latest, RecordFile::getConsensusEnd)
+                .returns(3L, RecordFile::getCount);
+    }
+
+    @Test
+    void verifyRecordFileStartAndEndTimestampsOrderedItems() {
+        final long earliest = 1_000_000_000L;
+        final long middle = 2_000_000_000L;
+        final long latest = 3_000_000_000L;
+        var bytes = gzip(ProtoRecordStreamFile.of(b -> {
+            b.clearRecordStreamItems();
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(earliest));
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(middle));
+            b.addRecordStreamItems(buildRecordStreamItemWithTimestamp(latest));
+            return b;
+        }));
+
+        var recordFile = new ProtoRecordFileReader().read(StreamFileData.from(FILENAME, bytes));
+
+        assertThat(recordFile)
+                .returns(earliest, RecordFile::getConsensusStart)
+                .returns(latest, RecordFile::getConsensusEnd)
+                .returns(3L, RecordFile::getCount);
+    }
+
+    private RecordStreamItem buildRecordStreamItemWithTimestamp(long timestamp) {
+        return RecordStreamItem.newBuilder()
+                .setTransaction(Transaction.newBuilder()
+                        .setSignedTransactionBytes(SignedTransaction.newBuilder()
+                                .setBodyBytes(TransactionBody.newBuilder()
+                                        .setCryptoTransfer(CryptoTransferTransactionBody.newBuilder()
+                                                .build())
+                                        .build()
+                                        .toByteString())
+                                .build()
+                                .toByteString()))
+                .setRecord(TransactionRecord.newBuilder()
+                        .setConsensusTimestamp(Timestamp.newBuilder()
+                                .setSeconds(timestamp / 1_000_000_000)
+                                .setNanos((int) (timestamp % 1_000_000_000))
+                                .build())
+                        .build())
+                .build();
     }
 
     private static class ProtoRecordStreamFile {


### PR DESCRIPTION
**Description**:

An async java migration is created that updates two columns in the `record_file` table - `consensus_start` and `consensus_end`. Is some rare edge cases in the past there were transactions with a `consensus_timestamp` that is not in the range of any block but the `count`, `logs_bloom`, `gas_used` for their respective block were calculated correctly. 

The `/blocks/*` REST endpoints will now return a block's `consensus_start` and `consensus_end` that are the updated timestamps. This way all of the transactions that are queried between the timestamps of these blocks will now get returned.

**Related issue(s)**:

Fixes #13135

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
