### PR TITLE
Add receipts root to record and block file

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/BlockFile.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/BlockFile.java
@@ -82,6 +82,9 @@ public final class BlockFile implements StreamFile<BlockTransaction> {
 
     private byte[] rawPreviousHash;
 
+    @ToString.Exclude
+    private byte[] receiptsRoot;
+
     private RecordFile recordFile;
 
     private Long roundEnd;

--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordFile.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordFile.java
@@ -109,6 +109,9 @@ public class RecordFile implements StreamFile<RecordItem> {
     @ToString.Exclude
     private byte[] previousWrappedRecordBlockHash;
 
+    @ToString.Exclude
+    private byte[] receiptsRoot;
+
     private Long roundEnd;
 
     private Long roundStart;

--- a/common/src/test/java/org/hiero/mirror/common/domain/DomainBuilder.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/DomainBuilder.java
@@ -896,6 +896,7 @@ public class DomainBuilder {
                 .loadStart(now.toEpochMilli())
                 .name(instantString + ".rcd.gz")
                 .previousHash(hash(96))
+                .receiptsRoot(bytes(32))
                 .roundEnd(round)
                 .roundStart(round)
                 .sidecarCount(1)

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/BlockFileTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/BlockFileTest.java
@@ -43,4 +43,12 @@ final class BlockFileTest {
         blockFile = BlockFile.builder().onNewRound(1L).onNewRound(2L).build();
         assertThat(blockFile).returns(1L, BlockFile::getRoundStart).returns(2L, BlockFile::getRoundEnd);
     }
+
+    @Test
+    void receiptsRoot() {
+        var receiptsRoot = new byte[] {1, 2, 3, 4};
+        var blockFile = BlockFile.builder().receiptsRoot(receiptsRoot).build();
+        assertThat(blockFile.getReceiptsRoot()).isEqualTo(receiptsRoot);
+        assertThat(blockFile.toString()).doesNotContain("receiptsRoot");
+    }
 }

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/RecordFileTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/RecordFileTest.java
@@ -40,4 +40,12 @@ class RecordFileTest {
         assertThat(RecordFile.EMPTY.isEmpty()).isTrue();
         assertThat(new RecordFile().isEmpty()).isFalse();
     }
+
+    @Test
+    void testReceiptsRoot() {
+        final var receiptsRoot = new byte[] {1, 2, 3, 4};
+        final var recordFile = RecordFile.builder().receiptsRoot(receiptsRoot).build();
+        assertThat(recordFile.getReceiptsRoot()).isEqualTo(receiptsRoot);
+        assertThat(recordFile.toString()).doesNotContain("receiptsRoot");
+    }
 }

--- a/importer/src/main/resources/db/migration/v1/V1.125.0__add_receipts_root.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.125.0__add_receipts_root.sql
@@ -1,0 +1,2 @@
+alter table if exists record_file
+  add column if not exists receipts_root bytea null;

--- a/importer/src/main/resources/db/migration/v2/V2.30.0__add_receipts_root.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.30.0__add_receipts_root.sql
@@ -1,0 +1,2 @@
+alter table if exists record_file
+  add column if not exists receipts_root bytea null;

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderTest.java
@@ -145,6 +145,7 @@ public final class BlockStreamReaderTest {
                             "initialState",
                             "items",
                             "previousWrappedRecordBlockHash",
+                            "receiptsRoot",
                             "wrappedRecordBlockHash")
                     .build();
 

--- a/importer/src/test/java/org/hiero/mirror/importer/repository/RecordFileRepositoryTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/repository/RecordFileRepositoryTest.java
@@ -132,6 +132,16 @@ final class RecordFileRepositoryTest extends ImporterIntegrationTest {
     }
 
     @Test
+    void persistReceiptsRoot() {
+        final var recordFile = domainBuilder.recordFile().persist();
+
+        assertThat(recordFileRepository.findById(recordFile.getConsensusEnd()))
+                .get()
+                .extracting(RecordFile::getReceiptsRoot)
+                .isEqualTo(recordFile.getReceiptsRoot());
+    }
+
+    @Test
     void prune() {
         domainBuilder.recordFile().persist();
         var recordFile2 = domainBuilder.recordFile().persist();


### PR DESCRIPTION
**Description**:
Add receipts root to record and block file so the calculation can be moved from relay to the mirror node.

**Related issue(s)**:

Fixes #13632 


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
