### PR TITLE
Fix monitor test failure in CI

### DIFF
--- a/charts/hedera-mirror/ci/v1-values.yaml
+++ b/charts/hedera-mirror/ci/v1-values.yaml
@@ -22,7 +22,6 @@ rest:
   monitor:
     config:
       contract:
-        call: false  # Temporary until #12049
         limit: 2
         logs: false
       freshness: false

--- a/charts/hedera-mirror/ci/v1-values.yaml
+++ b/charts/hedera-mirror/ci/v1-values.yaml
@@ -23,6 +23,7 @@ rest:
     config:
       contract:
         call: false  # Temporary until #12049
+        limit: 2
         logs: false
       freshness: false
       interval: 5

--- a/charts/hedera-mirror/ci/v2-values.yaml
+++ b/charts/hedera-mirror/ci/v2-values.yaml
@@ -28,6 +28,7 @@ rest:
     config:
       contract:
         call: false  # Temporary until #12049
+        limit: 2
         logs: false
       freshness: false
       interval: 5

--- a/charts/hedera-mirror/ci/v2-values.yaml
+++ b/charts/hedera-mirror/ci/v2-values.yaml
@@ -27,7 +27,6 @@ rest:
   monitor:
     config:
       contract:
-        call: false  # Temporary until #12049
         limit: 2
         logs: false
       freshness: false


### PR DESCRIPTION
**Description**:

This PR fixes monitor test failure in CI

- Enable contract call monitor check
- Set monitor contract limit to 2

**Related issue(s)**:

Fixes #13834 

**Notes for reviewer**:

The default value of `contract.limit` was increased from 2 to 15 because `contracts/results` will include those made from synthetic contract logs. The limit also applies to `/contracts` endpoint. The data from demo bucket doesn't have 15 contracts so it'll always fail.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
