### PR TITLE
Use random healthy node provided by SDK

### DIFF
--- a/rosetta/app/services/construction_service.go
+++ b/rosetta/app/services/construction_service.go
@@ -529,10 +529,6 @@ func (c *constructionAPIService) getRandomNodeAccountId() (hiero.AccountID, *rTy
 		return nodeAccountIds[0], nil
 	}
 
-	for _, n := range nodeAccountIds {
-		log.Infof("node account id %s", n)
-	}
-
 	return nodeAccountIds[index.Int64()], nil
 }
 

--- a/rosetta/app/services/construction_service.go
+++ b/rosetta/app/services/construction_service.go
@@ -509,20 +509,15 @@ func (c *constructionAPIService) getSdkPayerAccountId(payerAccountId types.Accou
 }
 
 func (c *constructionAPIService) getRandomNodeAccountId() (hiero.AccountID, *rTypes.Error) {
-	nodeAccountIds := make([]hiero.AccountID, 0)
-	seen := map[hiero.AccountID]struct{}{}
-	// network returned from sdkClient is a map[string]AccountID, the key is the address of a node and the value is
-	// its node account id. Since a node can have multiple addresses, we need the seen map to get a unique node account
-	// id array
-	for _, nodeAccountId := range c.sdkClient.GetNetwork() {
-		if _, ok := seen[nodeAccountId]; ok {
-			continue
-		}
-
-		seen[nodeAccountId] = struct{}{}
-		nodeAccountIds = append(nodeAccountIds, nodeAccountId)
+	// Create a transfer transaction and freeze it with the client to get the list of healthy nodes from SDK
+	transaction, err := hiero.NewTransferTransaction().
+		SetTransactionID(hiero.TransactionIDGenerate(hiero.AccountID{Account: 2})).
+		FreezeWith(c.sdkClient)
+	if err != nil {
+		return hiero.AccountID{}, errors.ErrNodeAccountIdsEmpty
 	}
 
+	nodeAccountIds := transaction.GetNodeAccountIDs()
 	if len(nodeAccountIds) == 0 {
 		return hiero.AccountID{}, errors.ErrNodeAccountIdsEmpty
 	}
@@ -532,6 +527,10 @@ func (c *constructionAPIService) getRandomNodeAccountId() (hiero.AccountID, *rTy
 	if err != nil {
 		log.Errorf("Failed to get a random number, use 0 instead: %s", err)
 		return nodeAccountIds[0], nil
+	}
+
+	for _, n := range nodeAccountIds {
+		log.Infof("node account id %s", n)
 	}
 
 	return nodeAccountIds[index.Int64()], nil


### PR DESCRIPTION
**Description**:

This PR improves rosetta node selection

- Pick a random node from the list of healthy nodes provided by SDK

**Related issue(s)**:

Fixes #13939

**Notes for reviewer**:

Did the following manual tests:

- Ran rosetta with manual testnet nodes config, 2 testnet nodes, and one node (account id 0.0.12) with non-existing service endpoint (so it's guaranteed to fail)
- Ran the bdd crypto transfer test scenario multiple times

The first time the construction service picks node account id 0.0.12, the transaction will fail and the node gets marked as unhealthy.

In subsequent construction service `ConstructionMetadata` calls, the list of healthy nodes from SDK does have 0.0.12 excluded. This verifies the approach works. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
