### PR TITLE
Add workflow that compares gas estimation with actual contract results

### DIFF
--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Gas Estimate Accuracy
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Daily at midnight UTC
+  # TODO: revert — temporary triggers for testing this workflow; remove before merge
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Mirror node network"
+        required: true
+        type: choice
+        options:
+          - testnet
+          - mainnet
+        default: testnet
+      results_count:
+        description: "Number of contract results to process"
+        required: false
+        type: string
+        default: "100"
+      tolerance_percent:
+        description: "Max |estimate - gas_consumed| / gas_consumed percent"
+        required: false
+        type: string
+        default: "20"
+      sleep_seconds:
+        description: "Sleep between individual /contracts/call requests"
+        required: false
+        type: string
+        default: "0.3"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  LC_ALL: C.UTF-8
+
+jobs:
+  verify:
+    name: verify (${{ github.event_name == 'workflow_dispatch' && github.event.inputs.network || 'testnet' }})
+    runs-on: hiero-mirror-node-linux-medium
+    timeout-minutes: 180
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve configuration
+        id: config
+        run: |
+          set -euo pipefail
+
+          NETWORK="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.network || 'testnet' }}"
+          RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '100' }}"
+          TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent || '20' }}"
+          SLEEP_SECONDS="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sleep_seconds || '0.3' }}"
+
+          case "${NETWORK}" in
+            mainnet) HOST="mainnet-public.mirrornode.hedera.com" ;;
+            testnet) HOST="testnet.mirrornode.hedera.com" ;;
+            *)
+              echo "Unsupported network: ${NETWORK}"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "NETWORK=${NETWORK}"
+            echo "BASE_URL=https://${HOST}"
+            echo "RESULTS_COUNT=${RESULTS_COUNT}"
+            echo "TOLERANCE_PERCENT=${TOLERANCE_PERCENT}"
+            echo "SLEEP_SECONDS=${SLEEP_SECONDS}"
+          } >> "${GITHUB_ENV}"
+
+          echo "Resolved network=${NETWORK} base_url=https://${HOST} results_count=${RESULTS_COUNT} tolerance=${TOLERANCE_PERCENT}%"
+
+      - name: Verify gas estimates
+        run: |
+          chmod +x .github/workflows/resources/gas-estimate-accuracy.sh
+          .github/workflows/resources/gas-estimate-accuracy.sh

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -5,6 +5,8 @@ name: Gas Estimate Accuracy
 on:
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
+  # TODO: revert — temporary triggers for testing this workflow; remove before merge
+  pull_request:
   workflow_dispatch:
     inputs:
       network:
@@ -12,24 +14,25 @@ on:
         required: true
         type: choice
         options:
-          - testnet
           - mainnet
+          - previewnet
+          - testnet
         default: testnet
-      results_count:
+      total:
         description: "Number of contract results to process"
         required: false
-        type: string
-        default: "100"
+        type: number
+        default: 6000
       tolerance_percent:
-        description: "Max estimate overhead above gas_used percent (min is always 5%)"
+        description: "Max estimate overhead above gas_used percent (must be > 5; min overhead is always 5%)"
         required: false
-        type: string
-        default: "20"
+        type: number
+        default: 20
       sleep_seconds:
         description: "Sleep between individual /contracts/call requests"
         required: false
-        type: string
-        default: "0.3"
+        type: number
+        default: 0.3
 
 permissions:
   contents: read
@@ -61,13 +64,20 @@ jobs:
           set -euo pipefail
 
           NETWORK="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.network || 'testnet' }}"
-          RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '100' }}"
+          RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '6000' }}"
           TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent || '20' }}"
           SLEEP_SECONDS="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sleep_seconds || '0.3' }}"
+          MIN_TOLERANCE_PERCENT=5
+
+          if ! awk -v t="${TOLERANCE_PERCENT}" -v m="${MIN_TOLERANCE_PERCENT}" 'BEGIN { exit (t > m) ? 0 : 1 }'; then
+            echo "TOLERANCE_PERCENT must be greater than ${MIN_TOLERANCE_PERCENT} (got ${TOLERANCE_PERCENT})"
+            exit 1
+          fi
 
           case "${NETWORK}" in
-            mainnet) HOST="mainnet-public.mirrornode.hedera.com" ;;
+            mainnet) HOST="mainnet.mirrornode.hedera.com" ;;
             testnet) HOST="testnet.mirrornode.hedera.com" ;;
+            previewnet) HOST="previewnet.mirrornode.hedera.com" ;;
             *)
               echo "Unsupported network: ${NETWORK}"
               exit 1
@@ -86,5 +96,4 @@ jobs:
 
       - name: Verify gas estimates
         run: |
-          chmod +x .github/workflows/resources/gas-estimate-accuracy.sh
           .github/workflows/resources/gas-estimate-accuracy.sh

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -27,8 +27,13 @@ on:
         required: false
         type: number
         default: 3000
-      tolerance_percent:
-        description: "Max estimate overhead above gas_used percent (must be > 5; min overhead is always 5%)"
+      tolerance_percent_min:
+        description: "Min estimate overhead above gas_used percent"
+        required: false
+        type: number
+        default: 2
+      tolerance_percent_max:
+        description: "Max estimate overhead above gas_used percent"
         required: false
         type: number
         default: 20
@@ -69,9 +74,9 @@ jobs:
 
           NETWORK="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.network || 'testnet' }}"
           RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '3000' }}"
-          TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent || '20' }}"
+          TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent_max || '20' }}"
+          MIN_TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent_min || '2' }}"
           SLEEP_SECONDS="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sleep_seconds || '0.3' }}"
-          MIN_TOLERANCE_PERCENT=5
 
           if ! awk -v t="${TOLERANCE_PERCENT}" -v m="${MIN_TOLERANCE_PERCENT}" 'BEGIN { exit (t > m) ? 0 : 1 }'; then
             echo "TOLERANCE_PERCENT must be greater than ${MIN_TOLERANCE_PERCENT} (got ${TOLERANCE_PERCENT})"
@@ -92,11 +97,12 @@ jobs:
             echo "NETWORK=${NETWORK}"
             echo "BASE_URL=https://${HOST}"
             echo "RESULTS_COUNT=${RESULTS_COUNT}"
+            echo "MIN_TOLERANCE_PERCENT=${MIN_TOLERANCE_PERCENT}"
             echo "TOLERANCE_PERCENT=${TOLERANCE_PERCENT}"
             echo "SLEEP_SECONDS=${SLEEP_SECONDS}"
           } >> "${GITHUB_ENV}"
 
-          echo "Resolved network=${NETWORK} base_url=https://${HOST} results_count=${RESULTS_COUNT} tolerance=${TOLERANCE_PERCENT}%"
+          echo "Resolved network=${NETWORK} base_url=https://${HOST} results_count=${RESULTS_COUNT} min_tolerance=${MIN_TOLERANCE_PERCENT}% max_tolerance=${TOLERANCE_PERCENT}%"
 
       - name: Verify gas estimates
         run: |

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -26,7 +26,7 @@ on:
         description: "Number of contract results to process"
         required: false
         type: number
-        default: 6000
+        default: 3000
       tolerance_percent:
         description: "Max estimate overhead above gas_used percent (must be > 5; min overhead is always 5%)"
         required: false
@@ -68,7 +68,7 @@ jobs:
           set -euo pipefail
 
           NETWORK="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.network || 'testnet' }}"
-          RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '6000' }}"
+          RESULTS_COUNT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.results_count || '3000' }}"
           TOLERANCE_PERCENT="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tolerance_percent || '20' }}"
           SLEEP_SECONDS="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sleep_seconds || '0.3' }}"
           MIN_TOLERANCE_PERCENT=5

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: "100"
       tolerance_percent:
-        description: "Max |estimate - gas_consumed| / gas_consumed percent"
+        description: "Max estimate overhead above gas_consumed percent (min is always 5%)"
         required: false
         type: string
         default: "20"

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -5,8 +5,12 @@ name: Gas Estimate Accuracy
 on:
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
-  # TODO: revert — temporary triggers for testing this workflow; remove before merge
   pull_request:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/gas-estimate-accuracy.yml"
+      - ".github/workflows/resources/gas-estimate-accuracy.sh"
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -5,12 +5,6 @@ name: Gas Estimate Accuracy
 on:
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
-  pull_request:
-    branches:
-      - "main"
-    paths:
-      - ".github/workflows/gas-estimate-accuracy.yml"
-      - ".github/workflows/resources/gas-estimate-accuracy.sh"
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: "100"
       tolerance_percent:
-        description: "Max estimate overhead above gas_consumed percent (min is always 5%)"
+        description: "Max estimate overhead above gas_used percent (min is always 5%)"
         required: false
         type: string
         default: "20"

--- a/.github/workflows/gas-estimate-accuracy.yml
+++ b/.github/workflows/gas-estimate-accuracy.yml
@@ -5,8 +5,6 @@ name: Gas Estimate Accuracy
 on:
   schedule:
     - cron: "0 0 * * *" # Daily at midnight UTC
-  # TODO: revert — temporary triggers for testing this workflow; remove before merge
-  pull_request:
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -30,11 +30,12 @@ hex_to_dec() {
 within_tolerance() {
   local estimated="$1"
   local consumed="$2"
-  # |estimated - consumed| / consumed * 100 <= TOLERANCE_PERCENT
+  # Estimate must be at least 5% above gas_consumed and at most TOLERANCE_PERCENT above it.
   awk -v e="${estimated}" -v c="${consumed}" -v t="${TOLERANCE_PERCENT}" 'BEGIN {
     if (c <= 0) exit 1
-    diff = e > c ? e - c : c - e
-    exit (diff * 100.0 / c <= t) ? 0 : 1
+    lower = c * 1.05
+    upper = c * (1.0 + t / 100.0)
+    exit (e >= lower && e <= upper) ? 0 : 1
   }'
 }
 
@@ -49,7 +50,9 @@ build_request() {
       value: (.amount // 0),
       block: (if .block_number != null then (.block_number | tostring) else "latest" end)
     }
-    + (if (.to != null and .to != "" and .to != "0x") then {to: .to} else {} end)
+    + (if (.created_contract_ids | length) > 0 then {}
+       elif (.to != null and .to != "" and .to != "0x") then {to: .to}
+       else {} end)
   ' <<<"${result_json}"
 }
 
@@ -79,9 +82,9 @@ check_result() {
     return 0
   fi
 
-  local request body http_code response estimated consumed timestamp
+  local request body http_code response estimated consumed hash
   request="$(build_request "${result_json}")"
-  timestamp="$(jq -r '.timestamp // "unknown"' <<<"${result_json}")"
+  hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
   consumed="$(jq -r '.gas_consumed' <<<"${result_json}")"
 
   response="$(mktemp)"
@@ -98,10 +101,10 @@ check_result() {
     # Count those separately; only unexpected API failures fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))
-      log "Estimate revert for timestamp=${timestamp} request=${request}"
+      log "Estimate revert for hash=${hash} request=${request}"
     else
       api_errors=$((api_errors + 1))
-      log "API ${http_code} for timestamp=${timestamp} request=${request}: $(head -c 200 <<<"${body}")"
+      log "API ${http_code} for hash=${hash} request=${request}: $(head -c 200 <<<"${body}")"
     fi
     return 0
   fi
@@ -110,7 +113,7 @@ check_result() {
   result_hex="$(jq -r '.result // empty' <<<"${body}")"
   if [[ -z "${result_hex}" || "${result_hex}" == "null" ]]; then
     api_errors=$((api_errors + 1))
-    log "Missing estimate result for timestamp=${timestamp} request=${request}: $(head -c 200 <<<"${body}")"
+    log "Missing estimate result for hash=${hash} request=${request}: $(head -c 200 <<<"${body}")"
     return 0
   fi
 
@@ -123,10 +126,9 @@ check_result() {
     failed=$((failed + 1))
     local pct
     pct="$(awk -v e="${estimated}" -v c="${consumed}" 'BEGIN {
-      diff = e > c ? e - c : c - e
-      printf "%.2f", (diff * 100.0 / c)
+      printf "%.2f", ((e - c) * 100.0 / c)
     }')"
-    log "Out of tolerance for timestamp=${timestamp} request=${request}: estimated=${estimated} gas_consumed=${consumed} delta=${pct}%"
+    log "Out of tolerance for hash=${hash} request=${request}: estimated=${estimated} gas_consumed=${consumed} overhead=${pct}% (expected 5-${TOLERANCE_PERCENT}%)"
   fi
 }
 

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -30,7 +30,7 @@ hex_to_dec() {
 within_tolerance() {
   local estimated="$1"
   local consumed="$2"
-  # Estimate must be at least 5% above gas_consumed and at most TOLERANCE_PERCENT above it.
+  # Estimate must be at least 5% above gas_used and at most TOLERANCE_PERCENT above it.
   awk -v e="${estimated}" -v c="${consumed}" -v t="${TOLERANCE_PERCENT}" 'BEGIN {
     if (c <= 0) exit 1
     lower = c * 1.05
@@ -61,7 +61,7 @@ should_skip() {
   local reason
   reason="$(jq -r '
     if .result != "SUCCESS" then "non-success result"
-    elif .gas_consumed == null then "missing gas_consumed"
+    elif .gas_used == null then "missing gas_used"
     elif (.to == null or .to == "" or .to == "0x") and
          (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
       "missing data for contract deploy"
@@ -85,7 +85,7 @@ check_result() {
   local request body http_code response estimated consumed hash
   request="$(build_request "${result_json}")"
   hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
-  consumed="$(jq -r '.gas_consumed' <<<"${result_json}")"
+  consumed="$(jq -r '.gas_used' <<<"${result_json}")"
 
   response="$(mktemp)"
   http_code="$(curl -sS -o "${response}" -w '%{http_code}' \
@@ -101,10 +101,13 @@ check_result() {
     # Count those separately; only unexpected API failures fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))
-      log "Estimate revert for hash=${hash} request=${request}"
+      log "Estimate revert for hash=${hash}"
+      log "request=${request}"
     else
       api_errors=$((api_errors + 1))
-      log "API ${http_code} for hash=${hash} request=${request}: $(head -c 200 <<<"${body}")"
+      log "API ${http_code} for hash=${hash}"
+      log "request=${request}"
+      log "response=${body}"
     fi
     return 0
   fi
@@ -113,7 +116,9 @@ check_result() {
   result_hex="$(jq -r '.result // empty' <<<"${body}")"
   if [[ -z "${result_hex}" || "${result_hex}" == "null" ]]; then
     api_errors=$((api_errors + 1))
-    log "Missing estimate result for hash=${hash} request=${request}: $(head -c 200 <<<"${body}")"
+    log "Missing estimate result for hash=${hash}"
+    log "request=${request}"
+    log "response=${body}"
     return 0
   fi
 
@@ -128,7 +133,8 @@ check_result() {
     pct="$(awk -v e="${estimated}" -v c="${consumed}" 'BEGIN {
       printf "%.2f", ((e - c) * 100.0 / c)
     }')"
-    log "Out of tolerance for hash=${hash} request=${request}: estimated=${estimated} gas_consumed=${consumed} overhead=${pct}% (expected 5-${TOLERANCE_PERCENT}%)"
+    log "Out of tolerance for hash=${hash}: estimated=${estimated} gas_used=${consumed} overhead=${pct}% (expected 5-${TOLERANCE_PERCENT}%)"
+    log "request=${request}"
   fi
 }
 

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -90,11 +90,12 @@ check_result() {
     return 0
   fi
 
-  local request body http_code response estimated consumed hash
+  local request consumed hash
   request="$(build_request "${result_json}")"
   hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
   consumed="$(jq -r '.gas_used' <<<"${result_json}")"
 
+  local body http_code response
   response="$(mktemp)"
   http_code="$(curl -sS -o "${response}" -w '%{http_code}' \
     -X POST "${BASE_URL}/api/v1/contracts/call" \
@@ -122,6 +123,7 @@ check_result() {
     return 0
   fi
 
+  local estimated
   estimated="$(hex_to_dec "${result_hex}")"
   checked=$((checked + 1))
 
@@ -202,18 +204,18 @@ while ((processed < RESULTS_COUNT)); do
 done
 
 summary="$(cat <<EOF
-Summary
-  processed=${processed}
-  checked=${checked}
-  passed=${passed}
-  failed=${failed}
-  skipped=${skipped}
-  estimate_reverts=${estimate_reverts}
-  api_errors=${api_errors}
+  Fetched contract result count: ${processed}
+  Executed validation request count: ${checked}
+  Passed estimation count: ${passed}
+  Out of tolerance estimation count: ${failed}
+  Skipped request count: ${skipped}
+  Reverted estimate request count: ${estimate_reverts}
+  Errors count outside CONTRACT_REVERT_EXECUTED: ${api_errors}
 EOF
 )"
 log "${summary}"
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo "### Summary:" >> $GITHUB_STEP_SUMMARY
   printf '%s\n' "${summary}" >> "${GITHUB_STEP_SUMMARY}"
 fi
 

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -7,10 +7,9 @@ set -euo pipefail
 BASE_URL="${BASE_URL:?BASE_URL is required}"
 RESULTS_COUNT="${RESULTS_COUNT:-3000}"
 TOLERANCE_PERCENT="${TOLERANCE_PERCENT:-20}"
+MIN_TOLERANCE_PERCENT="${MIN_TOLERANCE_PERCENT:-2}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-0.3}"
 LIMIT=100
-# Minimum estimate overhead above gas_used; TOLERANCE_PERCENT is the max and must exceed this.
-MIN_TOLERANCE_PERCENT=5
 MAX_PAGE_FETCH_RETRIES=30
 
 processed=0
@@ -62,26 +61,47 @@ fetch_contract_bytecode() {
   curl -sS -f "${BASE_URL}/api/v1/contracts/${contract_id}" | jq -r '.bytecode // empty'
 }
 
+# Build create estimate data:
+# - Ethereum creates: function_parameters already has initcode + args
+# - Hedera creates: contracts.bytecode + function_parameters
+build_create_data() {
+  local result_json="$1"
+  local contract_id bytecode params
+
+  contract_id="$(jq -r '.contract_id // .created_contract_ids[0] // empty' <<<"${result_json}")"
+  params="$(jq -r '.function_parameters // empty' <<<"${result_json}")"
+  [[ "${params}" == 0x* || -z "${params}" ]] || params="0x${params}"
+
+  if [[ -n "${contract_id}" ]] \
+    && bytecode="$(fetch_contract_bytecode "${contract_id}")" \
+    && [[ -n "${bytecode}" && "${bytecode}" != "null" && "${bytecode}" != "0x" ]]; then
+    [[ "${bytecode}" == 0x* ]] || bytecode="0x${bytecode}"
+    # function_parameters already contains the bytecode (ethereum-style) — use it as-is.
+    if [[ -n "${params}" && "${params}" != "0x" && "${params}" == "${bytecode}"* ]]; then
+      printf '%s' "${params}"
+      return 0
+    fi
+    printf '%s%s' "${bytecode}" "${params#0x}"
+    return 0
+  fi
+
+  # No usable stored bytecode — fall back to function_parameters.
+  if [[ -n "${params}" && "${params}" != "0x" ]]; then
+    printf '%s' "${params}"
+    return 0
+  fi
+  return 1
+}
+
 # Build /contracts/call estimate body from a ContractResult.
-# For creates: data = contracts/{id}.bytecode + function_parameters (without 0x), and omit to.
 build_request() {
   local result_json="$1"
   local data
 
   if is_contract_create "${result_json}"; then
-    local contract_id bytecode params
-    contract_id="$(jq -r '.contract_id // .created_contract_ids[0] // empty' <<<"${result_json}")"
-    if [[ -z "${contract_id}" ]]; then
+    if ! data="$(build_create_data "${result_json}")"; then
       return 1
     fi
-    if ! bytecode="$(fetch_contract_bytecode "${contract_id}")" \
-      || [[ -z "${bytecode}" || "${bytecode}" == "null" || "${bytecode}" == "0x" ]]; then
-      return 1
-    fi
-    [[ "${bytecode}" == 0x* ]] || bytecode="0x${bytecode}"
-    params="$(jq -r '.function_parameters // empty' <<<"${result_json}")"
-    params="${params#0x}"
-    data="${bytecode}${params}"
     jq -c --arg data "${data}" '
       {
         estimate: true,
@@ -113,6 +133,7 @@ should_skip() {
   reason="$(jq -r '
     .contract_id as $cid
     | if .gas_used == null then "missing gas_used"
+      elif .gas_used <= 0 then "non-positive gas_used"
       elif (
           (.to == null or .to == "" or .to == "0x")
           or ($cid != null and ((.created_contract_ids // []) | index($cid) != null))
@@ -143,12 +164,14 @@ check_result() {
   local request consumed hash
   if ! request="$(build_request "${result_json}")"; then
     api_errors=$((api_errors + 1))
-    hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
-    log "Failed to build estimate request for hash=${hash} (bytecode fetch failed for contract create)"
     return 0
   fi
   hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
   consumed="$(jq -r '.gas_used' <<<"${result_json}")"
+  if [[ -z "${consumed}" ]] || ((consumed <= 0)); then
+    skipped=$((skipped + 1))
+    return 0
+  fi
 
   local body http_code response
   response="$(mktemp)"
@@ -161,7 +184,7 @@ check_result() {
   rm -f "${response}"
 
   if [[ "${http_code}" != "200" ]]; then
-    # Historical txs often revert on estimate replay (state/simulation drift).
+    # Historical txs often revert on estimate replay (due to state change).
     # Count those separately; only out-of-tolerance estimates fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:?BASE_URL is required}"
+RESULTS_COUNT="${RESULTS_COUNT:-100}"
+TOLERANCE_PERCENT="${TOLERANCE_PERCENT:-20}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-0.3}"
+MAX_PAGE_SIZE=100
+
+processed=0
+checked=0
+passed=0
+failed=0
+skipped=0
+estimate_reverts=0
+api_errors=0
+
+log() {
+  printf '%s\n' "$*"
+}
+
+hex_to_dec() {
+  local hex="${1#0x}"
+  printf '%d' "0x${hex}"
+}
+
+within_tolerance() {
+  local estimated="$1"
+  local consumed="$2"
+  # |estimated - consumed| / consumed * 100 <= TOLERANCE_PERCENT
+  awk -v e="${estimated}" -v c="${consumed}" -v t="${TOLERANCE_PERCENT}" 'BEGIN {
+    if (c <= 0) exit 1
+    diff = e > c ? e - c : c - e
+    exit (diff * 100.0 / c <= t) ? 0 : 1
+  }'
+}
+
+build_request() {
+  local result_json="$1"
+  jq -c '
+    {
+      estimate: true,
+      data: .function_parameters,
+      from: .from,
+      gas: (.gas_limit // 15000000),
+      value: (.amount // 0),
+      block: (if .block_number != null then (.block_number | tostring) else "latest" end)
+    }
+    + (if (.to != null and .to != "" and .to != "0x") then {to: .to} else {} end)
+  ' <<<"${result_json}"
+}
+
+should_skip() {
+  local result_json="$1"
+  local reason
+  reason="$(jq -r '
+    if .result != "SUCCESS" then "non-success result"
+    elif (.to == null or .to == "" or .to == "0x") and
+         (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
+      "missing data for contract deploy"
+    else empty end
+  ' <<<"${result_json}")"
+  if [[ -n "${reason}" ]]; then
+    printf '%s' "${reason}"
+    return 0
+  fi
+  return 1
+}
+
+check_result() {
+  local result_json="$1"
+  local skip_reason
+  if skip_reason="$(should_skip "${result_json}")"; then
+    skipped=$((skipped + 1))
+    return 0
+  fi
+
+  local request body http_code response estimated consumed timestamp
+  request="$(build_request "${result_json}")"
+  timestamp="$(jq -r '.timestamp // "unknown"' <<<"${result_json}")"
+  consumed="$(jq -r '.gas_consumed' <<<"${result_json}")"
+
+  response="$(mktemp)"
+  http_code="$(curl -sS -o "${response}" -w '%{http_code}' \
+    -X POST "${BASE_URL}/api/v1/contracts/call" \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    --data "${request}" || true)"
+  body="$(cat "${response}")"
+  rm -f "${response}"
+
+  if [[ "${http_code}" != "200" ]]; then
+    # Historical SUCCESS txs often revert on estimate replay (state/simulation drift).
+    # Count those separately; only unexpected API failures fail the job.
+    if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
+      estimate_reverts=$((estimate_reverts + 1))
+      log "Estimate revert for timestamp=${timestamp}"
+    else
+      api_errors=$((api_errors + 1))
+      log "API ${http_code} for timestamp=${timestamp}: $(head -c 200 <<<"${body}")"
+    fi
+    return 0
+  fi
+
+  local result_hex
+  result_hex="$(jq -r '.result // empty' <<<"${body}")"
+  if [[ -z "${result_hex}" || "${result_hex}" == "null" ]]; then
+    api_errors=$((api_errors + 1))
+    log "Missing estimate result for timestamp=${timestamp}: $(head -c 200 <<<"${body}")"
+    return 0
+  fi
+
+  estimated="$(hex_to_dec "${result_hex}")"
+  checked=$((checked + 1))
+
+  if within_tolerance "${estimated}" "${consumed}"; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    local pct
+    pct="$(awk -v e="${estimated}" -v c="${consumed}" 'BEGIN {
+      diff = e > c ? e - c : c - e
+      printf "%.2f", (diff * 100.0 / c)
+    }')"
+    log "Out of tolerance for timestamp=${timestamp}: estimated=${estimated} gas_consumed=${consumed} delta=${pct}%"
+  fi
+}
+
+log "Gas estimate accuracy check"
+log "  base_url=${BASE_URL}"
+log "  results_count=${RESULTS_COUNT}"
+log "  tolerance_percent=${TOLERANCE_PERCENT}"
+log "  sleep_seconds=${SLEEP_SECONDS}"
+
+if ((RESULTS_COUNT <= MAX_PAGE_SIZE)); then
+  limit="${RESULTS_COUNT}"
+else
+  limit="${MAX_PAGE_SIZE}"
+fi
+
+next_path="/api/v1/contracts/results?limit=${limit}&order=desc"
+page=0
+
+while ((processed < RESULTS_COUNT)); do
+  if [[ -z "${next_path}" || "${next_path}" == "null" ]]; then
+    log "No further pages after processing ${processed}/${RESULTS_COUNT} results; stopping early"
+    break
+  fi
+
+  page=$((page + 1))
+  page_url="${BASE_URL}${next_path}"
+  if ((RESULTS_COUNT > MAX_PAGE_SIZE)); then
+    log "Page ${page}: GET ${page_url} (${processed}/${RESULTS_COUNT} processed)"
+  else
+    log "GET ${page_url}"
+  fi
+
+  page_json="$(curl -sS -f "${page_url}")"
+  result_count="$(jq '.results | length' <<<"${page_json}")"
+  if [[ "${result_count}" -eq 0 ]]; then
+    log "Empty results page; stopping"
+    break
+  fi
+
+  while IFS= read -r result_json; do
+    if ((processed >= RESULTS_COUNT)); then
+      break
+    fi
+    check_result "${result_json}"
+    processed=$((processed + 1))
+    sleep "${SLEEP_SECONDS}"
+  done < <(jq -c '.results[]' <<<"${page_json}")
+
+  if ((RESULTS_COUNT <= MAX_PAGE_SIZE)); then
+    break
+  fi
+
+  next_path="$(jq -r '.links.next // empty' <<<"${page_json}")"
+done
+
+log ""
+log "Summary"
+log "  processed=${processed}"
+log "  checked=${checked}"
+log "  passed=${passed}"
+log "  failed=${failed}"
+log "  skipped=${skipped}"
+log "  estimate_reverts=${estimate_reverts}"
+log "  api_errors=${api_errors}"
+
+if ((checked == 0)); then
+  log "Gas estimate accuracy check failed: no comparable results"
+  exit 1
+fi
+
+if ((failed > 0 || api_errors > 0)); then
+  log "Gas estimate accuracy check failed"
+  exit 1
+fi
+
+log "Gas estimate accuracy check passed"
+exit 0

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -48,7 +48,7 @@ build_request() {
       from: .from,
       gas: (.gas_limit // 15000000),
       value: (.amount // 0),
-      block: (if .block_number != null then (.block_number | tostring) else "latest" end)
+      block: (if .block_number != null then ((.block_number - 1) | tostring) else "latest" end)
     }
     + (if (.created_contract_ids | length) > 0 then {}
        elif (.to != null and .to != "" and .to != "0x") then {to: .to}

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -5,10 +5,13 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:?BASE_URL is required}"
-RESULTS_COUNT="${RESULTS_COUNT:-100}"
+RESULTS_COUNT="${RESULTS_COUNT:-6000}"
 TOLERANCE_PERCENT="${TOLERANCE_PERCENT:-20}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-0.3}"
-MAX_PAGE_SIZE=100
+LIMIT=100
+# Minimum estimate overhead above gas_used; TOLERANCE_PERCENT is the max and must exceed this.
+MIN_TOLERANCE_PERCENT=5
+MAX_PAGE_FETCH_RETRIES=30
 
 processed=0
 checked=0
@@ -17,10 +20,16 @@ failed=0
 skipped=0
 estimate_reverts=0
 api_errors=0
+page_fetch_failures=0
 
 log() {
   printf '%s\n' "$*"
 }
+
+if ! awk -v t="${TOLERANCE_PERCENT}" -v m="${MIN_TOLERANCE_PERCENT}" 'BEGIN { exit (t > m) ? 0 : 1 }'; then
+  log "TOLERANCE_PERCENT must be greater than ${MIN_TOLERANCE_PERCENT} (got ${TOLERANCE_PERCENT})"
+  exit 1
+fi
 
 hex_to_dec() {
   local hex="${1#0x}"
@@ -30,10 +39,10 @@ hex_to_dec() {
 within_tolerance() {
   local estimated="$1"
   local consumed="$2"
-  # Estimate must be at least 5% above gas_used and at most TOLERANCE_PERCENT above it.
-  awk -v e="${estimated}" -v c="${consumed}" -v t="${TOLERANCE_PERCENT}" 'BEGIN {
+  # Estimate must be at least MIN_TOLERANCE_PERCENT above gas_used and at most TOLERANCE_PERCENT above it.
+  awk -v e="${estimated}" -v c="${consumed}" -v t="${TOLERANCE_PERCENT}" -v m="${MIN_TOLERANCE_PERCENT}" 'BEGIN {
     if (c <= 0) exit 1
-    lower = c * 1.05
+    lower = c * (1.0 + m / 100.0)
     upper = c * (1.0 + t / 100.0)
     exit (e >= lower && e <= upper) ? 0 : 1
   }'
@@ -61,8 +70,7 @@ should_skip() {
   local result_json="$1"
   local reason
   reason="$(jq -r '
-    if .result != "SUCCESS" then "non-success result"
-    elif .gas_used == null then "missing gas_used"
+    if .gas_used == null then "missing gas_used"
     elif (.to == null or .to == "" or .to == "0x") and
          (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
       "missing data for contract deploy"
@@ -97,7 +105,7 @@ check_result() {
   rm -f "${response}"
 
   if [[ "${http_code}" != "200" ]]; then
-    # Historical SUCCESS txs often revert on estimate replay (state/simulation drift).
+    # Historical txs often revert on estimate replay (state/simulation drift).
     # Count those separately; only out-of-tolerance estimates fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))
@@ -125,7 +133,7 @@ check_result() {
     pct="$(awk -v e="${estimated}" -v c="${consumed}" 'BEGIN {
       printf "%.2f", ((e - c) * 100.0 / c)
     }')"
-    log "Out of tolerance for hash=${hash}: estimated=${estimated} gas_used=${consumed} overhead=${pct}% (expected 5-${TOLERANCE_PERCENT}%)"
+    log "Out of tolerance for hash=${hash}: estimated=${estimated} gas_used=${consumed} overhead=${pct}% (expected ${MIN_TOLERANCE_PERCENT}-${TOLERANCE_PERCENT}%)"
     log "request=${request}"
   fi
 }
@@ -139,10 +147,10 @@ page_url_from_next() {
   fi
 }
 
-if ((RESULTS_COUNT < MAX_PAGE_SIZE)); then
+if ((RESULTS_COUNT < LIMIT)); then
   page_limit="${RESULTS_COUNT}"
 else
-  page_limit="${MAX_PAGE_SIZE}"
+  page_limit="${LIMIT}"
 fi
 
 next_path="/api/v1/contracts/results?limit=${page_limit}&order=desc"
@@ -153,11 +161,33 @@ while ((processed < RESULTS_COUNT)); do
   fi
 
   page_url="$(page_url_from_next "${next_path}")"
-  page_json="$(curl -sS -f "${page_url}")"
-  result_count="$(jq '.results | length' <<<"${page_json}")"
+  if ! page_json="$(curl -sS -f "${page_url}")"; then
+    page_fetch_failures=$((page_fetch_failures + 1))
+    log "Failed to fetch results page (${page_fetch_failures}/${MAX_PAGE_FETCH_RETRIES}): ${page_url}"
+    if ((page_fetch_failures >= MAX_PAGE_FETCH_RETRIES)); then
+      log "Giving up after ${MAX_PAGE_FETCH_RETRIES} consecutive results page fetch failures"
+      break
+    fi
+    sleep "${SLEEP_SECONDS}"
+    continue
+  fi
+
+  if ! result_count="$(jq '.results | length' <<<"${page_json}")" || [[ -z "${result_count}" ]]; then
+    page_fetch_failures=$((page_fetch_failures + 1))
+    log "Invalid results page response (${page_fetch_failures}/${MAX_PAGE_FETCH_RETRIES}): ${page_url}"
+    if ((page_fetch_failures >= MAX_PAGE_FETCH_RETRIES)); then
+      log "Giving up after ${MAX_PAGE_FETCH_RETRIES} consecutive results page fetch failures"
+      break
+    fi
+    sleep "${SLEEP_SECONDS}"
+    continue
+  fi
+
   if [[ "${result_count}" -eq 0 ]]; then
     break
   fi
+
+  page_fetch_failures=0
 
   while IFS= read -r result_json; do
     if ((processed >= RESULTS_COUNT)); then
@@ -171,14 +201,31 @@ while ((processed < RESULTS_COUNT)); do
   next_path="$(jq -r '.links.next // empty' <<<"${page_json}")"
 done
 
-log "Summary"
-log "  processed=${processed}"
-log "  checked=${checked}"
-log "  passed=${passed}"
-log "  failed=${failed}"
-log "  skipped=${skipped}"
-log "  estimate_reverts=${estimate_reverts}"
-log "  api_errors=${api_errors}"
+summary="$(cat <<EOF
+Summary
+  processed=${processed}
+  checked=${checked}
+  passed=${passed}
+  failed=${failed}
+  skipped=${skipped}
+  estimate_reverts=${estimate_reverts}
+  api_errors=${api_errors}
+EOF
+)"
+log "${summary}"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '%s\n' "${summary}" >> "${GITHUB_STEP_SUMMARY}"
+fi
+
+if ((page_fetch_failures >= MAX_PAGE_FETCH_RETRIES)); then
+  log "Gas estimate accuracy check failed: results page fetch retries exhausted"
+  exit 1
+fi
+
+if ((checked == 0)); then
+  log "Gas estimate accuracy check failed: no estimates were successfully checked (api_errors=${api_errors}, estimate_reverts=${estimate_reverts}, skipped=${skipped})"
+  exit 1
+fi
 
 if ((failed > 0)); then
   log "Gas estimate accuracy check failed: ${failed} out-of-tolerance estimate(s)"

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -39,12 +39,13 @@ within_tolerance() {
   }'
 }
 
+# Build /contracts/call estimate body from a ContractResult.
 build_request() {
   local result_json="$1"
   jq -c '
     {
       estimate: true,
-      data: .function_parameters,
+      data: (.function_parameters // "0x"),
       from: .from,
       gas: (.gas_limit // 15000000),
       value: (.amount // 0),
@@ -76,8 +77,7 @@ should_skip() {
 
 check_result() {
   local result_json="$1"
-  local skip_reason
-  if skip_reason="$(should_skip "${result_json}")"; then
+  if should_skip "${result_json}" >/dev/null; then
     skipped=$((skipped + 1))
     return 0
   fi
@@ -98,16 +98,11 @@ check_result() {
 
   if [[ "${http_code}" != "200" ]]; then
     # Historical SUCCESS txs often revert on estimate replay (state/simulation drift).
-    # Count those separately; only unexpected API failures fail the job.
+    # Count those separately; only out-of-tolerance estimates fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))
-      log "Estimate revert for hash=${hash}"
-      log "request=${request}"
     else
       api_errors=$((api_errors + 1))
-      log "API ${http_code} for hash=${hash}"
-      log "request=${request}"
-      log "response=${body}"
     fi
     return 0
   fi
@@ -116,9 +111,6 @@ check_result() {
   result_hex="$(jq -r '.result // empty' <<<"${body}")"
   if [[ -z "${result_hex}" || "${result_hex}" == "null" ]]; then
     api_errors=$((api_errors + 1))
-    log "Missing estimate result for hash=${hash}"
-    log "request=${request}"
-    log "response=${body}"
     return 0
   fi
 
@@ -138,39 +130,32 @@ check_result() {
   fi
 }
 
-log "Gas estimate accuracy check"
-log "  base_url=${BASE_URL}"
-log "  results_count=${RESULTS_COUNT}"
-log "  tolerance_percent=${TOLERANCE_PERCENT}"
-log "  sleep_seconds=${SLEEP_SECONDS}"
+page_url_from_next() {
+  local path_or_url="$1"
+  if [[ "${path_or_url}" =~ ^https?:// ]]; then
+    printf '%s' "${path_or_url}"
+  else
+    printf '%s%s' "${BASE_URL}" "${path_or_url}"
+  fi
+}
 
-if ((RESULTS_COUNT <= MAX_PAGE_SIZE)); then
-  limit="${RESULTS_COUNT}"
+if ((RESULTS_COUNT < MAX_PAGE_SIZE)); then
+  page_limit="${RESULTS_COUNT}"
 else
-  limit="${MAX_PAGE_SIZE}"
+  page_limit="${MAX_PAGE_SIZE}"
 fi
 
-next_path="/api/v1/contracts/results?limit=${limit}&order=desc"
-page=0
+next_path="/api/v1/contracts/results?limit=${page_limit}&order=desc"
 
 while ((processed < RESULTS_COUNT)); do
   if [[ -z "${next_path}" || "${next_path}" == "null" ]]; then
-    log "No further pages after processing ${processed}/${RESULTS_COUNT} results; stopping early"
     break
   fi
 
-  page=$((page + 1))
-  page_url="${BASE_URL}${next_path}"
-  if ((RESULTS_COUNT > MAX_PAGE_SIZE)); then
-    log "Page ${page}: GET ${page_url} (${processed}/${RESULTS_COUNT} processed)"
-  else
-    log "GET ${page_url}"
-  fi
-
+  page_url="$(page_url_from_next "${next_path}")"
   page_json="$(curl -sS -f "${page_url}")"
   result_count="$(jq '.results | length' <<<"${page_json}")"
   if [[ "${result_count}" -eq 0 ]]; then
-    log "Empty results page; stopping"
     break
   fi
 
@@ -183,14 +168,9 @@ while ((processed < RESULTS_COUNT)); do
     sleep "${SLEEP_SECONDS}"
   done < <(jq -c '.results[]' <<<"${page_json}")
 
-  if ((RESULTS_COUNT <= MAX_PAGE_SIZE)); then
-    break
-  fi
-
   next_path="$(jq -r '.links.next // empty' <<<"${page_json}")"
 done
 
-log ""
 log "Summary"
 log "  processed=${processed}"
 log "  checked=${checked}"
@@ -200,13 +180,8 @@ log "  skipped=${skipped}"
 log "  estimate_reverts=${estimate_reverts}"
 log "  api_errors=${api_errors}"
 
-if ((checked == 0)); then
-  log "Gas estimate accuracy check failed: no comparable results"
-  exit 1
-fi
-
-if ((failed > 0 || api_errors > 0)); then
-  log "Gas estimate accuracy check failed"
+if ((failed > 0)); then
+  log "Gas estimate accuracy check failed: ${failed} out-of-tolerance estimate(s)"
   exit 1
 fi
 

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 BASE_URL="${BASE_URL:?BASE_URL is required}"
-RESULTS_COUNT="${RESULTS_COUNT:-6000}"
+RESULTS_COUNT="${RESULTS_COUNT:-3000}"
 TOLERANCE_PERCENT="${TOLERANCE_PERCENT:-20}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-0.3}"
 LIMIT=100
@@ -48,33 +48,83 @@ within_tolerance() {
   }'
 }
 
+# Contract create: missing to, or the result's contract_id was itself created by the tx.
+is_contract_create() {
+  jq -e '
+    .contract_id as $cid
+    | (.to == null or .to == "" or .to == "0x")
+      or ($cid != null and ((.created_contract_ids // []) | index($cid) != null))
+  ' <<<"$1" >/dev/null
+}
+
+fetch_contract_bytecode() {
+  local contract_id="$1"
+  curl -sS -f "${BASE_URL}/api/v1/contracts/${contract_id}" | jq -r '.bytecode // empty'
+}
+
 # Build /contracts/call estimate body from a ContractResult.
+# For creates: data = contracts/{id}.bytecode + function_parameters (without 0x), and omit to.
 build_request() {
   local result_json="$1"
-  jq -c '
-    {
-      estimate: true,
-      data: (.function_parameters // "0x"),
-      from: .from,
-      gas: (.gas_limit // 15000000),
-      value: (.amount // 0),
-      block: (if .block_number != null then ((.block_number - 1) | tostring) else "latest" end)
-    }
-    + (if (.created_contract_ids | length) > 0 then {}
-       elif (.to != null and .to != "" and .to != "0x") then {to: .to}
-       else {} end)
-  ' <<<"${result_json}"
+  local data
+
+  if is_contract_create "${result_json}"; then
+    local contract_id bytecode params
+    contract_id="$(jq -r '.contract_id // .created_contract_ids[0] // empty' <<<"${result_json}")"
+    if [[ -z "${contract_id}" ]]; then
+      return 1
+    fi
+    if ! bytecode="$(fetch_contract_bytecode "${contract_id}")" \
+      || [[ -z "${bytecode}" || "${bytecode}" == "null" || "${bytecode}" == "0x" ]]; then
+      return 1
+    fi
+    [[ "${bytecode}" == 0x* ]] || bytecode="0x${bytecode}"
+    params="$(jq -r '.function_parameters // empty' <<<"${result_json}")"
+    params="${params#0x}"
+    data="${bytecode}${params}"
+    jq -c --arg data "${data}" '
+      {
+        estimate: true,
+        data: $data,
+        from: .from,
+        gas: (.gas_limit // 15000000),
+        value: (.amount // 0),
+        block: (if .block_number != null then ((.block_number - 1) | tostring) else "latest" end)
+      }
+    ' <<<"${result_json}"
+  else
+    jq -c '
+      {
+        estimate: true,
+        data: (.function_parameters // "0x"),
+        from: .from,
+        gas: (.gas_limit // 15000000),
+        value: (.amount // 0),
+        block: (if .block_number != null then ((.block_number - 1) | tostring) else "latest" end)
+      }
+      + (if (.to != null and .to != "" and .to != "0x") then {to: .to} else {} end)
+    ' <<<"${result_json}"
+  fi
 }
 
 should_skip() {
   local result_json="$1"
   local reason
   reason="$(jq -r '
-    if .gas_used == null then "missing gas_used"
-    elif (.to == null or .to == "" or .to == "0x") and
-         (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
-      "missing data for contract deploy"
-    else empty end
+    .contract_id as $cid
+    | if .gas_used == null then "missing gas_used"
+      elif (
+          (.to == null or .to == "" or .to == "0x")
+          or ($cid != null and ((.created_contract_ids // []) | index($cid) != null))
+        )
+        and ($cid == null)
+        and ((.created_contract_ids // []) | length) == 0 then
+        "missing contract id for contract create"
+      elif (.to == null or .to == "" or .to == "0x")
+        and ($cid == null or ((.created_contract_ids // []) | index($cid) == null))
+        and (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
+        "missing data for contract call"
+      else empty end
   ' <<<"${result_json}")"
   if [[ -n "${reason}" ]]; then
     printf '%s' "${reason}"
@@ -91,7 +141,12 @@ check_result() {
   fi
 
   local request consumed hash
-  request="$(build_request "${result_json}")"
+  if ! request="$(build_request "${result_json}")"; then
+    api_errors=$((api_errors + 1))
+    hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
+    log "Failed to build estimate request for hash=${hash} (bytecode fetch failed for contract create)"
+    return 0
+  fi
   hash="$(jq -r '.hash // "unknown"' <<<"${result_json}")"
   consumed="$(jq -r '.gas_used' <<<"${result_json}")"
 

--- a/.github/workflows/resources/gas-estimate-accuracy.sh
+++ b/.github/workflows/resources/gas-estimate-accuracy.sh
@@ -58,6 +58,7 @@ should_skip() {
   local reason
   reason="$(jq -r '
     if .result != "SUCCESS" then "non-success result"
+    elif .gas_consumed == null then "missing gas_consumed"
     elif (.to == null or .to == "" or .to == "0x") and
          (.function_parameters == null or .function_parameters == "" or .function_parameters == "0x") then
       "missing data for contract deploy"
@@ -97,10 +98,10 @@ check_result() {
     # Count those separately; only unexpected API failures fail the job.
     if [[ "${http_code}" == "400" ]] && grep -q 'CONTRACT_REVERT_EXECUTED' <<<"${body}"; then
       estimate_reverts=$((estimate_reverts + 1))
-      log "Estimate revert for timestamp=${timestamp}"
+      log "Estimate revert for timestamp=${timestamp} request=${request}"
     else
       api_errors=$((api_errors + 1))
-      log "API ${http_code} for timestamp=${timestamp}: $(head -c 200 <<<"${body}")"
+      log "API ${http_code} for timestamp=${timestamp} request=${request}: $(head -c 200 <<<"${body}")"
     fi
     return 0
   fi
@@ -109,7 +110,7 @@ check_result() {
   result_hex="$(jq -r '.result // empty' <<<"${body}")"
   if [[ -z "${result_hex}" || "${result_hex}" == "null" ]]; then
     api_errors=$((api_errors + 1))
-    log "Missing estimate result for timestamp=${timestamp}: $(head -c 200 <<<"${body}")"
+    log "Missing estimate result for timestamp=${timestamp} request=${request}: $(head -c 200 <<<"${body}")"
     return 0
   fi
 
@@ -125,7 +126,7 @@ check_result() {
       diff = e > c ? e - c : c - e
       printf "%.2f", (diff * 100.0 / c)
     }')"
-    log "Out of tolerance for timestamp=${timestamp}: estimated=${estimated} gas_consumed=${consumed} delta=${pct}%"
+    log "Out of tolerance for timestamp=${timestamp} request=${request}: estimated=${estimated} gas_consumed=${consumed} delta=${pct}%"
   fi
 }
 


### PR DESCRIPTION
**Description**:
This PR adds a new workflow that reads historical contracts results, then uses the data to construct an estimate request to the mirror node and compares the results. If the estimate is 5% to <configurable-tolerance>% above the actual gas used, the result is fine. Otherwise, an error message is logged and the workflow will fail. This workflow is scheduled to run nightly or manually with workflow_dispatch. 

Fixes #13942 