### PR TITLE
Add validation message in GRPC that can resolve for native image build (0.158)

### DIFF
--- a/grpc/src/main/java/org/hiero/mirror/grpc/domain/TopicMessageFilter.java
+++ b/grpc/src/main/java/org/hiero/mirror/grpc/domain/TopicMessageFilter.java
@@ -22,18 +22,18 @@ public class TopicMessageFilter {
 
     private Long endTime;
 
-    @Min(0)
+    @Min(value = 0, message = "must be greater than or equal to 0")
     private long limit;
 
-    @Min(0)
-    @NotNull
+    @Min(value = 0, message = "must be greater than or equal to 0")
+    @NotNull(message = "must not be null")
     @Builder.Default
     private long startTime = DomainUtils.now();
 
     @Builder.Default
     private String subscriberId = RandomStringUtils.random(8, 0, 0, true, true, null, RANDOM);
 
-    @NotNull
+    @NotNull(message = "must not be null")
     private EntityId topicId;
 
     public boolean hasLimit() {

--- a/grpc/src/test/java/org/hiero/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/grpc/src/test/java/org/hiero/mirror/grpc/controller/ConsensusControllerTest.java
@@ -74,6 +74,7 @@ class ConsensusControllerTest extends GrpcIntegrationTest {
                     iterator.hasNext();
                 })
                 .isInstanceOf(StatusRuntimeException.class)
+                .hasMessageContaining("subscribeTopic.filter.topicId: must not be null")
                 .extracting(t -> ((StatusRuntimeException) t).getStatus().getCode())
                 .isEqualTo(Status.Code.INVALID_ARGUMENT);
     }


### PR DESCRIPTION
**Description**:
This PR cherry-picks the release to 0.158.

With native image build some template messages are not resolved correctly. This PR adds a validation message that could be resolved. Tested locally with solo.

Fixes #13823 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
