### PR TITLE
Bump vulnerable dependencies and fix web3 build (0.158)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ extra.apply {
     set("logback.version", "1.5.36") // Temporary until next Spring Boot
     set("mapStructVersion", "1.6.3")
     set("nodeJsVersion", "24.18.0")
+    set("postgresql.version", "42.7.13") // Temporary until next Spring Boot
     set("tomcat.version", "11.0.23") // Temporary until next Spring Boot
     set("tuweniVersion", "2.3.1")
 }

--- a/importer/build.gradle.kts
+++ b/importer/build.gradle.kts
@@ -56,7 +56,12 @@ dependencies {
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.apache.commons:commons-math3")
     testImplementation("org.awaitility:awaitility")
-    testImplementation("org.gaul:s3proxy")
+    testImplementation("org.gaul:s3proxy") {
+        exclude(group = "com.github.openstack4j.core")
+        exclude(group = "com.github.openstack4j.core.connectors")
+        exclude(group = "com.google.cloud")
+        exclude(group = "io.opentelemetry")
+    }
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-flyway-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/web3/build.gradle.kts
+++ b/web3/build.gradle.kts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import java.net.URI
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
@@ -102,10 +103,61 @@ if (!isNativeBuild) {
         }
     }
 
+    // web3j-sokt 0.6.0 resolves solc by downloading a release index from its main branch and
+    // strict-parsing it.
+    // That upstream file now contains keys the released parser rejects (e.g. linux_arm64_url on the
+    // 0.8.31 entry),
+    // so any solc resolution fails on a cold cache, including CI. SolidityCompile uses its
+    // `executable` directly
+    // when set and skips the sokt resolver, so download pinned solc binaries and point the compile
+    // tasks at them.
+    val testSolidityVersion = "0.8.30"
+    val solcAsset =
+        if (System.getProperty("os.name").lowercase().contains("mac")) "solc-macos"
+        else "solc-static-linux"
+
+    fun provisionSolc(solcVersion: String) =
+        tasks.register("provisionSolc${solcVersion.replace(".", "")}") {
+            description =
+                "Download solc $solcVersion, bypassing the broken web3j-sokt version resolver"
+            val solc = layout.buildDirectory.file("solc/solc-$solcVersion")
+            outputs.file(solc)
+            doLast {
+                val file = solc.get().asFile
+                file.parentFile.mkdirs()
+                val url =
+                    URI(
+                            "https://github.com/ethereum/solidity/releases/download/v$solcVersion/$solcAsset"
+                        )
+                        .toURL()
+                url.openStream().use { input ->
+                    file.outputStream().use { output -> input.copyTo(output) }
+                }
+                file.setExecutable(true)
+            }
+        }
+
+    val provisionTestSolc = provisionSolc(testSolidityVersion)
+    val provisionHistoricalSolc = provisionSolc(historicalSolidityVersion)
+
     val resolveSolidity = tasks.named("resolveSolidity")
 
+    tasks.named<SolidityCompile>("compileTestSolidity") {
+        dependsOn(provisionTestSolc)
+        executable.set(
+            layout.buildDirectory.file("solc/solc-$testSolidityVersion").map {
+                it.asFile.absolutePath
+            }
+        )
+    }
+
     tasks.named<SolidityCompile>("compileTestHistoricalSolidity") {
-        dependsOn(resolveSolidity)
+        dependsOn(resolveSolidity, provisionHistoricalSolc)
+        executable.set(
+            layout.buildDirectory.file("solc/solc-$historicalSolidityVersion").map {
+                it.asFile.absolutePath
+            }
+        )
 
         group = "historical"
         resolvedImports.set(


### PR DESCRIPTION
**Description**:

Cherry-pick of #13860 and #13866 to release/0.158:

* Bypass solc resolution issue on web3 compileTestHistoricalSolidity (#13866)
* Bump postgresql from 42.7.11 to 42.7.13
* Exclude vulnerable and unused dependencies from `org.gaul:s3proxy`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
