### PR TITLE
Disable syntheticContractResults for 0.157

### DIFF
--- a/rest/__tests__/config.test.js
+++ b/rest/__tests__/config.test.js
@@ -224,7 +224,7 @@ describe('Override query config', () => {
       maxValidStartTimestampDrift: '1s',
       maxValidStartTimestampDriftNs: 1000000000n,
       strictTimestampParam: true,
-      syntheticContractResults: true,
+      syntheticContractResults: false,
       topicMessageLookup: false,
       transactions: {
         precedingTransactionTypes: [11, 15],

--- a/rest/__tests__/controllers/contractController.test.js
+++ b/rest/__tests__/controllers/contractController.test.js
@@ -444,19 +444,8 @@ describe('extractContractResultsByIdQuery', () => {
     },
   ];
 
-  // Global endpoint cases (no contractId → includeSynthetic: true)
+  // Global endpoint cases (no contractId, no from filter → includeSynthetic mirrors the flag)
   const globalSpecs = [
-    {
-      name: 'global endpoint - no contractId → includeSynthetic true',
-      input: {filter: [], contractId: undefined},
-      expected: {
-        conditions: ['cr.transaction_nonce = 0'],
-        includeSynthetic: true,
-        params: [],
-        order: constants.orderFilterValues.DESC,
-        limit: defaultLimit,
-      },
-    },
     {
       name: 'global endpoint - from filter disables includeSynthetic',
       input: {
@@ -481,13 +470,31 @@ describe('extractContractResultsByIdQuery', () => {
     });
   });
 
+  test('global endpoint - syntheticContractResults flag enabled, no contractId → includeSynthetic true', async () => {
+    const originalValue = config.query.syntheticContractResults;
+    config.query.syntheticContractResults = true;
+    try {
+      const result = await contracts.extractContractResultsByIdQuery([], undefined);
+      expect(result).toEqual({
+        conditions: ['cr.transaction_nonce = 0'],
+        includeSynthetic: true,
+        params: [],
+        order: constants.orderFilterValues.DESC,
+        limit: defaultLimit,
+      });
+    } finally {
+      config.query.syntheticContractResults = originalValue;
+    }
+  });
+
   test('global endpoint - syntheticContractResults flag disabled → includeSynthetic false', async () => {
+    const originalValue = config.query.syntheticContractResults;
     config.query.syntheticContractResults = false;
     try {
       const result = await contracts.extractContractResultsByIdQuery([], undefined);
       expect(result.includeSynthetic).toBe(false);
     } finally {
-      config.query.syntheticContractResults = true;
+      config.query.syntheticContractResults = originalValue;
     }
   });
 });

--- a/rest/config/application.yml
+++ b/rest/config/application.yml
@@ -67,7 +67,7 @@ hiero:
         maxTransactionsTimestampRange: 60d
         maxValidStartTimestampDrift: 1s
         strictTimestampParam: true
-        syntheticContractResults: true
+        syntheticContractResults: false
         topicMessageLookup: false
         transactions:
           precedingTransactionTypes:


### PR DESCRIPTION
**Description**:
Disable `syntheticContractResults` for 0.157 because of the regression. We will reenable after refactoring.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
