### PR TITLE
Cutover prod envs to grafana-cloud

### DIFF
--- a/clusters/mainnet-eu/common/helmrelease.yaml
+++ b/clusters/mainnet-eu/common/helmrelease.yaml
@@ -42,6 +42,8 @@ spec:
     minio:
       enabled: true
     prometheus:
+      alertmanager:
+        enabled: false
       defaultRules:
         disabled:
           KubeHpaMaxedOut: true
@@ -49,6 +51,7 @@ spec:
         prometheusSpec:
           externalLabels:
             cluster: mainnet-eu
+            env_category: production
           priorityClassName: high
           remoteWrite:
             - basicAuth:

--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -42,6 +42,8 @@ spec:
           limits:
             memory: 1Gi
     prometheus:
+      alertmanager:
+        enabled: false
       prometheus:
         defaultRules:
           disabled:
@@ -49,6 +51,7 @@ spec:
         prometheusSpec:
           externalLabels:
             cluster: mainnet-na
+            env_category: production
           priorityClassName: high
           remoteWrite:
             - basicAuth:

--- a/clusters/previewnet/common/helmrelease.yaml
+++ b/clusters/previewnet/common/helmrelease.yaml
@@ -38,10 +38,13 @@ spec:
           ruler:
             external_url: https://mirrornode.grafana.net
     prometheus:
+      alertmanager:
+        enabled: false
       prometheus:
         prometheusSpec:
           externalLabels:
             cluster: previewnet
+            env_category: production
           remoteWrite:
             - basicAuth:
                 password:

--- a/clusters/testnet-eu/common/helmrelease.yaml
+++ b/clusters/testnet-eu/common/helmrelease.yaml
@@ -38,10 +38,13 @@ spec:
     minio:
       enabled: true
     prometheus:
+      alertmanager:
+        enabled: false
       prometheus:
         prometheusSpec:
           externalLabels:
             cluster: testnet-eu
+            env_category: production
           remoteWrite:
             - basicAuth:
                 password:

--- a/clusters/testnet-na/common/helmrelease.yaml
+++ b/clusters/testnet-na/common/helmrelease.yaml
@@ -36,10 +36,13 @@ spec:
           ruler:
             external_url: https://mirrornode.grafana.net
     prometheus:
+      alertmanager:
+        enabled: false
       prometheus:
         prometheusSpec:
           externalLabels:
             cluster: testnet-na
+            env_category: production
           remoteWrite:
             - basicAuth:
                 password:


### PR DESCRIPTION
**Description**:
- Make the cutover of `prod` envs' alerts to Grafana Cloud:
  - Add `env_category: production` to allow GC matchers to work and fire alerts.
  - Disable local clusters' `alertmanager` to prevent them from firing alerts.

**Related issue(s)**:

- #13446 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- Tested by making this change in the five `non-prod` envs and letting them run since May 26th (today: June 3rd) to make sure alerts are reaching the appropriate Slack channel.
