### PR TITLE
Fix entity type keys in cache (#13929)

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/util/SpelHelper.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/SpelHelper.java
@@ -2,8 +2,8 @@
 
 package org.hiero.mirror.common.util;
 
-import java.util.Arrays;
 import java.util.Collection;
+import org.apache.tuweni.bytes.Bytes;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -17,11 +17,7 @@ public final class SpelHelper {
         return value == null || value.isEmpty();
     }
 
-    public int hashCode(byte[] value) {
-        return Arrays.hashCode(value);
-    }
-
-    public int hashCode(Object[] value) {
-        return Arrays.hashCode(value);
+    public Bytes getCacheKey(byte[] value) {
+        return value == null ? Bytes.EMPTY : Bytes.wrap(value);
     }
 }

--- a/web3/src/main/java/org/hiero/mirror/web3/repository/EntityRepository.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/repository/EntityRepository.java
@@ -32,20 +32,20 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
     @Cacheable(
             cacheNames = CACHE_NAME_EVM_ADDRESS,
             cacheManager = CACHE_MANAGER_ENTITY,
-            key = "@spelHelper.hashCode(#alias)",
+            key = "@spelHelper.getCacheKey(#alias)",
             unless = "#result == null")
     Optional<Entity> findByEvmAddressAndDeletedIsFalse(byte[] alias);
 
     @Cacheable(
             cacheNames = CACHE_NAME_ALIAS,
             cacheManager = CACHE_MANAGER_ENTITY,
-            key = "@spelHelper.hashCode(#alias)",
+            key = "@spelHelper.getCacheKey(#alias)",
             unless = "#result == null")
     @Query(value = """
-            select *
-            from entity
-            where (evm_address = ?1 or alias = ?1) and deleted is not true
-            """, nativeQuery = true)
+        select *
+        from entity
+        where (evm_address = ?1 or alias = ?1) and deleted is not true
+        """, nativeQuery = true)
     Optional<Entity> findByEvmAddressOrAliasAndDeletedIsFalse(byte[] alias);
 
     /**

--- a/web3/src/main/java/org/hiero/mirror/web3/service/ContractStateServiceImpl.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/ContractStateServiceImpl.java
@@ -123,6 +123,6 @@ final class ContractStateServiceImpl implements ContractStateService {
 
     // Generates a cache key emulating the default caching behavior in Spring
     private SimpleKey generateCacheKey(final EntityId contractId, final byte[] slotKey) {
-        return new SimpleKey(contractId, slotKey);
+        return new SimpleKey(contractId.getId(), slotKey);
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/repository/EntityRepositoryTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/repository/EntityRepositoryTest.java
@@ -3,11 +3,15 @@
 package org.hiero.mirror.web3.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.hiero.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_ENTITY;
 import static org.hiero.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_SYSTEM_ACCOUNT;
 import static org.hiero.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.Range;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +20,7 @@ import org.hiero.mirror.common.domain.entity.EntityHistory;
 import org.hiero.mirror.web3.ContextExtension;
 import org.hiero.mirror.web3.Web3IntegrationTest;
 import org.hiero.mirror.web3.common.ContractCallContext;
+import org.hiero.mirror.web3.repository.properties.CacheProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,6 +32,9 @@ import org.springframework.cache.CacheManager;
 @ExtendWith(ContextExtension.class)
 @RequiredArgsConstructor
 class EntityRepositoryTest extends Web3IntegrationTest {
+
+    private final CacheProperties cacheProperties;
+
     private final EntityRepository entityRepository;
 
     @Qualifier(CACHE_MANAGER_ENTITY)
@@ -517,6 +525,89 @@ class EntityRepositoryTest extends Web3IntegrationTest {
         assertThat(entityRepository.findByIdAndDeletedIsFalse(regularEntity.getId()))
                 .as("Entity should NOT be found after clearing the regular cache")
                 .isEmpty();
+    }
+
+    @Test
+    void findByEvmAddressAndDeletedIsFalseDoesNotCollideOnArraysHashCode() {
+        // These 20-byte addresses collide under the same Arrays hashcode but are not equal.
+        final byte[] address1 = new byte[20];
+        final byte[] address2 = new byte[20];
+        address2[0] = 1;
+        address2[1] = -31;
+
+        assertThat(Arrays.hashCode(address1)).isEqualTo(Arrays.hashCode(address2));
+        assertThat(Arrays.equals(address1, address2)).isFalse();
+
+        final var entity1 =
+                domainBuilder.entity().customize(e -> e.evmAddress(address1)).persist();
+        final var entity2 =
+                domainBuilder.entity().customize(e -> e.evmAddress(address2)).persist();
+
+        assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address1)).contains(entity1);
+        assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address2)).contains(entity2);
+
+        // Removed from DB; both remain independently cached until expireAfterWrite
+        entityRepository.deleteAll();
+        assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address1)).contains(entity1);
+        assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address2)).contains(entity2);
+
+        await("entityCacheExpired")
+                .atMost(entityCacheExpireAfterWrite().multipliedBy(2))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> {
+                    assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address1))
+                            .isEmpty();
+                    assertThat(entityRepository.findByEvmAddressAndDeletedIsFalse(address2))
+                            .isEmpty();
+                });
+    }
+
+    @Test
+    void findByEvmAddressOrAliasAndDeletedIsFalseDoesNotCollideOnArraysHashCode() {
+        // These 20-byte addresses collide under the same Arrays hashcode but are not equal.
+        final byte[] address1 = new byte[20];
+        final byte[] address2 = new byte[20];
+        address2[0] = 1;
+        address2[1] = -31;
+
+        assertThat(Arrays.hashCode(address1)).isEqualTo(Arrays.hashCode(address2));
+        assertThat(Arrays.equals(address1, address2)).isFalse();
+
+        final var entity1 =
+                domainBuilder.entity().customize(e -> e.evmAddress(address1)).persist();
+        final var entity2 =
+                domainBuilder.entity().customize(e -> e.evmAddress(address2)).persist();
+
+        assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address1))
+                .contains(entity1);
+        assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address2))
+                .contains(entity2);
+
+        // Removed from DB; both remain independently cached until expireAfterWrite
+        entityRepository.deleteAll();
+        assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address1))
+                .contains(entity1);
+        assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address2))
+                .contains(entity2);
+
+        await("entityCacheExpired")
+                .atMost(entityCacheExpireAfterWrite().multipliedBy(2))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> {
+                    assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address1))
+                            .isEmpty();
+                    assertThat(entityRepository.findByEvmAddressOrAliasAndDeletedIsFalse(address2))
+                            .isEmpty();
+                });
+    }
+
+    private Duration entityCacheExpireAfterWrite() {
+        return Caffeine.from(cacheProperties.getEntity())
+                .build()
+                .policy()
+                .expireAfterWrite()
+                .orElseThrow(() -> new IllegalStateException("entity cache missing expireAfterWrite"))
+                .getExpiresAfter();
     }
 
     private void invalidateCache() {

--- a/web3/src/test/resources/config/application.yml
+++ b/web3/src/test/resources/config/application.yml
@@ -3,6 +3,9 @@
 hiero:
   mirror:
     web3:
+      cache:
+        # Caffeine has no "ms" short form; PT0.1S is 100ms to keep cache-expiry tests fast
+        entity: expireAfterWrite=PT0.1S,maximumSize=10000,recordStats
       evm:
         properties:
           contracts.maxRefundPercentOfGasLimit: "100"


### PR DESCRIPTION
**Description**:
Cherry-pick of #13929.

In `ContractStateServiceImpl` there is a manual cache get and put operations for batch contract slots reading. The cache key is constructed as a `SimpleKey(<id>, byte[])`. On one of the places the id is put as a `long` and on another - as an `EntityId`. This causes unnecessary cache misses. This PR aligns the type correctly, so that the cache entries can be used correctly and the performance will improve as a result.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
