### PR TITLE
Fix broken lazy database pool connection in rosetta

### DIFF
--- a/rosetta/app/db/db.go
+++ b/rosetta/app/db/db.go
@@ -13,9 +13,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// ConnectToDb establishes connection to the Postgres Database
-func ConnectToDb(dbConfig config.Db) interfaces.DbClient {
-	db, err := gorm.Open(postgres.Open(dbConfig.GetDsn()), &gorm.Config{Logger: gormlogrus.New()})
+// ConnectToDb establishes connection to the Postgres Database. It returns the DbClient and a close function which
+// releases the underlying database resources and should be called when the connection is no longer needed.
+func ConnectToDb(dbConfig config.Db) (interfaces.DbClient, func()) {
+	db, err := gorm.Open(postgres.Open(dbConfig.GetDsn()), &gorm.Config{
+		DisableAutomaticPing: true,
+		Logger:               gormlogrus.New()})
 	if err != nil {
 		log.Warn(err)
 	} else {
@@ -25,12 +28,18 @@ func ConnectToDb(dbConfig config.Db) interfaces.DbClient {
 	sqlDb, err := db.DB()
 	if err != nil {
 		log.Errorf("Failed to get sql DB: %s", err)
-		return nil
+		return nil, nil
 	}
 
 	sqlDb.SetMaxIdleConns(dbConfig.Pool.MaxIdleConnections)
 	sqlDb.SetConnMaxLifetime(time.Duration(dbConfig.Pool.MaxLifetime) * time.Minute)
 	sqlDb.SetMaxOpenConns(dbConfig.Pool.MaxOpenConnections)
 
-	return NewDbClient(db, dbConfig.StatementTimeout)
+	closeFn := func() {
+		if err := sqlDb.Close(); err != nil {
+			log.Errorf("Error closing database connection: %v", err)
+		}
+	}
+
+	return NewDbClient(db, dbConfig.StatementTimeout), closeFn
 }

--- a/rosetta/app/db/db_test.go
+++ b/rosetta/app/db/db_test.go
@@ -29,7 +29,8 @@ func (suite *dbSuite) TearDownSuite() {
 }
 
 func (suite *dbSuite) TestConnectToDb() {
-	dbClient := ConnectToDb(suite.dbResource.GetDbConfig())
+	dbClient, closeDb := ConnectToDb(suite.dbResource.GetDbConfig())
+	defer closeDb()
 	err := dbClient.GetDb().Exec("select 1").Error
 	assert.Nil(suite.T(), err)
 }
@@ -37,7 +38,8 @@ func (suite *dbSuite) TestConnectToDb() {
 func (suite *dbSuite) TestConnectToDbInvalidPassword() {
 	dbConfig := suite.dbResource.GetDbConfig()
 	dbConfig.Password = "bad_password_dab"
-	dbClient := ConnectToDb(dbConfig)
+	dbClient, closeDb := ConnectToDb(dbConfig)
+	defer closeDb()
 	err := dbClient.GetDb().Exec("select 1").Error
 	assert.NotNil(suite.T(), err)
 }

--- a/rosetta/main.go
+++ b/rosetta/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/persistence/domain"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,6 +21,7 @@ import (
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/interfaces"
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/middleware"
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/persistence"
+	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/persistence/domain"
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/services"
 	"github.com/hiero-ledger/hiero-mirror-node/rosetta/app/services/construction"
 	log "github.com/sirupsen/logrus"
@@ -195,9 +195,15 @@ func main() {
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	var router http.Handler
 	if rosettaConfig.Online {
-		dbClient := db.ConnectToDb(rosettaConfig.Db)
+		dbClient, closeDb := db.ConnectToDb(rosettaConfig.Db)
+		if dbClient == nil {
+			log.Fatal("Failed to connect to database")
+		}
+		defer closeDb()
 
 		router, err = newBlockchainOnlineRouter(asserter, dbClient, network, mirrorConfig, ctx, version)
 		if err != nil {
@@ -235,7 +241,6 @@ func main() {
 	}()
 
 	<-ctx.Done()
-	stop()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), rosettaConfig.ShutdownTimeout)
 	defer cancel()


### PR DESCRIPTION
**Description**:

This PR fixes the lazy database pool connection issue in rosetta

- Disable gorm automatic ping to allow lazy database pool connection pattern
- Improve database clean up on shutdown

**Related issue(s)**:

Fixes #13813

**Notes for reviewer**:

In gorm v1.31.2, when opening a new database, and the connection can't be validated by the automatic ping mechanism, the logic has changed to close the underlying `sql.DB`, causing subsequent queries to fail with error `sql: database is closed`.

While it's debatable whether gorm should allow such change which obviously breaks lazy database connection pool pattern, the easy workaround is disable the automatic ping.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
