### PR TITLE
Register nested classes for `RecordFileConsensusTimestampsRecalculateMigration`

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/config/RuntimeHintsConfiguration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/config/RuntimeHintsConfiguration.java
@@ -47,6 +47,8 @@ final class RuntimeHintsConfiguration {
                     "org.hiero.mirror.importer.migration.FixAirdropTokenAssociationMigration$NftTransfer",
                     "org.hiero.mirror.importer.migration.FixAirdropTokenAssociationMigration$TokenBalanceChange",
                     "org.hiero.mirror.importer.migration.FixNodeTransactionsMigration$NodeTransaction",
+                    "org.hiero.mirror.importer.migration.RecordFileConsensusTimestampsRecalculateMigration$GapTransactionsResult",
+                    "org.hiero.mirror.importer.migration.RecordFileConsensusTimestampsRecalculateMigration$RecordFileSlice",
                     "org.hiero.mirror.importer.migration.SyntheticCryptoTransferApprovalMigration$TokenBalanceChange",
                     "org.hiero.mirror.importer.config.MetricsConfiguration$TableMetrics",
                     "org.hiero.mirror.importer.config.MetricsConfiguration$TableAttributes");


### PR DESCRIPTION
**Description**:
When building native images with GraalVM, we need to register in hints configuration the inner classes used in the newly added migration `RecordFileConsensusTimestampsRecalculateMigration`.

Fixes #13655 