### PR TITLE
Upgrade micrometer to 1.17.0 (0.156)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ extra.apply {
     set("grpcVersion", "1.81.0")
     set("jooq.version", "3.21.4") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
+    set("micrometer.version", "1.17.0") // Temporary until next Spring Boot
     set("netty.version", "4.2.13.Final") // Temporary until next Spring Boot
     set("nodeJsVersion", "24.15.0")
     set("postgresql.version", "42.7.11") // Temporary until next Spring Boot


### PR DESCRIPTION
**Description**:

This PR cherry-picks the change to `release/0.156`:

- upgrade micrometer to 1.17.0

**Related issue(s)**:

Fixes #13653 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
