### PR TITLE
Improve entity ID parsing (0.159)

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/entity/EntityId.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/entity/EntityId.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 import org.hiero.mirror.common.exception.InvalidEntityException;
+import org.hiero.mirror.common.util.DomainUtils;
 
 /**
  * Common encapsulation for a Hedera entity identifier.
@@ -28,6 +29,7 @@ import org.hiero.mirror.common.exception.InvalidEntityException;
 public final class EntityId implements Comparable<EntityId> {
 
     public static final EntityId EMPTY = new EntityId(0L);
+    public static final String INVALID_ENTITY_EXCEPTION_PROPERTY = "HIERO_MIRROR_COMMON_INVALIDENTITYEXCEPTION";
 
     static final int NUM_BITS = 38;
     static final int REALM_BITS = 16;
@@ -67,9 +69,16 @@ public final class EntityId implements Comparable<EntityId> {
      * realm: 0 - 65535 <br/> num: 0 - 274877906943 <br/> Placing entity num in the end has the advantage that encoded ids
      * <= 274877906943 will also be human-readable.
      */
-    private static long encode(long shard, long realm, long num) {
+    private static long encode(long shard, long realm, long num, boolean canThrow) {
         if (shard > SHARD_MASK || shard < 0 || realm > REALM_MASK || realm < 0 || num > NUM_MASK || num < 0) {
-            throw new InvalidEntityException("Invalid entity ID: " + shard + "." + realm + "." + num);
+            boolean throwError = Boolean.parseBoolean(System.getProperty(INVALID_ENTITY_EXCEPTION_PROPERTY, "true"));
+
+            if (canThrow && throwError) {
+                throw new InvalidEntityException("Invalid entity ID: " + shard + "." + realm + "." + num);
+            } else {
+                DomainUtils.logRecoverableError("Invalid entity ID: {}.{}.{}", shard, realm, num);
+                return EMPTY.getId();
+            }
         }
 
         if (shard == 0 && realm == 0) {
@@ -83,6 +92,10 @@ public final class EntityId implements Comparable<EntityId> {
         return of(accountID.getShardNum(), accountID.getRealmNum(), accountID.getAccountNum());
     }
 
+    public static EntityId tryOf(AccountID accountID) {
+        return tryOf(accountID.getShardNum(), accountID.getRealmNum(), accountID.getAccountNum());
+    }
+
     public static EntityId of(ContractID contractID) {
         return of(contractID.getShardNum(), contractID.getRealmNum(), contractID.getContractNum());
     }
@@ -91,16 +104,20 @@ public final class EntityId implements Comparable<EntityId> {
         return of(fileID.getShardNum(), fileID.getRealmNum(), fileID.getFileNum());
     }
 
-    public static EntityId of(TopicID topicID) {
-        return of(topicID.getShardNum(), topicID.getRealmNum(), topicID.getTopicNum());
+    public static EntityId of(ScheduleID scheduleID) {
+        return of(scheduleID.getShardNum(), scheduleID.getRealmNum(), scheduleID.getScheduleNum());
     }
 
     public static EntityId of(TokenID tokenID) {
         return of(tokenID.getShardNum(), tokenID.getRealmNum(), tokenID.getTokenNum());
     }
 
-    public static EntityId of(ScheduleID scheduleID) {
-        return of(scheduleID.getShardNum(), scheduleID.getRealmNum(), scheduleID.getScheduleNum());
+    public static EntityId tryOf(TokenID tokenID) {
+        return tryOf(tokenID.getShardNum(), tokenID.getRealmNum(), tokenID.getTokenNum());
+    }
+
+    public static EntityId of(TopicID topicID) {
+        return of(topicID.getShardNum(), topicID.getRealmNum(), topicID.getTopicNum());
     }
 
     public static EntityId of(String entityId) {
@@ -130,7 +147,12 @@ public final class EntityId implements Comparable<EntityId> {
     }
 
     public static EntityId of(long shard, long realm, long num) {
-        long id = encode(shard, realm, num);
+        long id = encode(shard, realm, num, true);
+        return of(id);
+    }
+
+    public static EntityId tryOf(long shard, long realm, long num) {
+        long id = encode(shard, realm, num, false);
         return of(id);
     }
 

--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
@@ -138,7 +138,9 @@ public class RecordItem implements StreamItem {
     }
 
     public void addContractTransaction(EntityId entityId) {
-        if (contractTransactionPredicate == null || !contractTransactionPredicate.test(entityId)) {
+        if (EntityId.isEmpty(entityId)
+                || contractTransactionPredicate == null
+                || !contractTransactionPredicate.test(entityId)) {
             return;
         }
         getContractTransactions().computeIfAbsent(entityId.getId(), key -> ContractTransaction.builder()
@@ -166,6 +168,10 @@ public class RecordItem implements StreamItem {
     }
 
     private void doAddEntityId(final EntityId entityId, final Predicate<EntityId> predicate) {
+        if (EntityId.isEmpty(entityId)) {
+            return;
+        }
+
         if (!predicate.test(entityId)) {
             return;
         }

--- a/common/src/main/java/org/hiero/mirror/common/util/DomainUtils.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/DomainUtils.java
@@ -46,6 +46,7 @@ public class DomainUtils {
     public static final ByteString EMPTY_BYTE_STRING = ByteString.EMPTY;
     public static final int EVM_ADDRESS_LENGTH = 20;
     public static final long NANOS_PER_SECOND = 1_000_000_000L;
+    public static final String RECOVERABLE_ERROR = "Recoverable error. ";
     public static final long TINYBARS_IN_ONE_HBAR = 100_000_000L;
 
     private static final long MAX_SYSTEM_ENTITY_NUM = 999;
@@ -202,6 +203,10 @@ public class DomainUtils {
         final var leftPaddedBytes = new byte[length];
         System.arraycopy(bytes, 0, leftPaddedBytes, paddingSize, bytes.length);
         return leftPaddedBytes;
+    }
+
+    public static void logRecoverableError(String message, Object... args) {
+        log.error(RECOVERABLE_ERROR + message, args);
     }
 
     public static long now() {

--- a/common/src/test/java/org/hiero/mirror/common/domain/entity/EntityIdTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/entity/EntityIdTest.java
@@ -15,12 +15,17 @@ import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import org.hiero.mirror.common.exception.InvalidEntityException;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
-class EntityIdTest {
+@ExtendWith(OutputCaptureExtension.class)
+final class EntityIdTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -33,6 +38,7 @@ class EntityIdTest {
     })
     void testEntityEncoding(long shard, long realm, long num, long encodedId) {
         assertThat(EntityId.of(shard, realm, num).getId()).isEqualTo(encodedId);
+        assertThat(EntityId.of(encodedId)).isEqualTo(EntityId.of(shard, realm, num));
     }
 
     @Test
@@ -43,19 +49,6 @@ class EntityIdTest {
         assertThatThrownBy(() -> EntityId.of(-1, 0, 0)).isInstanceOf(InvalidEntityException.class);
         assertThatThrownBy(() -> EntityId.of(0, -1, 0)).isInstanceOf(InvalidEntityException.class);
         assertThatThrownBy(() -> EntityId.of(0, 0, -1)).isInstanceOf(InvalidEntityException.class);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "0, 0, 0, 0",
-        "10, 0, 0, 10",
-        "4294967295, 0, 0, 4294967295",
-        "180146733873889290, 10, 10, 10",
-        "-1, 1023, 65535, 274877906943",
-        "-18014398509481984, 1023, 0, 0"
-    })
-    void testEntityDecoding(long encodedId, long shard, long realm, long num) {
-        assertThat(EntityId.of(encodedId)).isEqualTo(EntityId.of(shard, realm, num));
     }
 
     @Test
@@ -100,6 +93,78 @@ class EntityIdTest {
             })
     void isValid(String id, boolean result) {
         assertThat(EntityId.isValid(id)).isEqualTo(result);
+    }
+
+    @Test
+    void ofAccountId(CapturedOutput output) {
+        final var accountId = AccountID.newBuilder()
+                .setShardNum(1)
+                .setRealmNum(2)
+                .setAccountNum(3)
+                .build();
+        final var accountIdBad = AccountID.newBuilder()
+                .setShardNum(-1)
+                .setRealmNum(2)
+                .setAccountNum(9223372036854775807L)
+                .build();
+        assertThat(EntityId.of(accountId))
+                .isEqualTo(EntityId.tryOf(accountId))
+                .isNotEqualTo(EntityId.EMPTY)
+                .returns(1L, EntityId::getShard)
+                .returns(2L, EntityId::getRealm)
+                .returns(3L, EntityId::getNum);
+        assertThatThrownBy(() -> EntityId.of(accountIdBad)).isInstanceOf(InvalidEntityException.class);
+        System.setProperty(EntityId.INVALID_ENTITY_EXCEPTION_PROPERTY, "false");
+        assertThat(EntityId.of(accountIdBad)).isEqualTo(EntityId.EMPTY);
+        assertThat(output.getAll()).contains(DomainUtils.RECOVERABLE_ERROR);
+        System.setProperty(EntityId.INVALID_ENTITY_EXCEPTION_PROPERTY, "true");
+    }
+
+    @Test
+    void tryOfAccountId(CapturedOutput output) {
+        final var accountId = AccountID.newBuilder()
+                .setShardNum(-1)
+                .setRealmNum(2)
+                .setAccountNum(9223372036854775807L)
+                .build();
+        assertThat(EntityId.tryOf(accountId)).isEqualTo(EntityId.EMPTY);
+        assertThat(output.getAll()).contains(DomainUtils.RECOVERABLE_ERROR);
+    }
+
+    @Test
+    void ofTokenId(CapturedOutput output) {
+        final var tokenId = TokenID.newBuilder()
+                .setShardNum(1)
+                .setRealmNum(2)
+                .setTokenNum(3)
+                .build();
+        final var tokenIdBad = TokenID.newBuilder()
+                .setShardNum(-1)
+                .setRealmNum(2)
+                .setTokenNum(9223372036854775807L)
+                .build();
+        assertThat(EntityId.of(tokenId))
+                .isEqualTo(EntityId.tryOf(tokenId))
+                .isNotEqualTo(EntityId.EMPTY)
+                .returns(1L, EntityId::getShard)
+                .returns(2L, EntityId::getRealm)
+                .returns(3L, EntityId::getNum);
+        assertThatThrownBy(() -> EntityId.of(tokenIdBad)).isInstanceOf(InvalidEntityException.class);
+        System.setProperty(EntityId.INVALID_ENTITY_EXCEPTION_PROPERTY, "false");
+        assertThat(EntityId.of(tokenIdBad)).isEqualTo(EntityId.EMPTY);
+        assertThat(output.getAll()).contains(DomainUtils.RECOVERABLE_ERROR);
+        System.setProperty(EntityId.INVALID_ENTITY_EXCEPTION_PROPERTY, "true");
+    }
+
+    @Test
+    void tryOfTokenIdError(CapturedOutput output) {
+        final var tokenId = TokenID.newBuilder()
+                .setShardNum(-1)
+                .setRealmNum(2)
+                .setTokenNum(9223372036854775807L)
+                .build();
+        assertThat(EntityId.tryOf(tokenId)).isEqualTo(EntityId.EMPTY);
+        assertThat(output.getAll()).contains(DomainUtils.RECOVERABLE_ERROR);
     }
 
     @Test

--- a/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
@@ -38,13 +38,17 @@ import org.hiero.mirror.common.domain.transaction.ContractSlotKey;
 import org.hiero.mirror.common.exception.InvalidEntityException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
+@ExtendWith(OutputCaptureExtension.class)
 final class DomainUtilsTest {
 
     private static final String ED25519_KEY = "60beee88a761e079f71b03b5fe041979369e96450a7455b203a2578c8a7d4852";
@@ -267,6 +271,12 @@ final class DomainUtilsTest {
     @MethodSource("paddingByteProvider")
     void leftPadBytes(byte[] bytes, int paddingLength, byte[] expected) {
         assertThat(DomainUtils.leftPadBytes(bytes, paddingLength)).isEqualTo(expected);
+    }
+
+    @Test
+    void logRecoverableError(CapturedOutput capturedOutput) {
+        DomainUtils.logRecoverableError("Some error {} {}", 1, 2);
+        assertThat(capturedOutput.getAll()).contains("Some error 1 2");
     }
 
     @ParameterizedTest

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -171,8 +171,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         final var validDurationSeconds = body.hasTransactionValidDuration()
                 ? body.getTransactionValidDuration().getSeconds()
                 : null;
-        // transactions in stream always have valid node account id.
-        final var nodeAccount = EntityId.of(body.getNodeAccountID());
+        final var nodeAccount = EntityId.tryOf(body.getNodeAccountID());
         final var transactionId = body.getTransactionID();
 
         // build transaction
@@ -344,13 +343,13 @@ public class EntityRecordItemListener implements RecordItemListener {
     }
 
     private AccountAmount findAccountAmount(
-            Predicate<AccountAmount> accountAmountPredicate, EntityId tokenId, TransactionBody body) {
+            Predicate<AccountAmount> accountAmountPredicate, TokenID tokenId, TransactionBody body) {
         if (!body.hasCryptoTransfer()) {
             return null;
         }
         List<TokenTransferList> tokenTransfersLists = body.getCryptoTransfer().getTokenTransfersList();
         for (TokenTransferList transferList : tokenTransfersLists) {
-            if (!EntityId.of(transferList.getToken()).equals(tokenId)) {
+            if (!transferList.getToken().equals(tokenId)) {
                 continue;
             }
             for (AccountAmount aa : transferList.getTransfersList()) {
@@ -373,9 +372,9 @@ public class EntityRecordItemListener implements RecordItemListener {
         for (int i = 0; i < count; i++) {
             var maxCustomFee = body.getMaxCustomFees(i);
             maxCustomFees[i] = maxCustomFee.toByteArray();
-            recordItem.addEntityId(EntityId.of(maxCustomFee.getAccountId()));
+            recordItem.addEntityId(EntityId.tryOf(maxCustomFee.getAccountId()));
             for (var fixedFee : maxCustomFee.getFeesList()) {
-                recordItem.addEntityId(EntityId.of(fixedFee.getDenominatingTokenId()));
+                recordItem.addEntityId(EntityId.tryOf(fixedFee.getDenominatingTokenId()));
             }
         }
 
@@ -412,7 +411,7 @@ public class EntityRecordItemListener implements RecordItemListener {
             tokenTransfer.setIsApproval(false);
             tokenTransfer.setPayerAccountId(payerAccountId);
 
-            handleNegativeAccountAmounts(tokenId, body, accountAmount, amount, tokenTransfer);
+            handleNegativeAccountAmounts(tokenTransferList.getToken(), body, accountAmount, amount, tokenTransfer);
             entityListener.onTokenTransfer(tokenTransfer);
             recordItem.addEntityId(accountId);
             recordItem.addEntityId(tokenId);
@@ -472,7 +471,7 @@ public class EntityRecordItemListener implements RecordItemListener {
     }
 
     private void handleNegativeAccountAmounts(
-            EntityId tokenId,
+            TokenID tokenId,
             TransactionBody body,
             AccountAmount accountAmount,
             long amount,
@@ -524,7 +523,8 @@ public class EntityRecordItemListener implements RecordItemListener {
             }
         }
 
-        if (!recordItem.getTransactionBody().hasCryptoTransfer()
+        if (!recordItem.isSuccessful()
+                || !recordItem.getTransactionBody().hasCryptoTransfer()
                 || !entityProperties.getPersist().isTrackAllowance()) {
             return;
         }
@@ -540,13 +540,13 @@ public class EntityRecordItemListener implements RecordItemListener {
         }
         long transferSpenderId = spenderId;
         tokenTransfers.forEach(tokenTransfer -> {
-            var tokenId = EntityId.of(tokenTransfer.getToken());
+            var tokenId = EntityId.tryOf(tokenTransfer.getToken());
             tokenTransfer.getTransfersList().forEach(accountAmount -> {
                 // Emit allowance amount representing approved transfer debit
                 if (accountAmount.getIsApproval() && accountAmount.getAmount() < 0) {
                     var tokenAllowance = TokenAllowance.builder()
                             .amount(accountAmount.getAmount())
-                            .owner(EntityId.of(accountAmount.getAccountID()).getId())
+                            .owner(EntityId.tryOf(accountAmount.getAccountID()).getId())
                             .payerAccountId(payerAccountId)
                             .spender(transferSpenderId)
                             .tokenId(tokenId.getId())

--- a/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
@@ -41,7 +41,6 @@ public class Utility {
     public static final String HALT_ON_ERROR_PROPERTY = "HIERO_MIRROR_IMPORTER_PARSER_HALTONERROR";
     public static final String HALT_ON_DOWNLOADER_ERROR_PROPERTY = "HIERO_MIRROR_IMPORTER_DOWNLOADER_HALTONERROR";
 
-    static final String RECOVERABLE_ERROR = "Recoverable error. ";
     static final String HALT_ON_ERROR_DEFAULT = "false";
 
     /**
@@ -218,7 +217,7 @@ public class Utility {
             var formattedMessage = formattingTuple.getMessage();
             throw new ParserException(formattedMessage, throwable);
         } else {
-            log.error(RECOVERABLE_ERROR + message, args);
+            DomainUtils.logRecoverableError(message, args);
         }
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -210,6 +210,7 @@ final class ContractResultServiceImplTest {
         ids.add(Objects.requireNonNullElse(rootId, EntityId.EMPTY).getId());
         ids.add(EntityId.of(recordItem.getTransactionBody().getTransactionID().getAccountID())
                 .getId());
+        ids.remove(0L); // Do not store EntityId.EMPTY
 
         var idsList = new ArrayList<>(ids);
         idsList.sort(Long::compareTo);

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
@@ -768,6 +768,27 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 .returns(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId(), Transaction::getType);
     }
 
+    @Test
+    void submitMessageMaxCustomFeeOutOfRange() {
+        // given
+        final long outOfRangeAccountNum = 1L << 38; // 274,877,906,944
+        final var tokenId = recordItemBuilder.tokenId().toBuilder().setTokenNum(outOfRangeAccountNum);
+        final var customFeeLimit = CustomFeeLimit.newBuilder()
+                .setAccountId(recordItemBuilder.accountId().toBuilder().setAccountNum(outOfRangeAccountNum))
+                .addFees(FixedFee.newBuilder().setAmount(1).setDenominatingTokenId(tokenId))
+                .build();
+        final var recordItem = recordItemBuilder
+                .consensusSubmitMessage()
+                .transactionBodyWrapper(w -> w.clearMaxCustomFees().addMaxCustomFees(customFeeLimit))
+                .build();
+
+        // when
+        parseRecordItemAndCommit(recordItem);
+
+        // then
+        assertThat(transactionRepository.count()).isOne();
+    }
+
     @ParameterizedTest
     @CsvSource({
         "9000, test-message0, 9000000, runninghash, 1, 1, , , , false, 0",

--- a/importer/src/test/java/org/hiero/mirror/importer/util/UtilityTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/util/UtilityTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hiero.mirror.importer.util.Utility.HALT_ON_ERROR_DEFAULT;
 import static org.hiero.mirror.importer.util.Utility.HALT_ON_ERROR_PROPERTY;
-import static org.hiero.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -159,7 +158,7 @@ public class UtilityTest {
         System.setProperty(HALT_ON_ERROR_PROPERTY, "false");
         Utility.handleRecoverableError(format, args);
         var allOutput = capturedOutput.getAll();
-        assertThat(allOutput).contains(RECOVERABLE_ERROR + formatted);
+        assertThat(allOutput).contains(DomainUtils.RECOVERABLE_ERROR + formatted);
         if (causeProvided != null) {
             assertThat(allOutput).contains(causeLogOutput);
         }


### PR DESCRIPTION
**Description**:

Cherry-pick of #13955 to release/0.159:

* Add a `HIERO_MIRROR_COMMON_INVALIDENTITYEXCEPTION` system property to disable errors for invalid entity IDs
* Improve entity ID parsing

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
