### PR TITLE
Fix root hash calculation over merkle paths in StateProof

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherImpl.java
@@ -15,9 +15,13 @@ import org.hiero.mirror.importer.exception.InvalidStreamFileException;
 @Named
 final class BlockStateProofHasherImpl implements BlockStateProofHasher {
 
-    private static final int DEPTH3_RIGHT_SIBLING_MODULAR_INDEX = 2;
-    private static final int MIN_PREVIOUS_BLOCK_ROOT_PATH_SIBLING_COUNT = 7;
-    private static final int SIBLING_GROUP_SIZE = 4;
+    // The merkle path 1 carries the current block's root hash and the sibling nodes leading up to the signed block's
+    // depth1 right child node. The signed block's timestamp leaf lives in the first merkle path (index 0).
+    private static final int BLOCK_CONTENTS_PATH_INDEX = 1;
+    // Each block contributes 3 real sibling nodes plus a null-hash sentinel for the single-child internal node wrap.
+    // The signed block contributes only those (its timestamp is in the first merkle path), so the minimum sibling
+    // count is 4, corresponding to the current block being directly proven by the immediately following signed block.
+    private static final int MIN_SIBLING_COUNT = 4;
 
     @Override
     public byte[] getRootHash(
@@ -27,42 +31,40 @@ final class BlockStateProofHasherImpl implements BlockStateProofHasher {
                     "Number of merkle paths in block %d's StateProof is not 3".formatted(blockNumber));
         }
 
-        final var depth1RightPath = merklePaths.get(1);
-        // Sibling nodes are grouped in 4, with the last 3 and the timestamp leaf in the first merkle path forming
-        // the last group. Since the second merkle path is from the previous block root, there should be at least
-        // 7 sibling nodes: the hash and the first 4 sibling nodes lead to the current block's root, the next 3
-        // sibling nodes and the timestamp leaf then lead to the block's root the TSS signature is for.
-        final var siblings = depth1RightPath.getSiblingsList();
-        if (siblings.size() < MIN_PREVIOUS_BLOCK_ROOT_PATH_SIBLING_COUNT) {
-            throw new InvalidStreamFileException(
-                    "Block %d's merkle path from the previous block root has less than %d siblings"
-                            .formatted(blockNumber, MIN_PREVIOUS_BLOCK_ROOT_PATH_SIBLING_COUNT));
+        // The merkle path 1 starts from the current block's own root hash, which must match the hash independently
+        // computed for the block.
+        final var blockContentsPath = merklePaths.get(BLOCK_CONTENTS_PATH_INDEX);
+        byte[] hash = toBytes(blockContentsPath.getHash());
+        if (!Arrays.equals(hash, currentRootHash)) {
+            throw new InvalidStreamFileException("Block %d root hash mismatch: expected=%s, actual=%s"
+                    .formatted(blockNumber, Hex.encodeHexString(currentRootHash), Hex.encodeHexString(hash)));
         }
 
+        final var siblings = blockContentsPath.getSiblingsList();
+        if (siblings.size() < MIN_SIBLING_COUNT) {
+            throw new InvalidStreamFileException("Block %d's block contents merkle path has less than %d siblings"
+                    .formatted(blockNumber, MIN_SIBLING_COUNT));
+        }
+
+        // Walk the sibling nodes up the tree. Starting from the current block's root hash, each subsequent block
+        // contributes its right sibling nodes, a null-hash sentinel encoding the single-child internal node wrap,
+        // and (for intermediate blocks only) its timestamp as a left sibling to reach that block's root - which in
+        // turn is the left-most leaf of the next block. The last block is the signed block, whose timestamp is
+        // instead applied below via the first merkle path.
         final var digest = createSha384Digest();
-        byte[] hash = toBytes(depth1RightPath.getHash());
-        for (int i = 0; i < siblings.size(); i++) {
-            final var sibling = siblings.get(i);
+        for (final var sibling : siblings) {
             final byte[] siblingHash = toBytes(sibling.getHash());
-            final byte[] leftChild = sibling.getIsLeft() ? siblingHash : hash;
-            final byte[] rightChild = !sibling.getIsLeft() ? siblingHash : hash;
-            hash = HashUtils.hashInternalNode(digest, leftChild, rightChild);
-
-            if (i % SIBLING_GROUP_SIZE == DEPTH3_RIGHT_SIBLING_MODULAR_INDEX) {
-                // We get the depth2 left node's hash after processing the depth3 right sibling node. The depth2 left
-                // node is the depth1 right node's single child, and it's implicit. Directly calculate the node's hash
+            if (siblingHash.length == 0) {
+                // Null-hash sentinel: apply the single-child internal node wrap.
                 hash = HashUtils.hashInternalNode(digest, hash);
-            }
-
-            if (i == SIBLING_GROUP_SIZE - 1) {
-                // End of the first 4-sibling group, the hash should match the current root hash
-                if (!Arrays.equals(hash, currentRootHash)) {
-                    throw new InvalidStreamFileException("Block %d root hash mismatch: expected=%s, actual=%s"
-                            .formatted(blockNumber, Hex.encodeHexString(currentRootHash), Hex.encodeHexString(hash)));
-                }
+            } else if (sibling.getIsLeft()) {
+                hash = HashUtils.hashInternalNode(digest, siblingHash, hash);
+            } else {
+                hash = HashUtils.hashInternalNode(digest, hash, siblingHash);
             }
         }
 
+        // Combine the signed block's timestamp leaf (first merkle path) with the accumulated hash to get its root.
         final byte[] depth1Left =
                 HashUtils.hashLeaf(digest, toBytes(merklePaths.getFirst().getTimestampLeaf()));
         return HashUtils.hashInternalNode(digest, depth1Left, hash);

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherImpl.java
@@ -64,7 +64,6 @@ final class BlockStateProofHasherImpl implements BlockStateProofHasher {
             }
         }
 
-        // Combine the signed block's timestamp leaf (first merkle path) with the accumulated hash to get its root.
         final byte[] depth1Left =
                 HashUtils.hashLeaf(digest, toBytes(merklePaths.getFirst().getTimestampLeaf()));
         return HashUtils.hashInternalNode(digest, depth1Left, hash);

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/block/hash/BlockStateProofHasherTest.java
@@ -54,6 +54,7 @@ final class BlockStateProofHasherTest {
     @Test
     void getHashThrowWhenLessThanMinSiblings() {
         // given
+        final byte[] rootHash = TestUtils.generateRandomByteArray(48);
         final var merklePaths = List.of(
                 MerklePath.newBuilder()
                         .setNextPathIndex(2)
@@ -63,16 +64,16 @@ final class BlockStateProofHasherTest {
                                 .toByteString())
                         .build(),
                 MerklePath.newBuilder()
-                        .setHash(fromBytes(TestUtils.generateRandomByteArray(48)))
+                        .setHash(fromBytes(rootHash))
                         .setNextPathIndex(2)
                         .addSiblings(SiblingNode.newBuilder().build())
                         .build(),
                 MerklePath.newBuilder().setNextPathIndex(-1).build());
 
         // when, then
-        assertThatThrownBy(() -> hasher.getRootHash(0, TestUtils.generateRandomByteArray(48), merklePaths))
+        assertThatThrownBy(() -> hasher.getRootHash(0, rootHash, merklePaths))
                 .isInstanceOf(InvalidStreamFileException.class)
-                .hasMessage("Block 0's merkle path from the previous block root has less than 7 siblings");
+                .hasMessage("Block 0's block contents merkle path has less than 4 siblings");
     }
 
     @Test

--- a/importer/src/test/resources/data/stateproof/stateProofTestArtifact.json
+++ b/importer/src/test/resources/data/stateproof/stateProofTestArtifact.json
@@ -5,25 +5,11 @@
     "expectedRootHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
     "merklePaths": [
       {
-        "timestampLeaf": "CLDF9soGEPDQgrgD",
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "timestampLeaf": "CLDF9soGEPDQgrgD"
       },
       {
-        "hash": "vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX",
         "siblings": [
-          {
-            "hash": "vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX"
-          },
-          {
-            "hash": "szITXG1kGEeXF7DN1DvaAbyUh8cPXASqotbz+ddav6nSZkOGN3cg44MAtTf49zxN"
-          },
-          {
-            "hash": "Neol38vLZtLyxE3J2b6Hah7XTQgwpu3e3TGlyDRlUbW7xA3gqXZnm3jGlXIY9S6j"
-          },
-          {
-            "isLeft": true,
-            "hash": "0dFLEtCFSWMNBXkzUcqhiV+A2uUQfxFvMcdF2CFJDv16DpOPw/vTlrsl46JxuZLq"
-          },
           {
             "hash": "22Cc+zCK8yffvlToVTOO0ob7kxVwbgrI76ynandyPxy0JXM7MckEa7oMGiGSfn+9"
           },
@@ -33,6 +19,7 @@
           {
             "hash": "oKwy15WJ3erRqyA8hGUOlH4nX0y3ZD3YmWkS9f88YkyQq+JZG3lS9rRGXLH3AZnD"
           },
+          {},
           {
             "isLeft": true,
             "hash": "wsQ3BgDUVIXphy0ylqTaBB0LdPqRi64h2Rb/ljf0X8asLbCruRA9JYAL3PvJGMbO"
@@ -46,6 +33,7 @@
           {
             "hash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
           },
+          {},
           {
             "isLeft": true,
             "hash": "iKFyMv9MvyiIJn6wsU9hpYEIXaQQ2BMePaO0szKAsMgMNsoyQ3JtI/h/zTV1lBuG"
@@ -59,6 +47,7 @@
           {
             "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
           },
+          {},
           {
             "isLeft": true,
             "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -72,6 +61,7 @@
           {
             "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
           },
+          {},
           {
             "isLeft": true,
             "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -84,9 +74,11 @@
           },
           {
             "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
-          }
+          },
+          {}
         ],
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "hash": "fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W"
       },
       {
         "nextPathIndex": 4294967295
@@ -99,25 +91,11 @@
     "expectedRootHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
     "merklePaths": [
       {
-        "timestampLeaf": "CLDF9soGEPDQgrgD",
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "timestampLeaf": "CLDF9soGEPDQgrgD"
       },
       {
-        "hash": "fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W",
         "siblings": [
-          {
-            "hash": "22Cc+zCK8yffvlToVTOO0ob7kxVwbgrI76ynandyPxy0JXM7MckEa7oMGiGSfn+9"
-          },
-          {
-            "hash": "TtLoClaJllMWDEK+IUUVBU84Ln4gFyE4YAsdDmZzwsMwiPxgiFNqpa1R7XxkolT9"
-          },
-          {
-            "hash": "oKwy15WJ3erRqyA8hGUOlH4nX0y3ZD3YmWkS9f88YkyQq+JZG3lS9rRGXLH3AZnD"
-          },
-          {
-            "isLeft": true,
-            "hash": "wsQ3BgDUVIXphy0ylqTaBB0LdPqRi64h2Rb/ljf0X8asLbCruRA9JYAL3PvJGMbO"
-          },
           {
             "hash": "w5yEUQDjtDCNxcSBbZZWpkUzwG60E5gjlzhEV3Xakl2xvrVYP4lNdQGFbemBNWfH"
           },
@@ -127,6 +105,7 @@
           {
             "hash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
           },
+          {},
           {
             "isLeft": true,
             "hash": "iKFyMv9MvyiIJn6wsU9hpYEIXaQQ2BMePaO0szKAsMgMNsoyQ3JtI/h/zTV1lBuG"
@@ -140,6 +119,7 @@
           {
             "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
           },
+          {},
           {
             "isLeft": true,
             "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -153,6 +133,7 @@
           {
             "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
           },
+          {},
           {
             "isLeft": true,
             "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -165,9 +146,11 @@
           },
           {
             "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
-          }
+          },
+          {}
         ],
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "hash": "ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13"
       },
       {
         "nextPathIndex": 4294967295
@@ -180,25 +163,11 @@
     "expectedRootHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
     "merklePaths": [
       {
-        "timestampLeaf": "CLDF9soGEPDQgrgD",
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "timestampLeaf": "CLDF9soGEPDQgrgD"
       },
       {
-        "hash": "ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13",
         "siblings": [
-          {
-            "hash": "w5yEUQDjtDCNxcSBbZZWpkUzwG60E5gjlzhEV3Xakl2xvrVYP4lNdQGFbemBNWfH"
-          },
-          {
-            "hash": "/rrgBqQoZEeoDc1UMNQ5Fx2Qcb7UFho6f1OAt1AW1SCORIsAjJkKBSlgBuie/H83"
-          },
-          {
-            "hash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
-          },
-          {
-            "isLeft": true,
-            "hash": "iKFyMv9MvyiIJn6wsU9hpYEIXaQQ2BMePaO0szKAsMgMNsoyQ3JtI/h/zTV1lBuG"
-          },
           {
             "hash": "CvzQfYS60EGmJNk3Fp4O+FXA//0Uv89XvkXnWdO3aPtHBz5vZDVyb7JJ0ggDhzfD"
           },
@@ -208,6 +177,7 @@
           {
             "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
           },
+          {},
           {
             "isLeft": true,
             "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -221,6 +191,7 @@
           {
             "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
           },
+          {},
           {
             "isLeft": true,
             "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -233,9 +204,85 @@
           },
           {
             "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
-          }
+          },
+          {}
         ],
-        "nextPathIndex": 2
+        "nextPathIndex": 2,
+        "hash": "RRcfehwqOGFE5uitIhIaNoACq8s5exCg++1GtqgP33YVxh2DhPy87G9LpN4Guapz"
+      },
+      {
+        "nextPathIndex": 4294967295
+      }
+    ]
+  },
+  {
+    "block": 3,
+    "blockHash": "FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N",
+    "expectedRootHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
+    "merklePaths": [
+      {
+        "nextPathIndex": 2,
+        "timestampLeaf": "CLDF9soGEPDQgrgD"
+      },
+      {
+        "siblings": [
+          {
+            "hash": "cn0Ddk8hX88jkCBuJ7THFudcsor1mvg0YtXMz/Mu/GVzeYtE0w/k7B+cKpyStplD"
+          },
+          {
+            "hash": "RNTgGz49T2CudBOxhuvW5jgmc32GbmvUCnB5IaeEHzUuKPuulSPTkOzB5t9zK6Fq"
+          },
+          {
+            "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
+          },
+          {},
+          {
+            "isLeft": true,
+            "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
+          },
+          {
+            "hash": "BdoXf4WCEndsm3NIJ7C4TDDweNRRJqqSgBqKiN3lzbdbAcYdMhQTd2FegpGoUlwO"
+          },
+          {
+            "hash": "lbGRmXLsb2EqHMNynKogINix1X+C9CCCFyCWmUPL1EDLd1K710ljf4Am8YjJLsfV"
+          },
+          {
+            "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
+          },
+          {}
+        ],
+        "nextPathIndex": 2,
+        "hash": "FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N"
+      },
+      {
+        "nextPathIndex": 4294967295
+      }
+    ]
+  },
+  {
+    "block": 4,
+    "blockHash": "v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf",
+    "expectedRootHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
+    "merklePaths": [
+      {
+        "nextPathIndex": 2,
+        "timestampLeaf": "CLDF9soGEPDQgrgD"
+      },
+      {
+        "siblings": [
+          {
+            "hash": "BdoXf4WCEndsm3NIJ7C4TDDweNRRJqqSgBqKiN3lzbdbAcYdMhQTd2FegpGoUlwO"
+          },
+          {
+            "hash": "lbGRmXLsb2EqHMNynKogINix1X+C9CCCFyCWmUPL1EDLd1K710ljf4Am8YjJLsfV"
+          },
+          {
+            "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
+          },
+          {}
+        ],
+        "nextPathIndex": 2,
+        "hash": "v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf"
       },
       {
         "nextPathIndex": 4294967295


### PR DESCRIPTION
**Description**:

This PR fixes the block root hash calculation over merkle paths in StateProof:

- Adapt upstream change that the merkle path 1 now starts with the current block's root hash
- Handle null-hash sentinel sibling nodes 

**Related issue(s)**:

Fixes #13864 

**Notes for reviewer**:

Upstream [PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/26225) for reference.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
