### PR TITLE
HIP-1427 Skip historical migrations when starting with blockstream

### DIFF
--- a/docs/runbook/verify-recent-block-streams-bucket-access.md
+++ b/docs/runbook/verify-recent-block-streams-bucket-access.md
@@ -1,0 +1,72 @@
+# Verify Recent Block Streams Bucket Access
+
+## Problem
+
+To ensure a smooth record stream to block stream cutover (defined in [HIP-1193: Record Stream to Block Stream Cutover](https://hips.hedera.com/hip/hip-1193)), a third-party operator needs to confirm that their cloud credentials can`LIST`
+and `GET` objects in the Hedera "recent block streams" buckets, ahead of time. These buckets are
+**requester-pays**, so the caller must supply credentials and a billing account/project of their own. The
+[`tools/blockstream/verify-block-streams-bucket-access.sh`](../../tools/blockstream/verify-block-streams-bucket-access.sh)
+script performs that check against AWS S3 or GCS for a chosen network.
+
+The buckets checked (identical names across both providers) are:
+
+| Network    | Bucket                                   |
+| ---------- | ---------------------------------------- |
+| mainnet    | `hedera-mainnet-recent-block-streams`    |
+| testnet    | `hedera-testnet-recent-block-streams`    |
+| previewnet | `hedera-previewnet-recent-block-streams` |
+
+## What it does
+
+For the selected provider and network the script runs two requester-pays checks and prints a PASS/FAIL/SKIP summary:
+
+1. **LIST** — lists a single object from the bucket to confirm list permission.
+2. **GET** — reads the first object returned by the list to confirm read permission.
+
+The script exits `0` when all checks pass and `1` when any check fails.
+
+## Requirements
+
+- **AWS**: `aws` CLI v2.
+- **GCS**: `awscurl` and `xmllint` (`libxml2-utils`). GCS is accessed through its S3-compatible XML API, so a GCS
+  interoperability HMAC key is used as the access/secret key, and a billing project is required via `--project`.
+
+## Usage
+
+All commands are assumed to be run from the git repository root.
+
+```bash
+tools/blockstream/verify-block-streams-bucket-access.sh [options]
+```
+
+Options:
+
+| Option                       | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `-p, --provider <aws\|gcs>`  | Which cloud to check (required)                       |
+| `-n, --network <name>`       | `mainnet` \| `testnet` \| `previewnet` (required)     |
+| `--access-key <key>`         | Access key id / GCS HMAC key (required)               |
+| `--secret-key <secret>`      | Secret key / GCS HMAC secret (required)               |
+| `--region <region>`          | AWS region for the bucket (if needed)                 |
+| `--project <gcp-project-id>` | GCS billing project (required for `gcs`)              |
+| `--no-range`                 | Do a full `GET` instead of a `bytes=0-0` ranged `GET` |
+| `-v, --verbose`              | Print the operation/target for each check             |
+| `-h, --help`                 | Show help                                             |
+
+### Examples
+
+```bash
+# AWS, testnet
+tools/blockstream/verify-block-streams-bucket-access.sh -p aws -n testnet \
+    --access-key AKIA... --secret-key ...
+
+# GCS, previewnet
+tools/blockstream/verify-block-streams-bucket-access.sh -p gcs -n previewnet --project my-gcp-project \
+    --access-key GOOG... --secret-key ...
+```
+
+## Verification
+
+- A successful run prints `All checks passed.` and exits `0`.
+- On failure, each failing check reports the underlying AWS/GCS error (e.g. an access-denied or requester-pays error),
+  the summary line shows a non-zero `FAIL` count, and the script exits `1`.

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/BlockNumberMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/BlockNumberMigration.java
@@ -2,41 +2,44 @@
 
 package org.hiero.mirror.importer.migration;
 
-import static org.hiero.mirror.importer.ImporterProperties.HederaNetwork.MAINNET;
-import static org.hiero.mirror.importer.ImporterProperties.HederaNetwork.TESTNET;
-
 import com.google.common.base.Stopwatch;
 import jakarta.inject.Named;
-import java.util.Map;
-import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
+import java.util.Objects;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.importer.ImporterProperties;
 import org.hiero.mirror.importer.repository.RecordFileRepository;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 @Named
-public class BlockNumberMigration extends RepeatableMigration {
+final class BlockNumberMigration extends RepeatableMigration {
 
-    static final Map<String, Pair<Long, Long>> BLOCK_NUMBER_MAPPING = Map.of(
-            TESTNET, Pair.of(1656461617493248000L, 22384256L),
-            MAINNET, Pair.of(1656461547557609267L, 34305852L));
+    static final long MAINNET_BLOCK_CONSENSUS_END = 1656461547557609267L;
+    static final long MAINNET_BLOCK_NUMBER = 34305852L;
 
+    private final BlockStreamResolver blockStreamResolver;
     private final ImporterProperties importerProperties;
     private final ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider;
     private final ObjectProvider<RecordFileRepository> recordFileRepositoryProvider;
+    private final boolean v2;
 
-    public BlockNumberMigration(
+    BlockNumberMigration(
+            BlockStreamResolver blockStreamResolver,
+            Environment environment,
             ImporterProperties importerProperties,
             ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider,
             ObjectProvider<RecordFileRepository> recordFileRepositoryProvider) {
         super(importerProperties.getMigration());
+        this.blockStreamResolver = blockStreamResolver;
         this.importerProperties = importerProperties;
         this.jdbcOperationsProvider = jdbcOperationsProvider;
         this.recordFileRepositoryProvider = recordFileRepositoryProvider;
+        v2 = environment.acceptsProfiles(Profiles.of("v2"));
     }
 
     @Override
@@ -46,45 +49,47 @@ public class BlockNumberMigration extends RepeatableMigration {
 
     @Override
     protected MigrationVersion getMinimumVersion() {
-        return MigrationVersion.fromVersion("1.67.0");
+        return blockStreamResolver.getMinimumMigrationVersion(v2);
     }
 
     @Override
     protected void doMigrate() {
-        var hederaNetwork = importerProperties.getNetwork();
-        var consensusEndAndBlockNumber = BLOCK_NUMBER_MAPPING.get(hederaNetwork);
-
-        if (consensusEndAndBlockNumber == null) {
+        final var hederaNetwork = importerProperties.getNetwork();
+        if (!Objects.equals(hederaNetwork, ImporterProperties.HederaNetwork.MAINNET)) {
             log.info("No block migration necessary for {} network", hederaNetwork);
             return;
         }
 
-        long correctConsensusEnd = consensusEndAndBlockNumber.getKey();
-        long correctBlockNumber = consensusEndAndBlockNumber.getValue();
-
-        findBlockNumberByConsensusEnd(correctConsensusEnd)
-                .filter(blockNumber -> blockNumber != correctBlockNumber)
-                .ifPresent(blockNumber -> updateIndex(correctBlockNumber, blockNumber));
-    }
-
-    private void updateIndex(long correctBlockNumber, long incorrectBlockNumber) {
-        long offset = correctBlockNumber - incorrectBlockNumber;
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        int count = recordFileRepositoryProvider.getObject().updateIndex(offset);
-        log.info("Updated {} blocks with offset {} in {}", count, offset, stopwatch);
-    }
-
-    private Optional<Long> findBlockNumberByConsensusEnd(long consensusEnd) {
-        var params = new MapSqlParameterSource().addValue("consensusEnd", consensusEnd);
         try {
-            return Optional.ofNullable(jdbcOperationsProvider
+            final var params = new MapSqlParameterSource().addValue("consensusEnd", MAINNET_BLOCK_CONSENSUS_END);
+            final var index = jdbcOperationsProvider
                     .getObject()
                     .queryForObject(
                             "select index from record_file where consensus_end = :consensusEnd limit 1",
                             params,
-                            Long.class));
-        } catch (IncorrectResultSizeDataAccessException ex) {
-            return Optional.empty();
+                            Long.class);
+            if (index != null && index != MAINNET_BLOCK_NUMBER) {
+                final long offset = MAINNET_BLOCK_NUMBER - index;
+                final var stopwatch = Stopwatch.createStarted();
+                final int count = recordFileRepositoryProvider.getObject().updateIndex(offset);
+                log.info("Updated {} blocks with offset {} in {}", count, offset, stopwatch);
+            }
+        } catch (final IncorrectResultSizeDataAccessException _) {
+            // empty record_file table, ignore
         }
+    }
+
+    @Override
+    protected boolean skipMigration(Configuration configuration) {
+        if (super.skipMigration(configuration)) {
+            return true;
+        }
+
+        if (blockStreamResolver.isStartedFromBlockStream()) {
+            log.info("Skip migration since the importer started from the block stream");
+            return true;
+        }
+
+        return false;
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/BlockStreamResolver.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/BlockStreamResolver.java
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.hiero.mirror.common.domain.transaction.RecordFile.GENESIS_BLOCK_NUMBER;
+
+import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.MigrationVersion;
+import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
+import org.hiero.mirror.importer.repository.RecordFileRepository;
+import org.springframework.beans.factory.ObjectProvider;
+
+@Named
+@RequiredArgsConstructor
+final class BlockStreamResolver {
+
+    private final BlockProperties blockProperties;
+    private final ImporterProperties importerProperties;
+    private final ObjectProvider<RecordFileRepository> recordFileRepositoryProvider;
+
+    /**
+     * Whether the initial state has been, or will be, loaded from the genesis wrapped record block, i.e., the first
+     * ingested block is the genesis block ({@code index == 0}) and a wrapped record block, or nothing has been ingested
+     * yet and the importer is configured to ingest the block stream starting from genesis.
+     */
+    boolean isInitialStateFromGenesisWrb() {
+        final var firstRecordFile = recordFileRepositoryProvider.getObject().findFirst();
+        if (firstRecordFile.isPresent()) {
+            final var recordFile = firstRecordFile.get();
+            final var index = recordFile.getIndex();
+            return recordFile.getWrappedRecordBlockHash() != null && index != null && index == GENESIS_BLOCK_NUMBER;
+        }
+
+        final var startBlockNumber = importerProperties.getStartBlockNumber();
+        return blockProperties.isEnabled() && (startBlockNumber == null || startBlockNumber == 0L);
+    }
+
+    /**
+     * Whether the importer started, or will start, from the block stream, i.e., the first ingested block is a wrapped
+     * record block or a block stream block regardless of its index, or nothing has been ingested yet and the importer
+     * is configured to ingest the block stream from any block.
+     */
+    boolean isStartedFromBlockStream() {
+        final var firstRecordFile = recordFileRepositoryProvider.getObject().findFirst();
+        if (firstRecordFile.isPresent()) {
+            final var recordFile = firstRecordFile.get();
+            return recordFile.getWrappedRecordBlockHash() != null
+                    || recordFile.getVersion() == BlockStreamReader.VERSION;
+        }
+
+        return blockProperties.isEnabled();
+    }
+
+    MigrationVersion getMinimumMigrationVersion(final boolean v2) {
+        // The minimum version is the one record_file.wrapped_record_block_hash is added
+        return v2 ? MigrationVersion.fromVersion("2.25.0") : MigrationVersion.fromVersion("1.120.0");
+    }
+}

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/ErrataMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/ErrataMigration.java
@@ -16,6 +16,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.SneakyThrows;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.balance.AccountBalanceFile;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.token.TokenTransfer;
@@ -34,6 +36,8 @@ import org.hiero.mirror.importer.repository.TransactionRepository;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -46,7 +50,7 @@ import org.springframework.transaction.support.TransactionOperations;
  */
 @Named
 @Order(2)
-public class ErrataMigration extends RepeatableMigration implements BalanceStreamFileListener {
+final class ErrataMigration extends RepeatableMigration implements BalanceStreamFileListener {
 
     private static final int ACCOUNT_BALANCE_FILE_FIXED_TIME_OFFSET = 53;
     // The consensus timestamps of the first and the last account balance files in mainnet to add the fixed 53ns offset
@@ -57,6 +61,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     private Resource balanceOffsets;
 
     private final ObjectProvider<AccountBalanceFileRepository> accountBalanceFileRepositoryProvider;
+    private final BlockStreamResolver blockStreamResolver;
     private final ObjectProvider<EntityRecordItemListener> entityRecordItemListenerProvider;
     private final EntityProperties entityProperties;
     private final ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider;
@@ -66,12 +71,15 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     private final ObjectProvider<TransactionOperations> transactionOperationsProvider;
     private final ObjectProvider<TransactionRepository> transactionRepositoryProvider;
     private final Set<Long> timestamps = new HashSet<>();
+    private final boolean v2;
 
     @SuppressWarnings("java:S107")
-    public ErrataMigration(
+    ErrataMigration(
             ObjectProvider<AccountBalanceFileRepository> accountBalanceFileRepositoryProvider,
+            BlockStreamResolver blockStreamResolver,
             ObjectProvider<EntityRecordItemListener> entityRecordItemListenerProvider,
             EntityProperties entityProperties,
+            Environment environment,
             ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider,
             ImporterProperties importerProperties,
             ObjectProvider<RecordStreamFileListener> recordStreamFileListenerProvider,
@@ -80,6 +88,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
             ObjectProvider<TransactionRepository> transactionRepositoryProvider) {
         super(importerProperties.getMigration());
         this.accountBalanceFileRepositoryProvider = accountBalanceFileRepositoryProvider;
+        this.blockStreamResolver = blockStreamResolver;
         this.entityRecordItemListenerProvider = entityRecordItemListenerProvider;
         this.entityProperties = entityProperties;
         this.jdbcOperationsProvider = jdbcOperationsProvider;
@@ -88,11 +97,17 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
         this.tokenTransferRepositoryProvider = tokenTransferRepositoryProvider;
         this.transactionOperationsProvider = transactionOperationsProvider;
         this.transactionRepositoryProvider = transactionRepositoryProvider;
+        v2 = environment.acceptsProfiles(Profiles.of("v2"));
     }
 
     @Override
     public String getDescription() {
         return "Add errata information to the database to workaround older, incorrect data";
+    }
+
+    @Override
+    protected MigrationVersion getMinimumVersion() {
+        return blockStreamResolver.getMinimumMigrationVersion(v2);
     }
 
     @Override
@@ -129,6 +144,20 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
                 entityProperties.getPersist().setEntityHistory(entityHistory);
             }
         }
+    }
+
+    @Override
+    protected boolean skipMigration(final Configuration configuration) {
+        if (super.skipMigration(configuration)) {
+            return true;
+        }
+
+        if (blockStreamResolver.isStartedFromBlockStream()) {
+            log.info("Skip migration since the importer started from the block stream");
+            return true;
+        }
+
+        return false;
     }
 
     private void balanceFileAdjustment() {

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigration.java
@@ -19,6 +19,7 @@ import java.util.zip.GZIPInputStream;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
@@ -28,19 +29,23 @@ import org.hiero.mirror.importer.ImporterProperties;
 import org.hiero.mirror.importer.repository.EntityRepository;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 @Named
-public class HistoricalAccountInfoMigration extends RepeatableMigration {
+final class HistoricalAccountInfoMigration extends RepeatableMigration {
 
     static final Instant EXPORT_DATE = Instant.parse("2019-09-14T00:00:10Z");
 
+    private final BlockStreamResolver blockStreamResolver;
     private final Set<Long> contractIds = new HashSet<>();
     private final ObjectProvider<EntityRepository> entityRepositoryProvider;
     private final ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider;
     private final ImporterProperties importerProperties;
+    private final boolean v2;
 
     @Value("classpath:accountInfoContracts.txt")
     private Resource accountInfoContracts;
@@ -48,14 +53,18 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
     @Value("classpath:accountInfo.txt.gz")
     private Resource accountInfoPath;
 
-    public HistoricalAccountInfoMigration(
+    HistoricalAccountInfoMigration(
+            BlockStreamResolver blockStreamResolver,
             ObjectProvider<EntityRepository> entityRepositoryProvider,
+            Environment environment,
             ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider,
             ImporterProperties importerProperties) {
         super(importerProperties.getMigration());
+        this.blockStreamResolver = blockStreamResolver;
         this.entityRepositoryProvider = entityRepositoryProvider;
         this.jdbcOperationsProvider = jdbcOperationsProvider;
         this.importerProperties = importerProperties;
+        v2 = environment.acceptsProfiles(Profiles.of("v2"));
     }
 
     @Override
@@ -64,13 +73,8 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
     }
 
     @Override
-    protected boolean skipMigration(Configuration configuration) {
-        if (!migrationProperties.isEnabled()) {
-            log.info("Skip migration since it's disabled");
-            return true;
-        }
-
-        return false; // Migrate for both v1 and v2
+    protected MigrationVersion getMinimumVersion() {
+        return blockStreamResolver.getMinimumMigrationVersion(v2);
     }
 
     @Override
@@ -95,6 +99,20 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
         loadContractIds();
         fixContractEntities();
         processFile(stopwatch);
+    }
+
+    @Override
+    protected boolean skipMigration(final Configuration configuration) {
+        if (super.skipMigration(configuration)) {
+            return true;
+        }
+
+        if (blockStreamResolver.isInitialStateFromGenesisWrb()) {
+            log.info("Skip migration since initial state is loaded from the genesis wrapped record block");
+            return true;
+        }
+
+        return false;
     }
 
     private void processFile(Stopwatch stopwatch) throws IOException {

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -5,15 +5,18 @@ package org.hiero.mirror.importer.migration;
 import com.google.common.base.Stopwatch;
 import jakarta.inject.Named;
 import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.importer.ImporterProperties;
 import org.hiero.mirror.importer.repository.AccountBalanceFileRepository;
 import org.hiero.mirror.importer.repository.RecordFileRepository;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Named
-public class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigration {
+final class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigration {
 
     private static final String INITIALIZE_ENTITY_BALANCE_SQL = """
             with snapshot as (
@@ -44,8 +47,13 @@ public class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigra
                 balance_timestamp = coalesce(entity.balance_timestamp, excluded.balance_timestamp)
             """;
 
-    public InitializeEntityBalanceMigration(
+    private final BlockStreamResolver blockStreamResolver;
+    private final boolean v2;
+
+    InitializeEntityBalanceMigration(
             ObjectProvider<AccountBalanceFileRepository> accountBalanceFileRepositoryProvider,
+            BlockStreamResolver blockStreamResolver,
+            Environment environment,
             ImporterProperties importerProperties,
             ObjectProvider<NamedParameterJdbcOperations> jdbcOperationsProvider,
             ObjectProvider<RecordFileRepository> recordFileRepositoryProvider,
@@ -56,6 +64,8 @@ public class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigra
                 jdbcOperationsProvider,
                 recordFileRepositoryProvider,
                 transactionTemplateProvider);
+        this.blockStreamResolver = blockStreamResolver;
+        v2 = environment.acceptsProfiles(Profiles.of("v2"));
     }
 
     @Override
@@ -65,7 +75,7 @@ public class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigra
 
     @Override
     protected MigrationVersion getMinimumVersion() {
-        return MigrationVersion.fromVersion("1.89.2"); // The version which deduplicates balance tables
+        return blockStreamResolver.getMinimumMigrationVersion(v2);
     }
 
     @Override
@@ -73,5 +83,19 @@ public class InitializeEntityBalanceMigration extends AbstractTimestampInfoMigra
         var stopwatch = Stopwatch.createStarted();
         var count = doMigrate(INITIALIZE_ENTITY_BALANCE_SQL);
         log.info("Initialized {} entities balance in {}", count.get(), stopwatch);
+    }
+
+    @Override
+    protected boolean skipMigration(Configuration configuration) {
+        if (super.skipMigration(configuration)) {
+            return true;
+        }
+
+        if (blockStreamResolver.isStartedFromBlockStream()) {
+            log.info("Skip migration since the importer started from the block stream");
+            return true;
+        }
+
+        return false;
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/BlockNumberMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/BlockNumberMigrationTest.java
@@ -3,9 +3,11 @@
 package org.hiero.mirror.importer.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.mirror.importer.ImporterProperties.HederaNetwork.MAINNET;
 import static org.hiero.mirror.importer.ImporterProperties.HederaNetwork.PREVIEWNET;
-import static org.hiero.mirror.importer.ImporterProperties.HederaNetwork.TESTNET;
-import static org.hiero.mirror.importer.migration.BlockNumberMigration.BLOCK_NUMBER_MAPPING;
+import static org.hiero.mirror.importer.migration.BlockNumberMigration.MAINNET_BLOCK_CONSENSUS_END;
+import static org.hiero.mirror.importer.migration.BlockNumberMigration.MAINNET_BLOCK_NUMBER;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,30 +15,38 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.groups.Tuple;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
 import org.hiero.mirror.importer.repository.RecordFileRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @RequiredArgsConstructor
 @Tag("migration")
-class BlockNumberMigrationTest extends ImporterIntegrationTest {
-
-    private static final long CORRECT_CONSENSUS_END =
-            BLOCK_NUMBER_MAPPING.get(TESTNET).getKey();
-    private static final long CORRECT_BLOCK_NUMBER =
-            BLOCK_NUMBER_MAPPING.get(TESTNET).getValue();
+final class BlockNumberMigrationTest extends ImporterIntegrationTest {
 
     private final BlockNumberMigration blockNumberMigration;
+    private final BlockProperties blockProperties;
     private final ImporterProperties importerProperties;
     private final RecordFileRepository recordFileRepository;
 
     @BeforeEach
     void setup() {
-        importerProperties.setNetwork(TESTNET);
+        importerProperties.setNetwork(MAINNET);
+    }
+
+    @AfterEach
+    void teardown() {
+        blockProperties.setEnabled(false);
     }
 
     @Test
@@ -46,23 +56,21 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void unsupportedNetwork() {
-        var previousNetwork = importerProperties.getNetwork();
         importerProperties.setNetwork(PREVIEWNET);
         List<Tuple> expectedBlockNumbersAndConsensusEnd =
-                insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END)).stream()
+                insertDefaultRecordFiles(Set.of(MAINNET_BLOCK_CONSENSUS_END)).stream()
                         .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
                         .toList();
 
         blockNumberMigration.doMigrate();
 
         assertConsensusEndAndBlockNumber(expectedBlockNumbersAndConsensusEnd);
-        importerProperties.setNetwork(previousNetwork);
     }
 
     @Test
     void theCorrectOffsetMustBeAddedToTheBlockNumbers() {
         List<RecordFile> defaultRecordFiles = insertDefaultRecordFiles();
-        long offset = CORRECT_BLOCK_NUMBER - 8L;
+        long offset = MAINNET_BLOCK_NUMBER - 8L;
         List<Tuple> expectedBlockNumbersAndConsensusEnd = defaultRecordFiles.stream()
                 .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex() + offset))
                 .toList();
@@ -75,7 +83,7 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
     @Test
     void ifCorrectConsensusEndNotFoundDoNothing() {
         List<Tuple> expectedBlockNumbersAndConsensusEnd =
-                insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END)).stream()
+                insertDefaultRecordFiles(Set.of(MAINNET_BLOCK_CONSENSUS_END)).stream()
                         .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
                         .toList();
 
@@ -87,14 +95,14 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
     @Test
     void ifBlockNumberIsAlreadyCorrectDoNothing() {
         List<Tuple> expectedBlockNumbersAndConsensusEnd =
-                insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END)).stream()
+                insertDefaultRecordFiles(Set.of(MAINNET_BLOCK_CONSENSUS_END)).stream()
                         .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
                         .collect(Collectors.toList());
 
         final RecordFile targetRecordFile = domainBuilder
                 .recordFile()
-                .customize(
-                        builder -> builder.consensusEnd(CORRECT_CONSENSUS_END).index(CORRECT_BLOCK_NUMBER))
+                .customize(builder ->
+                        builder.consensusEnd(MAINNET_BLOCK_CONSENSUS_END).index(MAINNET_BLOCK_NUMBER))
                 .persist();
         expectedBlockNumbersAndConsensusEnd.add(
                 Tuple.tuple(targetRecordFile.getConsensusEnd(), targetRecordFile.getIndex()));
@@ -102,6 +110,38 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
         blockNumberMigration.doMigrate();
 
         assertConsensusEndAndBlockNumber(expectedBlockNumbersAndConsensusEnd);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void skipWhenIngestedFromBlockstream(final boolean wrapped) {
+        // given
+        domainBuilder
+                .recordFile()
+                .customize(r -> {
+                    if (wrapped) {
+                        r.wrappedRecordBlockHash(domainBuilder.bytes(48))
+                                .previousWrappedRecordBlockHash(domainBuilder.bytes(48));
+                    } else {
+                        r.version(BlockStreamReader.VERSION);
+                    }
+                })
+                .persist();
+
+        // when, then
+        assertThat(blockNumberMigration.skipMigration(mock(Configuration.class)))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, true
+            false, false
+            """)
+    void skipWithBlockStreamConfig(final boolean enabled, final boolean shouldSkip) {
+        blockProperties.setEnabled(enabled);
+        assertThat(blockNumberMigration.skipMigration(mock(Configuration.class)))
+                .isEqualTo(shouldSkip);
     }
 
     private void assertConsensusEndAndBlockNumber(List<Tuple> expectedBlockNumbersAndConsensusEnd) {
@@ -116,7 +156,7 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
     }
 
     private List<RecordFile> insertDefaultRecordFiles(Set<Long> skipRecordFileWithConsensusEnd) {
-        long[] consensusEnd = {1570800761443132000L, CORRECT_CONSENSUS_END, CORRECT_CONSENSUS_END + 1L};
+        long[] consensusEnd = {1570800761443132000L, MAINNET_BLOCK_CONSENSUS_END, MAINNET_BLOCK_CONSENSUS_END + 1L};
         long[] blockNumber = {0L, 8L, 9L};
         var recordFiles = new ArrayList<RecordFile>(consensusEnd.length);
 

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/BlockStreamResolverTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/BlockStreamResolverTest.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.MigrationVersion;
+import org.hiero.mirror.importer.ImporterIntegrationTest;
+import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
+import org.hiero.mirror.importer.reader.record.ProtoRecordFileReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+final class BlockStreamResolverTest extends ImporterIntegrationTest {
+
+    private final BlockProperties blockProperties;
+    private final BlockStreamResolver blockStreamResolver;
+    private final ImporterProperties importerProperties;
+
+    @AfterEach
+    void teardown() {
+        blockProperties.setEnabled(false);
+        importerProperties.setStartBlockNumber(null);
+    }
+
+    @Test
+    void genesisWrbIngested() {
+        persistRecordFile(0L, ProtoRecordFileReader.VERSION, true);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isTrue();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void nonGenesisWrbIngested() {
+        persistRecordFile(10L, ProtoRecordFileReader.VERSION, true);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isFalse();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void blockStreamBlockIngested() {
+        // A block stream block, not a wrapped record block: no wrappedRecordBlockHash, version >= block stream version
+        persistRecordFile(10L, BlockStreamReader.VERSION, false);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isFalse();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void recordStreamIngested() {
+        // A legacy record stream file: no wrappedRecordBlockHash and version below the block stream version
+        persistRecordFile(0L, ProtoRecordFileReader.VERSION, false);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isFalse();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isFalse();
+    }
+
+    @Test
+    void noBlocksBlockStreamDisabled() {
+        blockProperties.setEnabled(false);
+        importerProperties.setStartBlockNumber(null);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isFalse();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isFalse();
+    }
+
+    @Test
+    void noBlocksConfiguredFromGenesisNullStart() {
+        blockProperties.setEnabled(true);
+        importerProperties.setStartBlockNumber(null);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isTrue();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void noBlocksConfiguredFromGenesisZeroStart() {
+        blockProperties.setEnabled(true);
+        importerProperties.setStartBlockNumber(0L);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isTrue();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void noBlocksConfiguredFromNonGenesis() {
+        blockProperties.setEnabled(true);
+        importerProperties.setStartBlockNumber(5L);
+        assertThat(blockStreamResolver.isInitialStateFromGenesisWrb()).isFalse();
+        assertThat(blockStreamResolver.isStartedFromBlockStream()).isTrue();
+    }
+
+    @Test
+    void getMinimumMigrationVersion() {
+        assertThat(blockStreamResolver.getMinimumMigrationVersion(true))
+                .isEqualTo(MigrationVersion.fromVersion("2.25.0"));
+        assertThat(blockStreamResolver.getMinimumMigrationVersion(false))
+                .isEqualTo(MigrationVersion.fromVersion("1.120.0"));
+    }
+
+    private void persistRecordFile(final long index, final int version, final boolean wrapped) {
+        final byte[] wrappedRecordBlockHash = wrapped ? domainBuilder.bytes(48) : null;
+        domainBuilder
+                .recordFile()
+                .customize(r -> r.index(index).version(version).wrappedRecordBlockHash(wrappedRecordBlockHash))
+                .persist();
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/ErrataMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/ErrataMigrationTest.java
@@ -3,12 +3,14 @@
 package org.hiero.mirror.importer.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.IterableAssert;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.balance.AccountBalanceFile;
 import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.transaction.CryptoTransfer;
@@ -18,7 +20,9 @@ import org.hiero.mirror.common.domain.transaction.TransactionType;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
 import org.hiero.mirror.importer.parser.record.entity.EntityProperties;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
 import org.hiero.mirror.importer.repository.AccountBalanceFileRepository;
 import org.hiero.mirror.importer.repository.ContractResultRepository;
 import org.hiero.mirror.importer.repository.CryptoTransferRepository;
@@ -30,11 +34,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings("java:S5786")
 @RequiredArgsConstructor
 @Tag("migration")
-public class ErrataMigrationTest extends ImporterIntegrationTest {
+public final class ErrataMigrationTest extends ImporterIntegrationTest {
 
     public static final long BAD_TIMESTAMP1 = 1568415600193620000L;
     private static final long BAD_TIMESTAMP2 = 1568528100472477002L;
@@ -57,6 +64,7 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
             EXPECTED_ACCOUNT_BALANCE_FILE1, EXPECTED_ACCOUNT_BALANCE_FILE2, EXPECTED_ACCOUNT_BALANCE_FILE_FIXED_OFFSET);
 
     private final AccountBalanceFileRepository accountBalanceFileRepository;
+    private final BlockProperties blockProperties;
     private final ContractResultRepository contractResultRepository;
     private final CryptoTransferRepository cryptoTransferRepository;
     private final EntityProperties entityProperties;
@@ -73,6 +81,7 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
 
     @AfterEach
     void teardown() {
+        blockProperties.setEnabled(false);
         importerProperties.setEndDate(Utility.MAX_INSTANT_LONG);
         importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
         importerProperties.setStartDate(Instant.EPOCH);
@@ -164,6 +173,36 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
 
         assertThat(entityProperties.getPersist().isEntityHistory()).isTrue();
         assertThat(entityProperties.getPersist().isTrackBalance()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void skipWhenIngestedFromBlockstream(final boolean wrapped) {
+        // given
+        domainBuilder
+                .recordFile()
+                .customize(r -> {
+                    if (wrapped) {
+                        r.wrappedRecordBlockHash(domainBuilder.bytes(48))
+                                .previousWrappedRecordBlockHash(domainBuilder.bytes(48));
+                    } else {
+                        r.version(BlockStreamReader.VERSION);
+                    }
+                })
+                .persist();
+
+        // when, then
+        assertThat(errataMigration.skipMigration(mock(Configuration.class))).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, true
+            false, false
+            """)
+    void skipWithBlockStreamConfig(final boolean enabled, final boolean shouldSkip) {
+        blockProperties.setEnabled(enabled);
+        assertThat(errataMigration.skipMigration(mock(Configuration.class))).isEqualTo(shouldSkip);
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.importer.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
@@ -14,20 +15,24 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
 import org.hiero.mirror.importer.repository.EntityRepository;
 import org.hiero.mirror.importer.util.Utility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @RequiredArgsConstructor
-class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
+final class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
 
     // These are the three accounts present in the test accountInfo.txt.gz
     private static final long ACCOUNT_ID1 = 2977L;
@@ -37,6 +42,7 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
     private static final int CONTRACT_COUNT = 1;
     private static final int ENTITY_COUNT = 3;
 
+    private final BlockProperties blockProperties;
     private final HistoricalAccountInfoMigration historicalAccountInfoMigration;
     private final EntityRepository entityRepository;
     private final ImporterProperties importerProperties;
@@ -52,8 +58,10 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
 
     @AfterEach
     void after() {
+        blockProperties.setEnabled(false);
         importerProperties.setImportHistoricalAccountInfo(false);
         importerProperties.setNetwork(network);
+        importerProperties.setStartBlockNumber(null);
     }
 
     @Test
@@ -120,6 +128,37 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
         historicalAccountInfoMigration.doMigrate();
 
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrderElementsOf(entities);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, true
+            1, false
+            """)
+    void skipWhenFirstBlockIsWrb(final long blockNumber, final boolean shouldSkip) {
+        // given
+        domainBuilder
+                .recordFile()
+                .customize(r -> r.index(blockNumber).wrappedRecordBlockHash(domainBuilder.bytes(48)))
+                .persist();
+
+        // when / then
+        assertThat(historicalAccountInfoMigration.skipMigration(mock(Configuration.class)))
+                .isEqualTo(shouldSkip);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, , true
+            true, 0, true
+            true, 2, false
+            false, , false
+            """)
+    void skipWithBlockStreamConfig(final boolean blockEnabled, final Long startBlockNumber, final boolean shouldSkip) {
+        blockProperties.setEnabled(blockEnabled);
+        importerProperties.setStartBlockNumber(startBlockNumber);
+        assertThat(historicalAccountInfoMigration.skipMigration(mock(Configuration.class)))
+                .isEqualTo(shouldSkip);
     }
 
     @Test
@@ -259,7 +298,8 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void skipMigrationFalse() {
-        assertThat(historicalAccountInfoMigration.skipMigration(null)).isFalse();
+        assertThat(historicalAccountInfoMigration.skipMigration(mock(Configuration.class)))
+                .isFalse();
     }
 
     @SuppressWarnings("deprecation")

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -6,12 +6,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.common.domain.entity.EntityType.CONTRACT;
 import static org.hiero.mirror.common.domain.entity.EntityType.TOPIC;
 import static org.hiero.mirror.common.domain.entity.EntityType.UNKNOWN;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Range;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.configuration.Configuration;
 import org.hiero.mirror.common.domain.balance.AccountBalance;
 import org.hiero.mirror.common.domain.balance.AccountBalanceFile;
 import org.hiero.mirror.common.domain.entity.Entity;
@@ -20,16 +22,21 @@ import org.hiero.mirror.common.domain.transaction.ErrataType;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.downloader.block.BlockProperties;
+import org.hiero.mirror.importer.reader.block.BlockStreamReader;
 import org.hiero.mirror.importer.repository.AccountBalanceFileRepository;
 import org.hiero.mirror.importer.repository.AccountBalanceRepository;
 import org.hiero.mirror.importer.repository.CryptoTransferRepository;
 import org.hiero.mirror.importer.repository.EntityRepository;
 import org.hiero.mirror.importer.repository.RecordFileRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +44,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @RequiredArgsConstructor
 @Tag("migration")
-class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
+final class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
 
     private static final String DELETE_ACCOUNT_BALANCE_SQL =
             "delete from account_balance where consensus_timestamp <= ?";
@@ -46,8 +53,11 @@ class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
 
     private final AccountBalanceFileRepository accountBalanceFileRepository;
     private final AccountBalanceRepository accountBalanceRepository;
+    private final BlockProperties blockProperties;
+    private final BlockStreamResolver blockStreamResolver;
     private final CryptoTransferRepository cryptoTransferRepository;
     private final EntityRepository entityRepository;
+    private final Environment environment;
     private final ImporterProperties importerProperties;
     private final NamedParameterJdbcOperations namedParameterJdbcOperations;
     private final RecordFileRepository recordFileRepository;
@@ -74,10 +84,17 @@ class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
         var transactionTemplateProvider = objectProvider(transactionTemplate);
         migration = new InitializeEntityBalanceMigration(
                 accountBalanceFileRepositoryProvider,
+                blockStreamResolver,
+                environment,
                 importerProperties,
                 namedParameterJdbcOperationsProvider,
                 recordFileRepositoryProvider,
                 transactionTemplateProvider);
+    }
+
+    @AfterEach
+    void teardown() {
+        blockProperties.setEnabled(false);
     }
 
     @Test
@@ -116,6 +133,36 @@ class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
         setExpectedBalance();
         assertThat(entityRepository.findAll())
                 .containsExactlyInAnyOrder(account, account2, accountDeleted, contract, topic);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void skipWhenIngestedFromBlockstream(final boolean wrapped) {
+        // given
+        domainBuilder
+                .recordFile()
+                .customize(r -> {
+                    if (wrapped) {
+                        r.wrappedRecordBlockHash(domainBuilder.bytes(48))
+                                .previousWrappedRecordBlockHash(domainBuilder.bytes(48));
+                    } else {
+                        r.version(BlockStreamReader.VERSION);
+                    }
+                })
+                .persist();
+
+        // when, then
+        assertThat(migration.skipMigration(mock(Configuration.class))).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, true
+            false, false
+            """)
+    void skipWithBlockStreamConfig(final boolean enabled, final boolean shouldSkip) {
+        blockProperties.setEnabled(enabled);
+        assertThat(migration.skipMigration(mock(Configuration.class))).isEqualTo(shouldSkip);
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
@@ -37,18 +37,21 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @RequiredArgsConstructor
-class EntityStakeCalculatorIntegrationTest extends ImporterIntegrationTest {
+final class EntityStakeCalculatorIntegrationTest extends ImporterIntegrationTest {
 
     private final EntityProperties entityProperties;
     private final EntityRecordItemListener entityRecordItemListener;
     private final EntityStakeRepository entityStakeRepository;
     private final RecordItemBuilder recordItemBuilder;
     private final RecordStreamFileListener recordStreamFileListener;
+    private final StakingProperties stakingProperties;
     private final TransactionTemplate transactionTemplate;
 
     @BeforeEach
     void setup() {
         entityProperties.getPersist().setPendingReward(true);
+        stakingProperties.setChunkDelay(Durations.ONE_HUNDRED_MILLISECONDS);
+        stakingProperties.setChunkSize(100_000_000);
     }
 
     @AfterEach

--- a/tools/blockstream/verify-block-streams-bucket-access.sh
+++ b/tools/blockstream/verify-block-streams-bucket-access.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+set -o pipefail
+
+# ---- static config --------------------------------------------------------
+
+GCS_ENDPOINT="https://storage.googleapis.com"
+GCS_USER_PROJECT_HEADER="x-amz-user-project"
+
+# network -> bucket name (shared across AWS and GCS)
+declare -A BUCKETS=(
+  [mainnet]="hedera-mainnet-recent-block-streams"
+  [testnet]="hedera-testnet-recent-block-streams"
+  [previewnet]="hedera-previewnet-recent-block-streams"
+)
+
+# ---- defaults / state -----------------------------------------------------
+
+PROVIDER=""
+NETWORK=""
+ACCESS_KEY=""
+SECRET_KEY=""
+AWS_REGION_ARG=""
+GCS_BILLING_PROJECT=""
+USE_RANGE=1
+VERBOSE=0
+
+FAIL_COUNT=0
+RESULTS=()   # "network|provider|op|status|detail"
+
+# ---- usage ----------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Usage: verify-block-streams-bucket-access.sh [options]
+
+Verifies LIST and GET (requester-pays) access to a chosen Hedera recent-block-
+stream bucket (mainnet, testnet or previewnet), on AWS or GCS.
+
+Options:
+  -p, --provider <aws|gcs>        Which cloud to check           (required)
+  -n, --network  <name>           mainnet|testnet|previewnet     (required)
+      --access-key <key>          Access key id / HMAC key   (required)
+      --secret-key <secret>       Secret key / HMAC secret   (required)
+      --region <region>           AWS region for the bucket (if needed)
+      --project <gcp-project-id>  GCS billing project (required for gcs)
+      --no-range                  Do a full GET instead of a bytes=0-0 ranged GET
+  -v, --verbose                   Print the operation/target for each check
+  -h, --help                      Show this help
+
+Explicit access key and secret key are always required for the chosen provider,
+supplied via the flags above. Note that command-line secrets are visible in the
+process list on shared hosts. The script passes credentials to aws/awscurl via
+the environment internally (never on their argv).
+
+Examples:
+  # AWS, testnet
+  ./verify-block-streams-bucket-access.sh -p aws -n testnet \
+      --access-key AKIA... --secret-key ...
+
+  # GCS, previewnet
+  ./verify-block-streams-bucket-access.sh -p gcs -n previewnet --project my-gcp-project \
+      --access-key GOOG... --secret-key ...
+EOF
+}
+
+log()  { printf '%s\n' "$*" >&2; }
+vlog() { (( VERBOSE )) && printf '%s\n' "$*" >&2; }
+die()  { printf 'Error: %s\n' "$*" >&2; exit 2; }
+
+record() { # network provider op status detail
+  RESULTS+=("$1|$2|$3|$4|$5")
+  [[ "$4" == "FAIL" ]] && ((FAIL_COUNT++))
+  printf '  [%-4s] %-10s %-4s %-4s  %s\n' "$4" "$1" "$2" "$3" "$5"
+}
+
+# ---- arg parsing ----------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--provider)    PROVIDER="${2:-}"; shift 2 ;;
+    -n|--network)     NETWORK="${2:-}"; shift 2 ;;
+    --access-key)     ACCESS_KEY="${2:-}"; shift 2 ;;
+    --secret-key)     SECRET_KEY="${2:-}"; shift 2 ;;
+    --region)         AWS_REGION_ARG="${2:-}"; shift 2 ;;
+    --project)        GCS_BILLING_PROJECT="${2:-}"; shift 2 ;;
+    --no-range)       USE_RANGE=0; shift ;;
+    -v|--verbose)     VERBOSE=1; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *) die "unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+case "$PROVIDER" in
+  aws|gcs) ;;
+  "") die "a provider is required: choose aws or gcs (-p)" ;;
+  *) die "--provider must be aws or gcs" ;;
+esac
+
+if [[ -z "$NETWORK" ]]; then
+  die "a network is required: choose one of mainnet, testnet, previewnet (-n)"
+elif [[ -n "${BUCKETS[$NETWORK]:-}" ]]; then
+  SELECTED_NETWORK="$NETWORK"
+else
+  die "--network must be one of: mainnet, testnet, previewnet"
+fi
+
+want_aws() { [[ "$PROVIDER" == "aws" ]]; }
+want_gcs() { [[ "$PROVIDER" == "gcs" ]]; }
+
+# ---- dependency / credential preflight ------------------------------------
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required tool not found: $1"; }
+
+if want_aws; then
+  need aws
+fi
+
+if want_gcs; then
+  need awscurl
+  need xmllint
+  [[ -n "$GCS_BILLING_PROJECT" ]] || \
+    die "GCS billing project required (use --project)"
+fi
+
+[[ -n "$ACCESS_KEY" && -n "$SECRET_KEY" ]] || \
+  die "access key and secret key required (use --access-key and --secret-key)"
+
+# ---- temp workspace -------------------------------------------------------
+
+TMPDIR_RUN="$(mktemp -d "${TMPDIR:-/tmp}/blkverify.XXXXXX")"
+cleanup() { rm -rf "$TMPDIR_RUN"; }
+trap cleanup EXIT
+OUT="$TMPDIR_RUN/out"
+ERR="$TMPDIR_RUN/err"
+
+# first non-empty line of stderr, for compact error reporting
+err_summary() {
+  local line
+  line="$(grep -v '^[[:space:]]*$' "$ERR" 2>/dev/null | tail -n 1)"
+  [[ -n "$line" ]] && printf '%s' "$line"
+}
+
+# ---- AWS checks -----------------------------------------------------------
+
+aws_base_opts() {
+  local -a opts=(--request-payer requester)
+  [[ -n "$AWS_REGION_ARG" ]] && opts+=(--region "$AWS_REGION_ARG")
+  printf '%s\n' "${opts[@]}"
+}
+
+# Run the aws CLI with explicit credentials injected via the environment
+# (not argv). AWS_PROFILE is unset so the explicit keys are always used.
+aws_cli() {
+  env -u AWS_PROFILE \
+      "AWS_ACCESS_KEY_ID=$ACCESS_KEY" \
+      "AWS_SECRET_ACCESS_KEY=$SECRET_KEY" \
+      aws "$@"
+}
+
+check_aws() {
+  local net="$1" bucket="$2" key=""
+  local -a opts=()
+  while IFS= read -r o; do opts+=("$o"); done < <(aws_base_opts)
+
+  # --- LIST ---
+  vlog "aws s3api list-objects-v2 --bucket $bucket --max-keys 1 (requester pays)"
+  key="$(aws_cli s3api list-objects-v2 \
+            --bucket "$bucket" --max-keys 1 \
+            "${opts[@]}" \
+            --query 'Contents[0].Key' --output text 2>"$ERR")"
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    record "$net" aws list FAIL "$(err_summary)"
+    return
+  fi
+  if [[ -z "$key" || "$key" == "None" ]]; then
+    record "$net" aws list PASS "bucket empty (no objects returned)"
+    record "$net" aws get  SKIP "no object available to read"
+    return
+  fi
+  record "$net" aws list PASS "first key: $key"
+
+  # --- GET (first object returned by list) ---
+  local target="$key"
+  local -a getopts=("${opts[@]}")
+  (( USE_RANGE )) && getopts+=(--range "bytes=0-0")
+  vlog "aws s3api get-object --bucket $bucket --key $target (requester pays$( ((USE_RANGE)) && echo ', ranged' ))"
+  aws_cli s3api get-object \
+        --bucket "$bucket" --key "$target" \
+        "${getopts[@]}" \
+        "$OUT" >/dev/null 2>"$ERR"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    # A successful GET confirms read access, even when the object has 0 bytes.
+    if [[ -s "$OUT" ]]; then
+      record "$net" aws get PASS "read $target"
+    else
+      record "$net" aws get PASS "read $target (empty object)"
+    fi
+  else
+    # A ranged read of a 0-byte object is rejected with InvalidRange (HTTP 416);
+    # that still proves access (a permission failure returns 403, not 416). The
+    # aws CLI prints a multi-line error, so scan the whole stderr, not just the
+    # summary line.
+    if grep -qiE 'InvalidRange|not satisfiable|ActualObjectSize|\b416\b' "$ERR"; then
+      record "$net" aws get PASS "read $target (empty object, range not satisfiable)"
+    else
+      record "$net" aws get FAIL "$(err_summary)"
+    fi
+  fi
+  rm -f "$OUT"
+}
+
+# ---- GCS checks -----------------------------------------------------------
+
+# Run awscurl against GCS. stdout -> $1, stderr -> $2, extra args follow.
+# Credentials are passed via the environment (not argv) and AWS_PROFILE is
+# unset so the explicit HMAC key is always used.
+gcs_awscurl() {
+  local outf="$1" errf="$2"; shift 2
+  env -u AWS_PROFILE \
+      "AWS_ACCESS_KEY_ID=$ACCESS_KEY" \
+      "AWS_SECRET_ACCESS_KEY=$SECRET_KEY" \
+      awscurl \
+      --service s3 --region auto \
+      -H "${GCS_USER_PROJECT_HEADER}: ${GCS_BILLING_PROJECT}" \
+      "$@" >"$outf" 2>"$errf"
+}
+
+# Is the response body an S3/GCS XML error document?
+is_xml_error() {
+  grep -q "<Error>" "$1" 2>/dev/null && grep -q "<Code>" "$1" 2>/dev/null
+}
+xml_error_text() {
+  local code msg
+  code="$(xmllint --xpath "string(/*[local-name()='Error']/*[local-name()='Code'])" "$1" 2>/dev/null)"
+  msg="$(xmllint  --xpath "string(/*[local-name()='Error']/*[local-name()='Message'])" "$1" 2>/dev/null)"
+  printf '%s' "${code:-error}${msg:+: $msg}"
+}
+
+check_gcs() {
+  local net="$1" bucket="$2" key=""
+  local listout="$TMPDIR_RUN/list.xml"
+
+  # --- LIST ---
+  vlog "GET $GCS_ENDPOINT/$bucket?list-type=2&max-keys=1 (x-amz-user-project: $GCS_BILLING_PROJECT)"
+  gcs_awscurl "$listout" "$ERR" \
+      "${GCS_ENDPOINT}/${bucket}?list-type=2&max-keys=1"
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    record "$net" gcs list FAIL "awscurl rc=$rc${ERR:+; $(err_summary)}"
+    return
+  fi
+  if is_xml_error "$listout"; then
+    record "$net" gcs list FAIL "$(xml_error_text "$listout")"
+    return
+  fi
+  if ! grep -q "ListBucketResult" "$listout"; then
+    record "$net" gcs list FAIL "unexpected response (no ListBucketResult)"
+    return
+  fi
+  key="$(xmllint --xpath "string((//*[local-name()='Contents']/*[local-name()='Key'])[1])" "$listout" 2>/dev/null)"
+  if [[ -z "$key" ]]; then
+    record "$net" gcs list PASS "bucket empty (no objects returned)"
+    record "$net" gcs get  SKIP "no object available to read"
+    return
+  fi
+  record "$net" gcs list PASS "first key: $key"
+
+  # --- GET (first object returned by list) ---
+  local target="$key"
+  local -a rangehdr=()
+  (( USE_RANGE )) && rangehdr=(-H "Range: bytes=0-0")
+  vlog "GET $GCS_ENDPOINT/$bucket/$target$( ((USE_RANGE)) && echo ' (ranged)' )"
+  gcs_awscurl "$OUT" "$ERR" "${rangehdr[@]}" "${GCS_ENDPOINT}/${bucket}/${target}"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    record "$net" gcs get FAIL "awscurl rc=$rc${ERR:+; $(err_summary)}"
+  elif is_xml_error "$OUT"; then
+    # A ranged read of a 0-byte object is rejected with InvalidRange (HTTP 416);
+    # that still proves access (a permission failure returns 403, not 416).
+    if grep -qiE 'InvalidRange|not satisfiable|ActualObjectSize|\b416\b' "$OUT"; then
+      record "$net" gcs get PASS "read $target (empty object, range not satisfiable)"
+    else
+      record "$net" gcs get FAIL "$(xml_error_text "$OUT")"
+    fi
+  elif [[ -s "$OUT" ]]; then
+    record "$net" gcs get PASS "read $target"
+  else
+    # An empty body with no XML error means the object was read and has 0 bytes.
+    record "$net" gcs get PASS "read $target (empty object)"
+  fi
+  rm -f "$OUT"
+}
+
+# ---- run ------------------------------------------------------------------
+
+printf 'Verifying requester-pays access  provider=%s  network=%s%s\n' \
+  "$PROVIDER" "$SELECTED_NETWORK" \
+  "$( ((USE_RANGE)) && echo '  (ranged get)' )"
+log ""
+
+net="$SELECTED_NETWORK"
+bucket="${BUCKETS[$net]}"
+printf '%s  (%s)\n' "$net" "$bucket"
+if want_aws; then check_aws "$net" "$bucket"; fi
+if want_gcs; then check_gcs "$net" "$bucket"; fi
+log ""
+
+# ---- summary --------------------------------------------------------------
+
+printf 'Summary\n'
+pass=0; fail=0; skip=0
+for r in "${RESULTS[@]}"; do
+  IFS='|' read -r _n _p _o status _d <<<"$r"
+  case "$status" in PASS) ((pass++));; FAIL) ((fail++));; SKIP) ((skip++));; esac
+done
+printf '  PASS=%d  FAIL=%d  SKIP=%d\n' "$pass" "$fail" "$skip"
+
+if (( FAIL_COUNT > 0 )); then
+  printf 'One or more checks failed.\n'
+  exit 1
+fi
+printf 'All checks passed.\n'
+exit 0


### PR DESCRIPTION
**Description**:

This PR adds logic to skip historical migrations when importer starts with blockstream:

- Skip `HistoricalAccountInfoMigration` when importer started / will start with genesis WRB
- Skip `BlockNumberMigration`, `ErrataMigration`, and `InitializeEntityBalanceMigration` when importer started / will start with blockstream
- Remove stale testnet data from `BlockNumberMigration`
- Fix flaky `EntityStakeCalculatorIntegrationTest`
- Add runbook and script for third-party operators to verify access to recent block streams buckets

**Related issue(s)**:

Fixes #13651 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
