### PR TITLE
Fix INSUFFICIENT_TX_FEE error on contract create (0.158.0)

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/TransactionExecutionService.java
@@ -58,7 +58,7 @@ import org.hyperledger.besu.datatypes.Address;
 public class TransactionExecutionService {
 
     private static final Duration TRANSACTION_DURATION = new Duration(15);
-    private static final long CONTRACT_CREATE_TX_FEES = 1_000_000_000L;
+    private static final long TX_FEE = 100_000_000_000L;
     private static final String SENDER_NOT_FOUND = "Sender account not found.";
 
     private final AccountReadableKVState accountReadableKVState;
@@ -178,7 +178,7 @@ public class TransactionExecutionService {
                         .gas(estimatedGas)
                         .autoRenewPeriod(new Duration(maxLifetime))
                         .build())
-                .transactionFee(CONTRACT_CREATE_TX_FEES)
+                .transactionFee(TX_FEE)
                 .build();
     }
 
@@ -195,6 +195,7 @@ public class TransactionExecutionService {
                         .amount(params.getValue()) // tinybars sent to contract
                         .gas(estimatedGas)
                         .build())
+                .transactionFee(TX_FEE)
                 .build();
     }
 
@@ -204,7 +205,7 @@ public class TransactionExecutionService {
                         .ethereumData(Bytes.wrap(params.getEthereumData()))
                         .maxGasAllowance(Long.MAX_VALUE)
                         .build())
-                .transactionFee(CONTRACT_CREATE_TX_FEES)
+                .transactionFee(TX_FEE)
                 .build();
 
         patchSenderNonce(params);


### PR DESCRIPTION
**Description**:

This PR fixes an issue related to throwing INSUFFICIENT_TX_FEE when deploying large contracts in a simulated eth_call/eth_estimateGas call.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
