### PR TITLE
Exclude vulnerable plugin dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,9 +38,16 @@ dependencies {
     implementation("org.web3j:web3j-gradle-plugin:5.0.2")
 }
 
+// These transitive dependencies are vulnerable and not used
+configurations.all {
+    exclude(group = "io.netty")
+    exclude(group = "io.vertx")
+}
+
 val gitHook =
     tasks.register<Exec>("gitHook") {
         commandLine("git", "config", "core.hookspath", "buildSrc/src/main/resources/hooks")
+        description = "Adds our git hook that runs Spotless apply"
     }
 
 tasks.processResources { dependsOn(gitHook) }

--- a/common/src/main/java/org/hiero/mirror/common/util/RuntimeHintsHelper.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/RuntimeHintsHelper.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
@@ -28,7 +29,7 @@ public final class RuntimeHintsHelper {
         MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.ACCESS_DECLARED_FIELDS
     };
 
-    private static final MemberCategory[] DEFAULT_CATEGORIES = {
+    public static final MemberCategory[] DEFAULT_CATEGORIES = {
         MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
         MemberCategory.INVOKE_DECLARED_METHODS,
         MemberCategory.ACCESS_DECLARED_FIELDS,
@@ -70,7 +71,7 @@ public final class RuntimeHintsHelper {
         registerAnnotatedPackage(hints, loader, basePackage, annotationType, DEFAULT_CATEGORIES);
     }
 
-    public static void registerAnnotatedPackage(
+    private static void registerAnnotatedPackage(
             RuntimeHints hints,
             ClassLoader loader,
             String basePackage,
@@ -105,9 +106,9 @@ public final class RuntimeHintsHelper {
         hints.reflection().registerType(type, memberCategories);
     }
 
-    private static void registerPackageMatching(
+    public static void registerPackageMatching(
             RuntimeHints hints,
-            ClassLoader loader,
+            @Nullable ClassLoader loader,
             String basePackage,
             TypeFilter includeFilter,
             MemberCategory... memberCategories) {
@@ -125,7 +126,7 @@ public final class RuntimeHintsHelper {
     }
 
     private static void registerLoadedClass(
-            RuntimeHints hints, ClassLoader loader, String className, MemberCategory... memberCategories) {
+            RuntimeHints hints, @Nullable ClassLoader loader, String className, MemberCategory... memberCategories) {
         try {
             final var type = Class.forName(className, false, loader);
             hints.reflection().registerType(type, memberCategories);

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ version=0.157.0-SNAPSHOT
 # Gradle settings
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
+org.gradle.configuration-cache.parallel=false # Disable due to limitation in graalvm plugin
 org.gradle.configuration-cache.problems=warn
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseParallelGC -Dfile.encoding=UTF-8

--- a/importer/src/main/java/org/hiero/mirror/importer/config/RuntimeHintsConfiguration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/config/RuntimeHintsConfiguration.java
@@ -3,7 +3,9 @@
 package org.hiero.mirror.importer.config;
 
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.CONSTRUCTORS_AND_METHODS;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.DEFAULT_CATEGORIES;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerPackage;
+import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerPackageMatching;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerReflectionTypes;
 import static org.hiero.mirror.common.util.RuntimeHintsHelper.registerResourcePatterns;
 
@@ -23,6 +25,8 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.util.ClassUtils;
 
 @Configuration(proxyBeanMethods = false)
 @ImportRuntimeHints(RuntimeHintsConfiguration.CustomRuntimeHints.class)
@@ -35,21 +39,10 @@ final class RuntimeHintsConfiguration {
             final var loader = classLoader != null ? classLoader : getClass().getClassLoader();
 
             registerReflectionTypes(hints, EntityProperties.PersistProperties.class.getName());
-
+            registerMigrationClasses(hints, classLoader);
             registerReflectionTypes(
                     hints,
                     CONSTRUCTORS_AND_METHODS,
-                    "org.hiero.mirror.importer.migration.AbstractTimestampInfoMigration$TimestampInfo",
-                    "org.hiero.mirror.importer.migration.ContractLogIndexMigration$RecordFileSlice",
-                    "org.hiero.mirror.importer.migration.BackfillEthereumTransactionHashMigration$MigrationEthereumTransaction",
-                    "org.hiero.mirror.importer.migration.ContractResultMigration$MigrationContractResult",
-                    "org.hiero.mirror.importer.migration.FixAirdropTokenAssociationMigration$ClaimedAirdrop",
-                    "org.hiero.mirror.importer.migration.FixAirdropTokenAssociationMigration$NftTransfer",
-                    "org.hiero.mirror.importer.migration.FixAirdropTokenAssociationMigration$TokenBalanceChange",
-                    "org.hiero.mirror.importer.migration.FixNodeTransactionsMigration$NodeTransaction",
-                    "org.hiero.mirror.importer.migration.RecordFileConsensusTimestampsRecalculateMigration$GapTransactionsResult",
-                    "org.hiero.mirror.importer.migration.RecordFileConsensusTimestampsRecalculateMigration$RecordFileSlice",
-                    "org.hiero.mirror.importer.migration.SyntheticCryptoTransferApprovalMigration$TokenBalanceChange",
                     "org.hiero.mirror.importer.config.MetricsConfiguration$TableMetrics",
                     "org.hiero.mirror.importer.config.MetricsConfiguration$TableAttributes");
 
@@ -71,6 +64,20 @@ final class RuntimeHintsConfiguration {
                     "linux/amd64/libzstd-jni-*.so",
                     "win/aarch64/libzstd-jni-*.dll",
                     "win/amd64/libzstd-jni-*.dll");
+        }
+
+        // Register migration member classes created reflectively via RowMapper
+        private void registerMigrationClasses(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+            TypeFilter memberClassFilter = (r, _) -> {
+                try {
+                    final var clazz = ClassUtils.forName(r.getClassMetadata().getClassName(), classLoader);
+                    return clazz.isMemberClass() && !clazz.isEnum() && !clazz.isInterface();
+                } catch (Exception e) {
+                    return false;
+                }
+            };
+            registerPackageMatching(
+                    hints, classLoader, "org.hiero.mirror.importer.migration", memberClassFilter, DEFAULT_CATEGORIES);
         }
 
         private void registerVelocityHints(RuntimeHints hints, ClassLoader loader) {

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -205,10 +205,10 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
                     var updateParams = new MapSqlParameterSource()
                             .addValue("consensus_timestamp", transfer.consensusTimestamp)
                             .addValue("payer_account_id", transfer.payerAccountId);
-                    if (transfer.transferType == TRANSFER_TYPE.CRYPTO_TRANSFER) {
+                    if (transfer.transferType == TransferType.CRYPTO_TRANSFER) {
                         updateSql = UPDATE_CRYPTO_TRANSFER_SQL;
                         updateParams.addValue("sender", transfer.sender);
-                    } else if (transfer.transferType == TRANSFER_TYPE.NFT_TRANSFER) {
+                    } else if (transfer.transferType == TransferType.NFT_TRANSFER) {
                         updateSql = UPDATE_NFT_TRANSFER_SQL;
                         updateParams.addValue("index", transfer.index);
                     } else {
@@ -293,6 +293,12 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         this.executed.set(executed);
     }
 
+    private enum TransferType {
+        CRYPTO_TRANSFER,
+        NFT_TRANSFER,
+        TOKEN_TRANSFER
+    }
+
     @Data
     static class ApprovalTransfer {
         private long consensusTimestamp;
@@ -302,12 +308,6 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         private long payerAccountId;
         private long sender;
         private Long tokenId;
-        private TRANSFER_TYPE transferType;
-    }
-
-    private enum TRANSFER_TYPE {
-        CRYPTO_TRANSFER,
-        NFT_TRANSFER,
-        TOKEN_TRANSFER
+        private TransferType transferType;
     }
 }

--- a/monitor/src/main/java/org/hiero/mirror/monitor/MonitorProperties.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/MonitorProperties.java
@@ -35,8 +35,7 @@ public class MonitorProperties {
     private HederaNetwork network = HederaNetwork.TESTNET;
 
     @NotNull
-    @Valid
-    private Set<NodeProperties> nodes = new LinkedHashSet<>();
+    private Set<@Valid NodeProperties> nodes = new LinkedHashSet<>();
 
     @NotNull
     @Valid

--- a/monitor/src/main/java/org/hiero/mirror/monitor/publish/PublishProperties.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/publish/PublishProperties.java
@@ -34,8 +34,7 @@ public class PublishProperties {
     private Duration nodeMaxBackoff = Duration.ofMinutes(1L);
 
     @NotNull
-    @Valid
-    private Map<String, PublishScenarioProperties> scenarios = new LinkedHashMap<>();
+    private Map<String, @Valid PublishScenarioProperties> scenarios = new LinkedHashMap<>();
 
     @DurationMin(seconds = 1L)
     @NotNull

--- a/monitor/src/main/java/org/hiero/mirror/monitor/subscribe/SubscribeProperties.java
+++ b/monitor/src/main/java/org/hiero/mirror/monitor/subscribe/SubscribeProperties.java
@@ -32,12 +32,10 @@ public class SubscribeProperties {
     private boolean enabled = true;
 
     @NotNull
-    @Valid
-    private Map<String, GrpcSubscriberProperties> grpc = new LinkedHashMap<>();
+    private Map<String, @Valid GrpcSubscriberProperties> grpc = new LinkedHashMap<>();
 
     @NotNull
-    @Valid
-    private Map<String, RestSubscriberProperties> rest = new LinkedHashMap<>();
+    private Map<String, @Valid RestSubscriberProperties> rest = new LinkedHashMap<>();
 
     @DurationMin(seconds = 1L)
     @NotNull

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,8 +75,7 @@ public final class AcceptanceTestProperties {
     private HederaNetwork network = HederaNetwork.TESTNET;
 
     @NotNull
-    @Valid
-    private Set<NodeProperties> nodes = new LinkedHashSet<>();
+    private Set<@Valid NodeProperties> nodes = new LinkedHashSet<>();
 
     @NotNull
     @DecimalMax("1000000")


### PR DESCRIPTION
**Description**:

* Disable parallel configuration cache since it breaks `./gradlew build`
* Exclude vulnerable netty and vertx plugin dependencies
* Fix remaining `@Valid` warnings on collection types
* Register migration member classes runtime hints dynamically

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
