### PR TITLE
Bump httpclient5 from 5.6.1 to 5.6.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ extra.apply {
     set("besuVersion", "25.2.2")
     set("blockNodeVersion", "0.38.0")
     set("consensusNodeVersion", "0.75.0-rc.5")
+    set("httpclient5.version", "5.6.2") // Temporary until next Spring Boot
+    set("httpcore5.version", "5.4.3") // Temporary until next Spring Boot
     set("jackson-2-bom.version", "2.22.0") // Temporary until next Spring Boot
     set("jooq.version", "3.21.6") // Must match buildSrc/build.gradle.kts
     set("logback.version", "1.5.36") // Temporary until next Spring Boot


### PR DESCRIPTION
**Description**:

* Bump httpclient5 from 5.6.1 to 5.6.2
* Bump httpcore5 from 5.4.2 to 5.4.3

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
