### PR TITLE
Аdd stream input bound in importer

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/BlockTransaction.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/BlockTransaction.java
@@ -22,7 +22,6 @@ import com.hederahashgraph.api.proto.java.SlotKey;
 import com.hederahashgraph.api.proto.java.TopicID;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -52,8 +51,6 @@ import org.springframework.util.CollectionUtils;
 @ToString(onlyExplicitlyIncluded = true)
 @Value
 public class BlockTransaction implements StreamItem {
-
-    private static final MessageDigest DIGEST = createSha384Digest();
 
     @ToString.Include
     private final long consensusTimestamp;
@@ -287,7 +284,7 @@ public class BlockTransaction implements StreamItem {
     }
 
     private static ByteString digest(final byte[] data) {
-        return DomainUtils.fromBytes(DIGEST.digest(data));
+        return DomainUtils.fromBytes(createSha384Digest().digest(data));
     }
 
     private static <T extends MessageLite> T getTraceDataItem(

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/BlockTransactionTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/BlockTransactionTest.java
@@ -14,6 +14,7 @@ import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.ho
 import static org.hiero.mirror.common.domain.transaction.StateChangeTestUtils.makeIdentical;
 
 import com.google.common.primitives.Bytes;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.hedera.hapi.block.stream.output.protoc.CallContractOutput;
 import com.hedera.hapi.block.stream.output.protoc.MapChangeKey;
@@ -36,9 +37,13 @@ import com.hederahashgraph.api.proto.java.Token;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.Topic;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
@@ -379,6 +384,59 @@ final class BlockTransactionTest {
                 .build();
         assertThat(blockTransaction.getTransactionHash())
                 .isEqualTo(DomainUtils.fromBytes(Hex.decodeHex(expectedTransactionHash)));
+    }
+
+    @Test
+    void getTransactionHashIsThreadSafeAcrossConcurrentInstances() throws InterruptedException {
+        // given - regression test: BlockTransaction previously shared a single non-thread-safe static
+        // MessageDigest across instances, corrupting hashes when computed concurrently
+        var threadCount = 64;
+        var transactions = new ArrayList<BlockTransaction>(threadCount);
+        var expectedHashes = new ArrayList<ByteString>(threadCount);
+        var digest = DomainUtils.createSha384Digest();
+
+        for (int i = 0; i < threadCount; i++) {
+            var signedTransactionBytes = ("payload-" + i + "-" + "x".repeat(i)).getBytes();
+            var transactionResult = TransactionResult.newBuilder()
+                    .setConsensusTimestamp(Timestamp.newBuilder().setSeconds(i).build())
+                    .build();
+            var blockTransaction = defaultBuilder()
+                    .signedTransaction(SignedTransaction.getDefaultInstance())
+                    .signedTransactionBytes(signedTransactionBytes)
+                    .transactionResult(transactionResult)
+                    .build();
+            transactions.add(blockTransaction);
+
+            digest.reset();
+            expectedHashes.add(DomainUtils.fromBytes(digest.digest(signedTransactionBytes)));
+        }
+
+        var executor = Executors.newFixedThreadPool(threadCount);
+        var readyLatch = new CountDownLatch(threadCount);
+        var startLatch = new CountDownLatch(1);
+        var results = new ByteString[threadCount];
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            var index = i;
+            executor.submit(() -> {
+                readyLatch.countDown();
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                results[index] = transactions.get(index).getTransactionHash();
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // then
+        assertThat(results).containsExactlyElementsOf(expectedHashes);
     }
 
     @Test

--- a/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.Value;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.hiero.mirror.importer.exception.FileOperationException;
 import org.hiero.mirror.importer.exception.InvalidStreamFileException;
@@ -27,6 +28,8 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @Value
 public class StreamFileData {
+
+    private static final long MAX_DECOMPRESSED_BYTES = 1_073_741_824L; // 1 GiB
 
     private static final CompressorStreamFactory compressorStreamFactory = new CompressorStreamFactory(true);
 
@@ -108,12 +111,21 @@ public class StreamFileData {
             return getBytes();
         }
 
+        var filename = streamFilename.getFilename();
         try (var inputStream = new ByteArrayInputStream(getBytes());
                 var compressorInputStream =
-                        compressorStreamFactory.createCompressorInputStream(compressor, inputStream)) {
-            return compressorInputStream.readAllBytes();
+                        compressorStreamFactory.createCompressorInputStream(compressor, inputStream);
+                var boundedInputStream = BoundedInputStream.builder()
+                        .setInputStream(compressorInputStream)
+                        .setMaxCount(MAX_DECOMPRESSED_BYTES + 1)
+                        .get()) {
+            var decompressed = boundedInputStream.readAllBytes();
+            if (decompressed.length > MAX_DECOMPRESSED_BYTES) {
+                throw new InvalidStreamFileException("Decompressed size of stream file " + filename
+                        + " exceeds the maximum allowed size of " + MAX_DECOMPRESSED_BYTES + " bytes");
+            }
+            return decompressed;
         } catch (IOException e) {
-            var filename = streamFilename.getFilename();
             log.error("Failed to decompress stream file {}", filename);
             throw new InvalidStreamFileException(filename, e);
         }

--- a/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
@@ -30,10 +31,8 @@ import org.springframework.util.unit.DataSize;
 @Value
 public class StreamFileData {
 
-    public static final String MAX_DECOMPRESSED_BYTES_PROPERTY = "HIERO_MIRROR_IMPORTER_MAXDECOMPRESSEDBYTES";
-
-    private static final long DEFAULT_MAX_DECOMPRESSED_BYTES =
-            DataSize.ofMegabytes(200).toBytes();
+    private static final AtomicLong maxDecompressedBytes =
+            new AtomicLong(DataSize.ofMegabytes(512).toBytes());
 
     private static final CompressorStreamFactory compressorStreamFactory = new CompressorStreamFactory(true);
 
@@ -88,6 +87,10 @@ public class StreamFileData {
         return new StreamFileData(StreamFilename.from(filename), () -> bytes, Instant.now());
     }
 
+    public static void setMaxDecompressedBytes(long bytes) {
+        maxDecompressedBytes.set(bytes);
+    }
+
     public byte[] getBytes() {
         return bytes.get();
     }
@@ -116,14 +119,14 @@ public class StreamFileData {
         }
 
         var filename = streamFilename.getFilename();
-        var maxDecompressedBytes = getMaxDecompressedBytes();
+        var decompressionLimit = maxDecompressedBytes.get();
         try (var boundedInputStream = BoundedInputStream.builder()
                 .setInputStream(compressorStreamFactory.createCompressorInputStream(
                         compressor, new ByteArrayInputStream(getBytes())))
-                .setMaxCount(maxDecompressedBytes + 1)
+                .setMaxCount(decompressionLimit + 1)
                 .setOnMaxCount((max, count) -> {
                     throw new InvalidStreamFileException("Decompressed size of stream file " + filename
-                            + " exceeds the maximum allowed size of " + maxDecompressedBytes + " bytes");
+                            + " exceeds the maximum allowed size of " + decompressionLimit + " bytes");
                 })
                 .get()) {
             return boundedInputStream.readAllBytes();
@@ -131,10 +134,5 @@ public class StreamFileData {
             log.error("Failed to decompress stream file {}", filename);
             throw new InvalidStreamFileException(filename, e);
         }
-    }
-
-    private static long getMaxDecompressedBytes() {
-        var property = System.getProperty(MAX_DECOMPRESSED_BYTES_PROPERTY);
-        return StringUtils.isBlank(property) ? DEFAULT_MAX_DECOMPRESSED_BYTES : Long.parseLong(property);
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/domain/StreamFileData.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hiero.mirror.importer.exception.FileOperationException;
 import org.hiero.mirror.importer.exception.InvalidStreamFileException;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.util.unit.DataSize;
 
 @CustomLog
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -29,7 +30,10 @@ import org.jspecify.annotations.NullMarked;
 @Value
 public class StreamFileData {
 
-    private static final long MAX_DECOMPRESSED_BYTES = 1_073_741_824L; // 1 GiB
+    public static final String MAX_DECOMPRESSED_BYTES_PROPERTY = "HIERO_MIRROR_IMPORTER_MAXDECOMPRESSEDBYTES";
+
+    private static final long DEFAULT_MAX_DECOMPRESSED_BYTES =
+            DataSize.ofMegabytes(200).toBytes();
 
     private static final CompressorStreamFactory compressorStreamFactory = new CompressorStreamFactory(true);
 
@@ -112,22 +116,25 @@ public class StreamFileData {
         }
 
         var filename = streamFilename.getFilename();
-        try (var inputStream = new ByteArrayInputStream(getBytes());
-                var compressorInputStream =
-                        compressorStreamFactory.createCompressorInputStream(compressor, inputStream);
-                var boundedInputStream = BoundedInputStream.builder()
-                        .setInputStream(compressorInputStream)
-                        .setMaxCount(MAX_DECOMPRESSED_BYTES + 1)
-                        .get()) {
-            var decompressed = boundedInputStream.readAllBytes();
-            if (decompressed.length > MAX_DECOMPRESSED_BYTES) {
-                throw new InvalidStreamFileException("Decompressed size of stream file " + filename
-                        + " exceeds the maximum allowed size of " + MAX_DECOMPRESSED_BYTES + " bytes");
-            }
-            return decompressed;
+        var maxDecompressedBytes = getMaxDecompressedBytes();
+        try (var boundedInputStream = BoundedInputStream.builder()
+                .setInputStream(compressorStreamFactory.createCompressorInputStream(
+                        compressor, new ByteArrayInputStream(getBytes())))
+                .setMaxCount(maxDecompressedBytes + 1)
+                .setOnMaxCount((max, count) -> {
+                    throw new InvalidStreamFileException("Decompressed size of stream file " + filename
+                            + " exceeds the maximum allowed size of " + maxDecompressedBytes + " bytes");
+                })
+                .get()) {
+            return boundedInputStream.readAllBytes();
         } catch (IOException e) {
             log.error("Failed to decompress stream file {}", filename);
             throw new InvalidStreamFileException(filename, e);
         }
+    }
+
+    private static long getMaxDecompressedBytes() {
+        var property = System.getProperty(MAX_DECOMPRESSED_BYTES_PROPERTY);
+        return StringUtils.isBlank(property) ? DEFAULT_MAX_DECOMPRESSED_BYTES : Long.parseLong(property);
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockProperties.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockProperties.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.importer.downloader.block;
 
 import static org.hiero.mirror.importer.downloader.block.BlockNodeProperties.FULL_BLOCK_NODE_APIS;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.hiero.mirror.common.domain.transaction.BlockSourceType;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.domain.StreamFileData;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -51,6 +53,11 @@ public final class BlockProperties {
     private StreamProperties stream = new StreamProperties();
 
     private boolean writeFiles = false;
+
+    @PostConstruct
+    void init() {
+        StreamFileData.setMaxDecompressedBytes(stream.getMaxBlockSize().toBytes());
+    }
 
     public String getBucketName() {
         return StringUtils.isNotBlank(bucketName)

--- a/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
@@ -92,18 +92,28 @@ class StreamFileDataTest {
     }
 
     @Test
-    void decompressionIsBoundedAgainstDecompressionBomb() throws IOException {
-        String filename = "2021-03-10T16_00_00Z.rcd.gz";
-        byte[] uncompressedBytes = new byte[2_000_000_000]; // exceeds MAX_DECOMPRESSED_BYTES (1 GiB)
+    void decompressionExceedingMaxSizeThrows() throws IOException {
+        String previousProperty = System.getProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY);
+        System.setProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY, "100");
+        try {
+            String filename = "2021-03-10T16_00_00Z.rcd.gz";
+            byte[] uncompressedBytes = new byte[1000];
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            try (OutputStream os = new GZIPOutputStream(baos)) {
-                os.write(uncompressedBytes);
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                try (OutputStream os = new GZIPOutputStream(baos)) {
+                    os.write(uncompressedBytes);
+                }
+
+                StreamFileData streamFileData = StreamFileData.from(filename, baos.toByteArray());
+
+                assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
             }
-
-            StreamFileData streamFileData = StreamFileData.from(filename, baos.toByteArray());
-
-            assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
+        } finally {
+            if (previousProperty == null) {
+                System.clearProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY);
+            } else {
+                System.setProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY, previousProperty);
+            }
         }
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.util.unit.DataSize;
 
 class StreamFileDataTest {
 
@@ -93,8 +94,7 @@ class StreamFileDataTest {
 
     @Test
     void decompressionExceedingMaxSizeThrows() throws IOException {
-        String previousProperty = System.getProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY);
-        System.setProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY, "100");
+        StreamFileData.setMaxDecompressedBytes(100);
         try {
             String filename = "2021-03-10T16_00_00Z.rcd.gz";
             byte[] uncompressedBytes = new byte[1000];
@@ -109,11 +109,7 @@ class StreamFileDataTest {
                 assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
             }
         } finally {
-            if (previousProperty == null) {
-                System.clearProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY);
-            } else {
-                System.setProperty(StreamFileData.MAX_DECOMPRESSED_BYTES_PROPERTY, previousProperty);
-            }
+            StreamFileData.setMaxDecompressedBytes(DataSize.ofMegabytes(512).toBytes());
         }
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/StreamFileDataTest.java
@@ -90,4 +90,20 @@ class StreamFileDataTest {
         StreamFileData streamFileData = StreamFileData.from(filename, uncompressedBytes);
         assertThrows(InvalidStreamFileException.class, streamFileData::getInputStream);
     }
+
+    @Test
+    void decompressionIsBoundedAgainstDecompressionBomb() throws IOException {
+        String filename = "2021-03-10T16_00_00Z.rcd.gz";
+        byte[] uncompressedBytes = new byte[2_000_000_000]; // exceeds MAX_DECOMPRESSED_BYTES (1 GiB)
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (OutputStream os = new GZIPOutputStream(baos)) {
+                os.write(uncompressedBytes);
+            }
+
+            StreamFileData streamFileData = StreamFileData.from(filename, baos.toByteArray());
+
+            assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
+        }
+    }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockPropertiesTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockPropertiesTest.java
@@ -5,24 +5,94 @@ package org.hiero.mirror.importer.downloader.block;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.mirror.importer.downloader.block.BlockNodeTestUtils.singleEndpointProperties;
 import static org.hiero.mirror.importer.downloader.block.BlockNodeTestUtils.singleServiceEndpoint;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSortedSet;
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
 import org.hiero.mirror.common.domain.node.RegisteredServiceEndpoint.BlockNodeApi;
 import org.hiero.mirror.importer.ImporterProperties;
+import org.hiero.mirror.importer.domain.StreamFileData;
+import org.hiero.mirror.importer.exception.InvalidStreamFileException;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.util.unit.DataSize;
 
 final class BlockPropertiesTest {
 
     @AutoClose
     private static final ValidatorFactory VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
+
+    @Test
+    void initPropagatesMaxBlockSizeToStreamFileData() throws IOException {
+        var blockProperties = new BlockProperties(new ImporterProperties());
+        blockProperties.getStream().setMaxBlockSize(DataSize.ofBytes(100));
+        blockProperties.init();
+
+        try {
+            String filename = "2021-03-10T16_00_00Z.rcd.gz";
+            byte[] uncompressedBytes = new byte[1000];
+
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                try (OutputStream os = new GZIPOutputStream(baos)) {
+                    os.write(uncompressedBytes);
+                }
+
+                StreamFileData streamFileData = StreamFileData.from(filename, baos.toByteArray());
+
+                assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
+            }
+        } finally {
+            new BlockProperties(new ImporterProperties()).init();
+        }
+    }
+
+    @Test
+    void springBoundMaxBlockSizePropagatesToStreamFileData() throws IOException {
+        var context = new AnnotationConfigApplicationContext();
+        context.getEnvironment()
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "test", Map.of("hiero.mirror.importer.block.stream.maxBlockSize", "100B")));
+        ConfigurationPropertiesBindingPostProcessor.register(context.getDefaultListableBeanFactory());
+        context.register(ImporterProperties.class);
+        context.register(BlockProperties.class);
+        context.refresh();
+
+        try {
+            var blockProperties = context.getBean(BlockProperties.class);
+            assertThat(blockProperties.getStream().getMaxBlockSize().toBytes()).isEqualTo(100);
+
+            String filename = "2021-03-10T16_00_00Z.rcd.gz";
+            byte[] uncompressedBytes = new byte[1000];
+
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                try (OutputStream os = new GZIPOutputStream(baos)) {
+                    os.write(uncompressedBytes);
+                }
+
+                StreamFileData streamFileData = StreamFileData.from(filename, baos.toByteArray());
+
+                assertThrows(InvalidStreamFileException.class, streamFileData::getDecompressedBytes);
+            }
+        } finally {
+            context.close();
+            new BlockProperties(new ImporterProperties()).init();
+        }
+    }
 
     @Test
     void getBucketName() {


### PR DESCRIPTION
**Description**:
Аdd stream input bound in importer

Fixes #

**Notes for reviewer**:
`MAX_DECOMPRESSED_BYTES` set to `1gb`, can be changed or extracted to property
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
