### PR TITLE
Fix null from and make contract results main and synthetic query parallel

### DIFF
--- a/rest/__tests__/service/contractService.test.js
+++ b/rest/__tests__/service/contractService.test.js
@@ -203,9 +203,8 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
 });
 
 describe('ContractService.getSyntheticContractResultsQuery tests', () => {
-  test('No prior results, no extra conditions', () => {
+  test('No extra conditions', () => {
     const [query, params] = ContractService.getSyntheticContractResultsQuery(
-      [],
       ['cr.transaction_nonce = 0'],
       [],
       'desc',
@@ -233,7 +232,7 @@ describe('ContractService.getSyntheticContractResultsQuery tests', () => {
         null::bigint[] as created_contract_ids, null::text as error_message,
         null::bytea as failed_initcode, '\\x'::bytea as function_parameters,
         null::bytea as function_result, null::bigint as gas_consumed, 0::bigint as gas_limit,
-        null::bigint as gas_used, synth_raw.payer_account_id, null::bigint as sender_id,
+        null::bigint as gas_used, synth_raw.payer_account_id, synth_raw.payer_account_id as sender_id,
         synth_raw.transaction_hash, synth_raw.transaction_index, 0::integer as transaction_nonce,
         22::smallint as transaction_result,
         coalesce((select evm_address from contract_evm_address where id = synth_raw.contract_id), '') as evm_address
@@ -244,9 +243,8 @@ describe('ContractService.getSyntheticContractResultsQuery tests', () => {
     expect(params).toEqual([10]);
   });
 
-  test('No prior results, with timestamp conditions', () => {
+  test('With timestamp conditions', () => {
     const [query, params] = ContractService.getSyntheticContractResultsQuery(
-      [],
       ['cr.transaction_nonce = 0', 'cr.consensus_timestamp >= $1', 'cr.consensus_timestamp <= $2'],
       [1000, 2000],
       'desc',
@@ -274,7 +272,7 @@ describe('ContractService.getSyntheticContractResultsQuery tests', () => {
         null::bigint[] as created_contract_ids, null::text as error_message,
         null::bytea as failed_initcode, '\\x'::bytea as function_parameters,
         null::bytea as function_result, null::bigint as gas_consumed, 0::bigint as gas_limit,
-        null::bigint as gas_used, synth_raw.payer_account_id, null::bigint as sender_id,
+        null::bigint as gas_used, synth_raw.payer_account_id, synth_raw.payer_account_id as sender_id,
         synth_raw.transaction_hash, synth_raw.transaction_index, 0::integer as transaction_nonce,
         22::smallint as transaction_result,
         coalesce((select evm_address from contract_evm_address where id = synth_raw.contract_id), '') as evm_address
@@ -285,50 +283,8 @@ describe('ContractService.getSyntheticContractResultsQuery tests', () => {
     expect(params).toEqual([1000, 2000, 10]);
   });
 
-  test('Full page of prior results adds DESC timestamp bound', () => {
-    const [query, params] = ContractService.getSyntheticContractResultsQuery(
-      [{consensus_timestamp: '5'}],
-      ['cr.transaction_nonce = 0'],
-      [],
-      'desc',
-      1
-    );
-    const expected = `
-      with synth_raw as (
-        select distinct on (cl.consensus_timestamp)
-          cl.consensus_timestamp,
-          coalesce(cl.root_contract_id, cl.contract_id) as contract_id,
-          cl.transaction_hash, cl.transaction_index, cl.payer_account_id
-        from contract_log cl
-        where cl.consensus_timestamp >= $1 and cl.synthetic is true and cl.consensus_timestamp != all($2)
-        order by cl.consensus_timestamp desc, cl.index desc
-        limit $3
-      ), contract_evm_address as (
-        select e.id, e.evm_address
-        from synth_raw
-        join entity e on synth_raw.contract_id = e.id
-        group by synth_raw.contract_id, e.id
-      )
-      select
-        null::bigint as amount, null::bytea as bloom, null::bytea as call_result,
-        synth_raw.consensus_timestamp, synth_raw.contract_id,
-        null::bigint[] as created_contract_ids, null::text as error_message,
-        null::bytea as failed_initcode, '\\x'::bytea as function_parameters,
-        null::bytea as function_result, null::bigint as gas_consumed, 0::bigint as gas_limit,
-        null::bigint as gas_used, synth_raw.payer_account_id, null::bigint as sender_id,
-        synth_raw.transaction_hash, synth_raw.transaction_index, 0::integer as transaction_nonce,
-        22::smallint as transaction_result,
-        coalesce((select evm_address from contract_evm_address where id = synth_raw.contract_id), '') as evm_address
-      from synth_raw
-      order by synth_raw.consensus_timestamp desc
-    `;
-    assertSqlQueryEqual(query, expected);
-    expect(params).toEqual(['5', ['5'], 1]);
-  });
-
   test('Transaction index condition is mapped to cl.transaction_index', () => {
     const [query, params] = ContractService.getSyntheticContractResultsQuery(
-      [],
       ['cr.transaction_nonce = 0', 'cr.transaction_index = $1'],
       [3],
       'asc',
@@ -365,6 +321,7 @@ describe('ContractService.getContractResultsByIdAndFilters - synthetic inclusion
       gasLimit: 0,
       transactionNonce: 0,
       payerAccountId: entityId500.getEncodedId(),
+      senderId: entityId500.getEncodedId(),
     });
   });
 

--- a/rest/service/contractService.js
+++ b/rest/service/contractService.js
@@ -222,7 +222,7 @@ class ContractService extends BaseService {
     return [query, params];
   }
 
-  getSyntheticContractResultsQuery(contractResultRows, whereConditions, whereParams, order, limit) {
+  getSyntheticContractResultsQuery(whereConditions, whereParams, order, limit) {
     const params = [...whereParams];
     const contractResultAlias = `${ContractResult.tableAlias}.`;
     const clAlias = `${ContractLog.tableAlias}.`;
@@ -257,23 +257,7 @@ class ContractService extends BaseService {
         return condition;
       });
 
-    if (contractResultRows.length >= limit) {
-      const lastTs = contractResultRows[contractResultRows.length - 1][ContractResult.CONSENSUS_TIMESTAMP];
-      params.push(lastTs);
-      const boundParamIndex = params.length;
-      if (order === orderFilterValues.DESC) {
-        allConditions.push(`${clAlias}${ContractLog.CONSENSUS_TIMESTAMP} >= $${boundParamIndex}`);
-      } else {
-        allConditions.push(`${clAlias}${ContractLog.CONSENSUS_TIMESTAMP} <= $${boundParamIndex}`);
-      }
-    }
-
     allConditions.push(`${clAlias}${ContractLog.SYNTHETIC} is true`);
-    if (contractResultRows.length > 0) {
-      const knownTimestamps = contractResultRows.map((r) => r[ContractResult.CONSENSUS_TIMESTAMP]);
-      params.push(knownTimestamps);
-      allConditions.push(`${clAlias}${ContractLog.CONSENSUS_TIMESTAMP} != all($${params.length})`);
-    }
 
     const whereClause = `where ${allConditions.join(' and ')}`;
     params.push(limit);
@@ -316,7 +300,7 @@ class ContractService extends BaseService {
         0::bigint as ${ContractResult.GAS_LIMIT},
         null::bigint as ${ContractResult.GAS_USED},
         synth_raw.${ContractResult.PAYER_ACCOUNT_ID},
-        null::bigint as ${ContractResult.SENDER_ID},
+        synth_raw.${ContractResult.PAYER_ACCOUNT_ID} as ${ContractResult.SENDER_ID},
         synth_raw.${ContractResult.TRANSACTION_HASH},
         synth_raw.${ContractResult.TRANSACTION_INDEX},
         0::integer as ${ContractResult.TRANSACTION_NONCE},
@@ -340,27 +324,35 @@ class ContractService extends BaseService {
   ) {
     const originalWhereParams = [...whereParams];
     const [query, params] = this.getContractResultsByIdAndFiltersQuery(whereConditions, whereParams, order, limit);
-    const rows = await super.getRows(query, params);
 
     if (!includeSynthetic) {
+      const rows = await super.getRows(query, params);
       return rows.map((cr) => ({...new ContractResult(cr), hash: cr.hash}));
     }
 
     const [syntheticQuery, syntheticParams] = this.getSyntheticContractResultsQuery(
-      rows,
       whereConditions,
       originalWhereParams,
       order,
       limit
     );
-    const syntheticRows = await super.getRows(syntheticQuery, syntheticParams);
+    const [rows, syntheticRows] = await Promise.all([
+      super.getRows(query, params),
+      super.getRows(syntheticQuery, syntheticParams),
+    ]);
 
     const isDesc = order === orderFilterValues.DESC;
     const defaultValue = isDesc ? MIN_LONG : MAX_LONG;
+    const knownTimestamps = new Set(rows.map((row) => row[ContractResult.CONSENSUS_TIMESTAMP]));
     const merged = [];
     let i = 0;
     let j = 0;
     while (merged.length < limit && (i < rows.length || j < syntheticRows.length)) {
+      if (j < syntheticRows.length && knownTimestamps.has(syntheticRows[j][ContractResult.CONSENSUS_TIMESTAMP])) {
+        j++;
+        continue;
+      }
+
       const aTs = i < rows.length ? BigInt(rows[i][ContractResult.CONSENSUS_TIMESTAMP]) : defaultValue;
       const bTs =
         j < syntheticRows.length ? BigInt(syntheticRows[j][ContractResult.CONSENSUS_TIMESTAMP]) : defaultValue;


### PR DESCRIPTION
**Description**:
Fix null `from` and makes `/contracts/results` main + syntetic queries to run in parallel


**Related issue(s)**:

Fixes #13766 

**Notes for reviewer**:
Benchmarked parallelising the two `/contracts/results` queries against mainnet stage, we've got  **~50% more RPS**
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
