### PR TITLE
Bump Go from 1.26.2 to 1.26.4

### DIFF
--- a/pinger/Dockerfile
+++ b/pinger/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # Builder (multi-arch)
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.23 AS builder
 
 WORKDIR /src
 

--- a/pinger/build.gradle.kts
+++ b/pinger/build.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 
 go {
     pkg = "./..."
-    version = "1.26.2"
+    version = "1.26.4"
 }

--- a/rosetta/Dockerfile
+++ b/rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=development

--- a/rosetta/build.gradle.kts
+++ b/rosetta/build.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 
 go {
     pkg = "./app/..."
-    version = "1.26.2"
+    version = "1.26.4"
 }


### PR DESCRIPTION
**Description**:

Bump Go from 1.26.2 to 1.26.4

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
