### PR TITLE
Remove `AccountBalanceQuery` from acceptance tests

### DIFF
--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -5,7 +5,6 @@ package org.hiero.mirror.test.e2e.acceptance.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.KeyList;
@@ -212,17 +211,6 @@ abstract class AbstractNetworkClient implements Cleanable {
 
             return new TransactionRecordQuery().setTransactionId(transactionId).execute(client);
         });
-    }
-
-    public long getBalance() {
-        return getBalance(sdkClient.getExpandedOperatorAccountId());
-    }
-
-    public long getBalance(ExpandedAccountId accountId) {
-        var query = new AccountBalanceQuery().setAccountId(accountId.getAccountId());
-        var balance = executeQuery(() -> query).hbars;
-        log.debug("Account {} balance is {}", accountId, balance);
-        return balance.toTinybars();
     }
 
     protected String getMemo(String message) {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -54,11 +54,9 @@ public class AccountClient extends AbstractNetworkClient {
             SDKClient sdkClient, RetryTemplate retryTemplate, AcceptanceTestProperties acceptanceTestProperties) {
         super(sdkClient, retryTemplate, acceptanceTestProperties);
         try {
-            initialBalance = getBalance();
-            log.info(
-                    "Operator account {} initial balance is {}",
-                    sdkClient.getExpandedOperatorAccountId(),
-                    initialBalance);
+            var operatorAccountId = sdkClient.getExpandedOperatorAccountId().toString();
+            initialBalance = sdkClient.getMirrorNodeClient().waitForAccountBalance(operatorAccountId);
+            log.info("Operator account {} initial balance is {}", operatorAccountId, initialBalance);
         } catch (Throwable t) {
             clean();
             throw t;
@@ -70,7 +68,11 @@ public class AccountClient extends AbstractNetworkClient {
         log.info("Deleting {} accounts", accountIds.size());
         deleteOrLogEntities(accountIds, this::delete);
 
-        var cost = initialBalance - getBalance();
+        var cost = initialBalance
+                - sdkClient
+                        .getMirrorNodeClient()
+                        .waitForAccountBalance(
+                                sdkClient.getExpandedOperatorAccountId().toString());
         log.warn("Tests cost {} to run", Hbar.fromTinybars(cost));
 
         var operatorId = sdkClient.getDefaultOperator();
@@ -191,7 +193,7 @@ public class AccountClient extends AbstractNetworkClient {
     }
 
     private void reclaimFund(final ExpandedAccountId sender) {
-        final var amount = Hbar.fromTinybars(getBalance(sender));
+        final var amount = Hbar.fromTinybars(sdkClient.getMirrorNodeClient().waitForAccountBalance(sender.toString()));
         final var operator = sdkClient.getDefaultOperator();
         final var recipientId = operator.getAccountId();
         final var senderId = sender.getAccountId();

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -19,6 +19,7 @@ import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicMessageQuery;
 import jakarta.inject.Named;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
+import org.awaitility.core.ConditionTimeoutException;
 import org.hiero.mirror.rest.model.AccountBalanceTransactions;
 import org.hiero.mirror.rest.model.AccountInfo;
 import org.hiero.mirror.rest.model.AccountsResponse;
@@ -533,6 +535,33 @@ public class MirrorNodeClient {
 
     public BalancesResponse getBalancesForAccountId(String accountId) {
         return callRestEndpoint("/balances?account.id={accountId}", BalancesResponse.class, accountId);
+    }
+
+    public void waitForNextBlock() {
+        final var blocks = getBlocks(Order.DESC, 1).getBlocks();
+        if (CollectionUtils.isEmpty(blocks)) {
+            return;
+        }
+        final long currentBlockNumber = blocks.getFirst().getNumber();
+        try {
+            await("nextBlock")
+                    .atMost(Duration.ofSeconds(3))
+                    .pollInterval(Duration.ofMillis(250))
+                    .ignoreExceptions()
+                    .until(() -> {
+                        var latest = getBlocks(Order.DESC, 1).getBlocks();
+                        return !CollectionUtils.isEmpty(latest)
+                                && latest.getFirst().getNumber() > currentBlockNumber;
+                    });
+        } catch (ConditionTimeoutException e) {
+            log.info("No new block found within 3 seconds");
+        }
+    }
+
+    public long waitForAccountBalance(String accountId) {
+        waitForNextBlock();
+        var balances = getBalancesForAccountId(accountId).getBalances();
+        return balances == null || balances.isEmpty() ? 0L : balances.getFirst().getBalance();
     }
 
     public HooksResponse getAccountHooks(String accountId) {

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -87,7 +87,7 @@ public class AccountFeature extends AbstractFeature {
     public void treasuryDisbursement(long amount, String accountName) {
         senderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
 
-        startingBalance = accountClient.getBalance(senderAccountId);
+        startingBalance = mirrorClient.waitForAccountBalance(senderAccountId.toString());
 
         networkTransactionResponse =
                 accountClient.sendCryptoTransfer(senderAccountId.getAccountId(), Hbar.fromTinybars(amount), null);
@@ -137,7 +137,7 @@ public class AccountFeature extends AbstractFeature {
 
     @When("I send {long} tℏ to newly created account")
     public void sendTinyHbars(long amount) {
-        startingBalance = accountClient.getBalance(senderAccountId);
+        startingBalance = mirrorClient.waitForAccountBalance(senderAccountId.toString());
         networkTransactionResponse =
                 accountClient.sendCryptoTransfer(senderAccountId.getAccountId(), Hbar.fromTinybars(amount), null);
         assertNotNull(networkTransactionResponse.getTransactionId());
@@ -161,9 +161,11 @@ public class AccountFeature extends AbstractFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
+    @RetryAsserts
     @Then("the new balance should reflect cryptotransfer of {long}")
     public void accountReceivedFunds(long amount) {
-        assertThat(accountClient.getBalance(senderAccountId)).isGreaterThanOrEqualTo(startingBalance + amount);
+        assertThat(mirrorClient.waitForAccountBalance(senderAccountId.toString()))
+                .isGreaterThanOrEqualTo(startingBalance + amount);
     }
 
     @Then("the mirror node REST API should return status {int} for the crypto transfer transaction")

--- a/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
+++ b/test/src/test/java/org/hiero/mirror/test/e2e/acceptance/steps/HistoricalFeature.java
@@ -196,7 +196,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         // the block number where contract storage variable is still with initial value
         var initialBlockNumber = getLastBlockNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         ContractFunctionParameters parameters = new ContractFunctionParameters().addUint256(BigInteger.valueOf(5));
         var maxGas = contractClient
@@ -219,7 +219,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var initialResponse = callContract(data, estimateContractSolidityAddress, ADDRESS_BALANCE.getActualGas())
                 .getResultAsNumber();
         var initialBlockNumber = getLastBlockNumber();
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
         networkTransactionResponse =
                 accountClient.sendCryptoTransfer(receiverAccountId.getAccountId(), Hbar.fromTinybars(50000000), null);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -265,7 +265,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var initialResponse = callContract(data, estimateContractSolidityAddress, ADDRESS_BALANCE.getActualGas());
         var initialBlock = getLastBlockNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.delete(deletableAccountId);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -283,7 +283,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, precompileContractSolidityAddress, GET_TOKEN_INFO.getActualGas());
         final var trimmedResponse = trimTotalSupplyForGetTokenInfo(response.toString());
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.updateToken(tokenId, admin);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -303,7 +303,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, precompileContractSolidityAddress, GET_TOKEN_INFO.getActualGas());
         final var trimmedResponse = trimTotalSupplyForGetTokenInfo(response.toString());
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.burnFungible(tokenId, 5L);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -322,7 +322,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var initialBlockNumber = getLastBlockNumber();
         var response = callContract(data, precompileContractSolidityAddress, GET_TOKEN_INFO.getActualGas());
         final var trimmedResponse = trimTotalSupplyForGetTokenInfo(response.toString());
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.mint(tokenId, 5L);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -361,7 +361,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress, BALANCE_OF.getActualGas());
         var initialBalance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         if (tokenName.name().toLowerCase().contains("fungible")) {
             networkTransactionResponse = tokenClient.transferFungibleToken(
@@ -398,7 +398,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, tokenId.toEvmAddress());
         var initialBalance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         if (tokenName.name().toLowerCase().contains("fungible")) {
             networkTransactionResponse = tokenClient.mint(tokenId, 10L);
@@ -421,7 +421,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress, BALANCE_OF.getActualGas());
         var initialBalance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         if (tokenName.name().toLowerCase().contains("fungible")) {
             tokenClient.burnFungible(tokenId, 5L);
@@ -443,7 +443,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress, BALANCE_OF.getActualGas());
         var initialBalance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         if (tokenName.name().toLowerCase().contains("fungible")) {
             tokenClient.wipeFungible(tokenId, 1L, receiverAccountId);
@@ -465,7 +465,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, estimatePrecompileContractSolidityAddress, ALLOWANCE.getActualGas());
         var initialAllowance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveToken(tokenId, receiverAccountId.getAccountId(), 100L);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -487,7 +487,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, estimatePrecompileContractSolidityAddress, GET_APPROVED.getActualGas());
         var initialApprovedAddress = response.getResultAsAddress();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveNft(nftId, secondReceiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -505,7 +505,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress);
         var initialAllowance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveToken(tokenId, receiverAccountId.getAccountId(), 150L);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -526,7 +526,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress);
         var initialApprovedAddress = response.getResultAsAddress();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveNft(nftId, secondReceiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -543,7 +543,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, tokenId.toEvmAddress());
         var initialAllowance = response.getResultAsNumber();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveToken(tokenId, receiverAccountId.getAccountId(), 200L);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -564,7 +564,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, tokenId.toEvmAddress());
         var initialApprovedAddress = response.getResultAsAddress();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveNft(nftId, secondReceiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -584,7 +584,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
                 callContract(data, estimatePrecompileContractSolidityAddress, IS_APPROVED_FOR_ALL.getActualGas());
         var initialResult = response.getResultAsAddress();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = accountClient.approveNftAllSerials(tokenId, receiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -605,7 +605,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, ercContractSolidityAddress);
         var initialOwner = response.getResultAsAddress();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.transferNonFungibleToken(
                 tokenId,
@@ -629,7 +629,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var initialBlockNumber = getLastBlockNumber();
         var initialFreezeStatus = response.getResultAsBoolean();
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.freeze(tokenId, receiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -649,7 +649,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var data = encodeData(PRECOMPILE, GET_FUNGIBLE_TOKEN_INFO, asAddress(tokenId));
         var response = callContract(data, precompileContractSolidityAddress, GET_FUNGIBLE_TOKEN_INFO.getActualGas());
         final var trimmedResponse = trimTotalSupplyForFungibleTokenInfo(response.toString());
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         switch (action) {
             case "update" -> networkTransactionResponse = tokenClient.updateToken(tokenId, admin);
@@ -679,7 +679,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response = callContract(data, precompileContractSolidityAddress, GET_FUNGIBLE_TOKEN_INFO.getActualGas());
         final var trimmedResponse = trimTotalSupplyForFungibleTokenInfo(response.toString());
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         tokenClient.transferFungibleToken(tokenId, admin, receiverAccountId.getAccountId(), null, 10L);
         switch (action) {
@@ -727,7 +727,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var response =
                 callContract(data, precompileContractSolidityAddress, GET_NON_FUNGIBLE_TOKEN_INFO.getActualGas());
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         switch (action) {
             case "mint" -> networkTransactionResponse = tokenClient.mint(tokenId, "TEST_metadata".getBytes());
@@ -790,7 +790,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
                     callContract(data, estimatePrecompileContractSolidityAddress, GET_TOKEN_KEY.getActualGas()));
         }
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         // Perform update
         var updateData = encodeDataToByteArray(ESTIMATE_PRECOMPILE, UPDATE_TOKEN_KEYS, asAddress(tokenId));
@@ -815,7 +815,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
         var data = encodeData(PRECOMPILE, IS_KYC_GRANTED_SELECTOR, asAddress(tokenId), receiverAccountAddress);
         var response = callContract(data, precompileContractSolidityAddress);
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         networkTransactionResponse = tokenClient.revokeKyc(tokenId, receiverAccountId.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -856,7 +856,7 @@ public class HistoricalFeature extends AbstractEstimateFeature {
             }
         }
 
-        waitForNextBlock();
+        mirrorClient.waitForNextBlock();
 
         // deleting the token to change the state
         networkTransactionResponse = tokenClient.delete(admin, tokenId);
@@ -908,20 +908,6 @@ public class HistoricalFeature extends AbstractEstimateFeature {
                 .getFirst()
                 .getNumber()
                 .toString();
-    }
-
-    private void waitForNextBlock() {
-        int currentBlockNumber = Integer.parseInt(getLastBlockNumber());
-
-        try {
-            Awaitility.await()
-                    .atMost(3, TimeUnit.SECONDS)
-                    .pollInterval(250, TimeUnit.MILLISECONDS)
-                    .ignoreExceptions()
-                    .until(() -> Integer.parseInt(getLastBlockNumber()) > currentBlockNumber);
-        } catch (ConditionTimeoutException e) {
-            log.info("No new block found within 3 seconds");
-        }
     }
 
     private void waitUntilAccountIsImported(AccountId accountId) {


### PR DESCRIPTION
**Description**:
This PR follows the blog post recommendation to remove the `AccountBalanceQuery` and start using the mirror node REST API `/balances?account.id={accountId}`. The balance is read with 1 block delay in order for the importer to have a chance to read the latest updated balance. The overall cost to run the tests matches the value that was produced by tests with `AccountBalanceQuery`.

Fixes #13947 