### PR TITLE
Avoid deploy workflow getting triggered

### DIFF
--- a/.github/workflows/trigger-staging-deploy.yml
+++ b/.github/workflows/trigger-staging-deploy.yml
@@ -2,11 +2,12 @@
 
 name: Trigger Staging on Deploy Change
 
-#on:
-#  push:
-#    branches: [deploy]
-#    paths:
-#      - clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+on:
+  push:
+    branches: [deploy]
+    paths:
+      - do-not-exist/nothing.yaml
+      # - clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
 
 permissions:
   id-token: write


### PR DESCRIPTION
**Description**:

This PR properly skips the workflow by setting a non-existent path in the trigger.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

The workflow was tried by GitHub a lot of times on deploy PRs and commits merged to the `deploy` branch, though it didn't really do anything. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
