### PR TITLE
Fix `test-native-images` workflow when working with tags

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -65,17 +65,6 @@ runs:
       run: |
         set -ex
 
-        # TEMP: remove this FORCE_NATIVE_TAG_PATH block after validating the tag path in CI
-        if [[ "${FORCE_NATIVE_TAG_PATH:-}" == "true" ]]; then
-          TAG="${FORCE_NATIVE_TAG_VERSION}"
-          VERSION="${FORCE_NATIVE_TAG_VERSION}"
-          TRIGGERED_BY_TAG=true
-          echo "TAG=${TAG}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "TRIGGERED_BY_TAG=${TRIGGERED_BY_TAG}" >> $GITHUB_ENV
-          exit 0
-        fi
-
         TAG=$(sed -nE 's/^version: (.+)$/\1/p' charts/hedera-mirror/Chart.yaml)
         VERSION=$(grep -oP 'version=\K.+' gradle.properties)
         TRIGGERED_BY_TAG=false

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -65,6 +65,17 @@ runs:
       run: |
         set -ex
 
+        # TEMP: remove this FORCE_NATIVE_TAG_PATH block after validating the tag path in CI
+        if [[ "${FORCE_NATIVE_TAG_PATH:-}" == "true" ]]; then
+          TAG="${FORCE_NATIVE_TAG_VERSION}"
+          VERSION="${FORCE_NATIVE_TAG_VERSION}"
+          TRIGGERED_BY_TAG=true
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "TRIGGERED_BY_TAG=${TRIGGERED_BY_TAG}" >> $GITHUB_ENV
+          exit 0
+        fi
+
         TAG=$(sed -nE 's/^version: (.+)$/\1/p' charts/hedera-mirror/Chart.yaml)
         VERSION=$(grep -oP 'version=\K.+' gradle.properties)
         TRIGGERED_BY_TAG=false
@@ -126,10 +137,12 @@ runs:
       run: |
         set -ex
         for module in grpc importer monitor rest-java web3; do
+          image="${IMAGE_REGISTRY}/${module}:${VERSION}"
           if [[ "${TRIGGERED_BY_TAG}" == "true" ]]; then
-            docker pull --platform linux/amd64 "${IMAGE_REGISTRY}/${module}:${VERSION}"
+            docker pull "${image}-amd64"
+            docker tag "${image}-amd64" "${image}"
           fi
-          kind load docker-image "${IMAGE_REGISTRY}/${module}:${VERSION}" -n "${SOLO_CLUSTER_NAME}"
+          kind load docker-image "${image}" -n "${SOLO_CLUSTER_NAME}"
         done
 
     - name: Build image (rest)
@@ -154,8 +167,12 @@ runs:
       run: |
         set -ex
         for module in rest test; do
-          docker pull --platform linux/amd64 "gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}"
-          kind load docker-image "gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}" -n "${SOLO_CLUSTER_NAME}"
+          image="gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}"
+          archive="$(mktemp)"
+          docker pull --platform linux/amd64 "${image}"
+          docker save --platform linux/amd64 -o "${archive}" "${image}"
+          kind load image-archive "${archive}" -n "${SOLO_CLUSTER_NAME}"
+          rm -f "${archive}"
         done
 
     - name: Install yq

--- a/.github/workflows/test-native-images.yml
+++ b/.github/workflows/test-native-images.yml
@@ -3,6 +3,8 @@
 name: Test native images
 
 on:
+  # TEMP: remove pull_request trigger after validating the tag path in CI
+  pull_request:
   push:
     tags:
       - "v*"
@@ -25,10 +27,15 @@ defaults:
 
 env:
   LC_ALL: C.UTF-8
+  # TEMP: remove FORCE_* vars after validating the tag path in CI
+  FORCE_NATIVE_TAG_PATH: "true"
+  FORCE_NATIVE_TAG_VERSION: "0.160.0-rc1"
 
 jobs:
   image:
-    if: github.ref_type != 'tag'
+    # TEMP: also skip on pull_request (tag path pulls published images). Restore to:
+    #   if: github.ref_type != 'tag'
+    if: github.ref_type != 'tag' && github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-native-images.yml
+++ b/.github/workflows/test-native-images.yml
@@ -3,8 +3,6 @@
 name: Test native images
 
 on:
-  # TEMP: remove pull_request trigger after validating the tag path in CI
-  pull_request:
   push:
     tags:
       - "v*"
@@ -27,15 +25,10 @@ defaults:
 
 env:
   LC_ALL: C.UTF-8
-  # TEMP: remove FORCE_* vars after validating the tag path in CI
-  FORCE_NATIVE_TAG_PATH: "true"
-  FORCE_NATIVE_TAG_VERSION: "0.160.0-rc1"
 
 jobs:
   image:
-    # TEMP: also skip on pull_request (tag path pulls published images). Restore to:
-    #   if: github.ref_type != 'tag'
-    if: github.ref_type != 'tag' && github.event_name != 'pull_request'
+    if: github.ref_type != 'tag'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description**:
This is a continuation of the fix for the `test-native-images` workflow when working with tags since the issue surfaced again on another place.

Verified with test commit that the images can be pulled and loaded - https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/30353239500/job/90255417172?pr=13986