### PR TITLE
Bump Jackson 2 and Java versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ extra.apply {
     set("besuVersion", "25.2.2")
     set("blockNodeVersion", "0.35.1")
     set("consensusNodeVersion", "0.75.0-rc.5")
+    set("jackson-2-bom.version", "2.21.4") // Temporary until next Spring Boot
     set("jooq.version", "3.21.6") // Must match buildSrc/build.gradle.kts
     set("mapStructVersion", "1.6.3")
     set("nodeJsVersion", "24.18.0")

--- a/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
@@ -9,8 +9,8 @@ val latest = "latest"
 
 // Get the images to tag by splitting imageTag property and adding the project version
 fun imageTags(): Collection<String> {
-    val imageRegistry: String by project
-    val imageTag: String by project
+    val imageRegistry = project.property("imageRegistry") as String
+    val imageTag = project.property("imageTag") as String
     val image = "${imageRegistry}/hedera-mirror-${project.name}:"
     val customTags = imageTag.split(',').map { image.plus(it) }
     val versionTag = image.plus(project.version)
@@ -31,7 +31,7 @@ val dockerBuild =
         inputDir = file(projectDir)
         pull = true
 
-        val imagePlatform: String by project
+        val imagePlatform = project.property("imagePlatform") as String
         if (imagePlatform.isNotBlank()) {
             buildArgs.put("TARGETPLATFORM", imagePlatform)
             platform = imagePlatform

--- a/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/spring-conventions.gradle.kts
@@ -30,17 +30,17 @@ tasks.register("run") {
     group = "application"
 }
 
-val imagePlatform: String by project
+val imagePlatform = project.property("imagePlatform") as String
 val platform = imagePlatform.ifBlank { null }
 
 tasks.bootBuildImage {
     // Use digests for deterministic builds.
     val builderImageDigest =
-        "sha256:42981edb21bb82d4381d00ada9ae2c14837083aa36e993b64b48cf2cb7eb43dc" // 0.0.138
+        "sha256:8fa490fb5a4cac0c2e85bc2182ad264a534500aec89f631c6195cecb51a8943d" // 0.0.149
     val nativeImageDigest =
-        "sha256:41b0b40795f3703f210a38872b36e3ad9e23236a5a81e8e1984ebef2ff94a17c" // 14.5.0
+        "sha256:780ebf20487514a43a68ffd013f51e82b460934fcead9ff324f318b0553740e0" // 14.7.0
     val runImageDigest =
-        "sha256:9a4259a3735350bd49a226382dc62f96eec3d2be6ecb45dcf7f460111dfdfb8c" // 0.0.86
+        "sha256:9638fd32a376b96b068da9b3c44c7abadf536b567ad5bddd4cd94285e96551c4" // 0.0.93
 
     val env = System.getenv()
     val repo = env.getOrDefault("GITHUB_REPOSITORY", "hiero-ledger/hiero-mirror-node")

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8083
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8083/actuator/health/liveness

--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 WORKDIR /app

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness

--- a/rest-java/Dockerfile
+++ b/rest-java/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8084
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8084/actuator/health/liveness

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 WORKDIR /app

--- a/web3/Dockerfile
+++ b/web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-noble AS builder
+FROM eclipse-temurin:25-jre-resolute AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:25-jre-resolute
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview -Djava.io.tmpdir=/tmp/web3"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness


### PR DESCRIPTION
**Description**:

* Bump Jackson 2 from 2.21.2 to 2.21.4 to fix multiple security vulnerabilities
* Bump Java versions used for native images
* Change Java images from Ubuntu Noble to Resolute
* Fix deprecation warnings in Gradle

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
