### PR TITLE
Remove dead  override clauses from all envs

### DIFF
--- a/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
@@ -73,11 +73,6 @@ spec:
         HIERO_MIRROR_MONITOR_NETWORK: "MAINNET"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.368908"
         HIERO_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.368908"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       env:
         HIERO_MIRROR_REST_CHAINID: "0x127"

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -70,11 +70,6 @@ spec:
         HIERO_MIRROR_MONITOR_NETWORK: "MAINNET"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.368908"
         HIERO_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.368908"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       env:
         HIERO_MIRROR_REST_CHAINID: "0x127"

--- a/clusters/mainnet-staging-eu/mainnet/helmrelease.yaml
+++ b/clusters/mainnet-staging-eu/mainnet/helmrelease.yaml
@@ -48,11 +48,6 @@ spec:
         HEDERA_MIRROR_MONITOR_NETWORK: "MAINNET"
         HEDERA_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.797576"
         HEDERA_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.797576"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     postgresql:
       enabled: false
     redis:

--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -58,11 +58,6 @@ spec:
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.798453"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.02"
         HIERO_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.798453"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
       replicas: 0
     rest:
       env:

--- a/clusters/preprod/dev/helmrelease.yaml
+++ b/clusters/preprod/dev/helmrelease.yaml
@@ -41,13 +41,6 @@ spec:
       env:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     postgresql:
       enabled: false
     rest:

--- a/clusters/preprod/integration-docker/helmrelease.yaml
+++ b/clusters/preprod/integration-docker/helmrelease.yaml
@@ -41,13 +41,6 @@ spec:
       env:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     postgresql:
       enabled: false
     rest:

--- a/clusters/preprod/integration/helmrelease.yaml
+++ b/clusters/preprod/integration/helmrelease.yaml
@@ -50,13 +50,6 @@ spec:
       env:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "1"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     postgresql:
       enabled: false
     restjava:

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -49,13 +49,6 @@ spec:
     monitor:
       env:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         enabled: false

--- a/clusters/previewnet/previewnet-citus/helmrelease.yaml
+++ b/clusters/previewnet/previewnet-citus/helmrelease.yaml
@@ -55,13 +55,6 @@ spec:
         HIERO_MIRROR_MONITOR_NETWORK: "PREVIEWNET"
         HIERO_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "false"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       env:
         HIERO_MIRROR_REST_CHAINID: "0x129"

--- a/clusters/staging-council/staging-council/helmrelease.yaml
+++ b/clusters/staging-council/staging-council/helmrelease.yaml
@@ -53,13 +53,6 @@ spec:
       env:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         test:

--- a/clusters/staging-lg/staging-lg/helmrelease.yaml
+++ b/clusters/staging-lg/staging-lg/helmrelease.yaml
@@ -54,13 +54,6 @@ spec:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_NODEVALIDATION_ENABLED: "false"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         test:

--- a/clusters/staging-sm/staging-sm/helmrelease.yaml
+++ b/clusters/staging-sm/staging-sm/helmrelease.yaml
@@ -54,13 +54,6 @@ spec:
         HIERO_MIRROR_MONITOR_NETWORK: "OTHER"
         HIERO_MIRROR_MONITOR_NODEVALIDATION_ENABLED: "false"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.5"
-      prometheusRules:
-        MonitorPublishErrors:
-          enabled: false
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         test:

--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -70,11 +70,6 @@ spec:
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.1926"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.25"
         HIERO_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.1926"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         config:

--- a/clusters/testnet-na/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-na/testnet-citus/helmrelease.yaml
@@ -73,11 +73,6 @@ spec:
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_PROPERTIES_TOPICID: "0.0.1926"
         HIERO_MIRROR_MONITOR_PUBLISH_SCENARIOS_PINGER_TPS: "0.25"
         HIERO_MIRROR_MONITOR_SUBSCRIBE_GRPC_HCS_TOPICID: "0.0.1926"
-      prometheusRules:
-        MonitorPublishLatency:
-          enabled: false
-        MonitorSubscribeLatency:
-          enabled: false
     rest:
       monitor:
         config:


### PR DESCRIPTION
**Description**:
- Remove dead `monitor.prometheusRules.*` overrides from the HelmReleases; they are no longer consumed since the charts' `prometheusRules` entries were removed.

**Related issue(s)**:
- #13446 

**Notes for reviewer**:
Final cleanups of the disabled `prometheusRules:` blocks from our envs; this is in prep for the closure of the GC migration ticket.

**Checklist**
- Removals of `prometheusRules`, no longer being used nor required to override anything.
