### PR TITLE
Fix web3 native image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
         api("org.bouncycastle:bcpkix-jdk18on:1.84") // Temporary until next hedera-app
         api("org.bouncycastle:bcprov-jdk18on:1.84")
         api("org.gaul:s3proxy:3.2.0")
+        api("org.graalvm.nativeimage:svm:25.0.3")
         api("org.hiero.block-node:protobuf-sources:$blockNodeVersion")
         api("org.hyperledger.besu:secp256k1:0.8.2")
         api("org.hyperledger.besu:besu-datatypes:$besuVersion")

--- a/common/src/main/java/org/hiero/mirror/common/util/SignatureUtils.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/SignatureUtils.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.util;
+
+import java.util.Arrays;
+import lombok.experimental.UtilityClass;
+import org.bouncycastle.crypto.digests.KeccakDigest;
+import org.bouncycastle.crypto.ec.CustomNamedCurves;
+import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+@UtilityClass
+public final class SignatureUtils {
+
+    public static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;
+    private static final ECDomainParameters EC_DOMAIN_PARAMETERS;
+
+    static {
+        final var curveParams = CustomNamedCurves.getByName("secp256k1");
+        EC_DOMAIN_PARAMETERS = new ECDomainParameters(
+                curveParams.getCurve(), curveParams.getG(), curveParams.getN(), curveParams.getH());
+    }
+
+    /**
+     * Converts an ECDSA secp256k1 key to a 20-byte EVM address by taking the keccak hash of it.
+     *
+     * @param publicKeyBytes The bytes representing a secp256k1 public key
+     * @return The 20-byte EVM address or an empty byte array if the input is invalid
+     */
+    public static byte[] recoverAddressFromPubKey(byte @Nullable [] publicKeyBytes) {
+        if (publicKeyBytes == null || publicKeyBytes.length != ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
+            return DomainUtils.EMPTY_BYTE_ARRAY;
+        }
+
+        try {
+            final var point = EC_DOMAIN_PARAMETERS.getCurve().decodePoint(publicKeyBytes);
+
+            if (!point.isValid()) {
+                return DomainUtils.EMPTY_BYTE_ARRAY;
+            }
+
+            final var uncompressed = point.normalize().getEncoded(false);
+            final var raw64 = Arrays.copyOfRange(uncompressed, 1, 65);
+
+            final var digest = new KeccakDigest(256);
+            digest.update(raw64, 0, raw64.length);
+
+            final var hash = new byte[32];
+            digest.doFinal(hash, 0);
+
+            return Arrays.copyOfRange(hash, 12, 32);
+        } catch (final Exception e) {
+            return DomainUtils.EMPTY_BYTE_ARRAY;
+        }
+    }
+}

--- a/common/src/test/java/org/hiero/mirror/common/util/SignatureUtilsTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/SignatureUtilsTest.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HexFormat;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+final class SignatureUtilsTest {
+
+    @CsvSource(emptyValue = "", nullValues = "null", textBlock = """
+            null,''
+            '',''
+            02ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c614023,''
+            02ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310, efa0d905af20199aa03aca71cfa5f7647f29f439
+            02ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402311,''
+            02ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c6140231000,''
+            """)
+    @ParameterizedTest
+    void recoverAddressFromPubKey(String input, String output) {
+        final var keyBytes = input != null ? HexFormat.of().parseHex(input) : null;
+        final var expected = HexFormat.of().parseHex(output);
+        assertThat(SignatureUtils.recoverAddressFromPubKey(keyBytes)).isEqualTo(expected);
+    }
+}

--- a/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.util;
 
+import static org.hiero.mirror.common.util.SignatureUtils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
@@ -24,10 +26,8 @@ import lombok.experimental.UtilityClass;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.crypto.digests.KeccakDigest;
-import org.bouncycastle.crypto.ec.CustomNamedCurves;
-import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.hiero.mirror.common.util.DomainUtils;
+import org.hiero.mirror.common.util.SignatureUtils;
 import org.hiero.mirror.importer.exception.ParserException;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -43,15 +43,6 @@ public class Utility {
 
     static final String RECOVERABLE_ERROR = "Recoverable error. ";
     static final String HALT_ON_ERROR_DEFAULT = "false";
-
-    private static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;
-    private static final ECDomainParameters EC_DOMAIN_PARAMETERS;
-
-    static {
-        final var curveParams = CustomNamedCurves.getByName("secp256k1");
-        EC_DOMAIN_PARAMETERS = new ECDomainParameters(
-                curveParams.getCurve(), curveParams.getG(), curveParams.getN(), curveParams.getH());
-    }
 
     /**
      * Converts an ECDSA secp256k1 alias to a 20 byte EVM address by taking the keccak hash of it. Logic copied from
@@ -78,8 +69,9 @@ public class Utility {
             if (key.getKeyCase() == Key.KeyCase.ECDSA_SECP256K1
                     && key.getECDSASecp256K1().size() == ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
                 byte[] rawCompressedKey = DomainUtils.toBytes(key.getECDSASecp256K1());
-                evmAddress = recoverAddressFromPubKey(rawCompressedKey);
-                if (evmAddress == null) {
+                evmAddress = SignatureUtils.recoverAddressFromPubKey(rawCompressedKey);
+                if (evmAddress == null || evmAddress.length == 0) {
+                    evmAddress = null;
                     log.warn("Unable to recover EVM address from {}", Hex.encodeHexString(rawCompressedKey));
                 }
             }
@@ -228,27 +220,6 @@ public class Utility {
         } else {
             log.error(RECOVERABLE_ERROR + message, args);
         }
-    }
-
-    // This method is copied from consensus node's EthTxSigs::recoverAddressFromPubKey and should be kept in sync
-    @SuppressWarnings("java:S1168")
-    private static byte[] recoverAddressFromPubKey(byte[] pubKeyBytes) {
-        final var point = EC_DOMAIN_PARAMETERS.getCurve().decodePoint(pubKeyBytes);
-
-        if (!point.isValid()) {
-            throw new IllegalArgumentException("Invalid public key: point is not on the secp256k1 curve");
-        }
-
-        final var uncompressed = point.normalize().getEncoded(false);
-        final var raw64 = Arrays.copyOfRange(uncompressed, 1, 65);
-
-        final var digest = new KeccakDigest(256);
-        digest.update(raw64, 0, raw64.length);
-
-        final var hash = new byte[32];
-        digest.doFinal(hash, 0);
-
-        return Arrays.copyOfRange(hash, 12, 32);
     }
 
     private static byte[] stripHexPrefix(byte[] data) {

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -21,6 +21,7 @@ configurations.all {
 }
 
 dependencies {
+    compileOnly("org.graalvm.nativeimage:svm")
     implementation(project(":common"))
     implementation("com.bucket4j:bucket4j-core")
     implementation("com.hedera.hashgraph:app") {

--- a/web3/src/main/java/org/hiero/mirror/web3/config/EthSigsUtilsSubstitute.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/config/EthSigsUtilsSubstitute.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.web3.config;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.hiero.mirror.common.util.SignatureUtils;
+
+/**
+ * Substitutes consensus node's EthSigsUtils methods that use native Besu libraries with Java-based implementations
+ * so that it works in a native image.
+ */
+@TargetClass(className = "com.hedera.node.app.hapi.utils.EthSigsUtils")
+final class EthSigsUtilsSubstitute {
+
+    @Substitute
+    public static byte[] recoverAddressFromPubKey(final byte[] pubKeyBytes) {
+        return SignatureUtils.recoverAddressFromPubKey(pubKeyBytes);
+    }
+}


### PR DESCRIPTION
**Description**:

* Fix web3 native image by substituting a Java-based bouncy castle implementation
* Extract ECDSA recover into a separate `SignatureUtils` for sharing with web3

**Related issue(s)**:

Fixes #13773

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
