### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ extra.apply {
     set("logback.version", "1.5.36") // Temporary until next Spring Boot
     set("mapStructVersion", "1.6.3")
     set("nodeJsVersion", "24.18.0")
+    set("postgresql.version", "42.7.13") // Temporary until next Spring Boot
     set("tomcat.version", "11.0.23") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -56,7 +56,12 @@ dependencies {
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.apache.commons:commons-math3")
     testImplementation("org.awaitility:awaitility")
-    testImplementation("org.gaul:s3proxy")
+    testImplementation("org.gaul:s3proxy") {
+        exclude(group = "com.github.openstack4j.core")
+        exclude(group = "com.github.openstack4j.core.connectors")
+        exclude(group = "com.google.cloud")
+        exclude(group = "io.opentelemetry")
+    }
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-flyway-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")


### PR DESCRIPTION
**Description**:

* Bump postgresql from 42.7.11 to 42.7.13
* Exclude vulnerable and unused dependencies from `org.gaul:s3proxy`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
