### PR TITLE
`test-native-images` workflow - add kind load per platform in TAG case

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -65,6 +65,19 @@ runs:
       run: |
         set -ex
 
+        # >>> TEMPORARY: force published-tag path for native-image PR test — REVERT AFTER TEST <<<
+        if [[ -n "${FORCE_TAG_PATH_VERSION:-}" ]]; then
+          VERSION="${FORCE_TAG_PATH_VERSION#v}"
+          TAG="${VERSION}"
+          TRIGGERED_BY_TAG=true
+          echo "Forcing tag path with VERSION=${VERSION}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "TRIGGERED_BY_TAG=${TRIGGERED_BY_TAG}" >> $GITHUB_ENV
+          exit 0
+        fi
+        # <<< TEMPORARY
+
         TAG=$(sed -nE 's/^version: (.+)$/\1/p' charts/hedera-mirror/Chart.yaml)
         VERSION=$(grep -oP 'version=\K.+' gradle.properties)
         TRIGGERED_BY_TAG=false
@@ -125,13 +138,23 @@ runs:
       shell: bash
       run: |
         set -ex
+        # kind load docker-image uses `ctr import --all-platforms`. Pulling a multi-arch GHCR
+        # tag (even with --platform) keeps the full index, so import fails with missing digests.
+        # Export a single-platform archive instead.
+        load_image() {
+          local image="$1"
+          local archive
+          archive="$(mktemp)"
+          docker save --platform linux/amd64 -o "${archive}" "${image}"
+          kind load image-archive "${archive}" -n "${SOLO_CLUSTER_NAME}"
+          rm -f "${archive}"
+        }
+
         for module in grpc importer monitor rest-java web3; do
-          image="${IMAGE_REGISTRY}/${module}:${VERSION}"
           if [[ "${TRIGGERED_BY_TAG}" == "true" ]]; then
-            docker pull "${image}-amd64"
-            docker tag "${image}-amd64" "${image}"
+            docker pull --platform linux/amd64 "${IMAGE_REGISTRY}/${module}:${VERSION}"
           fi
-          kind load docker-image "${image}" -n "${SOLO_CLUSTER_NAME}"
+          load_image "${IMAGE_REGISTRY}/${module}:${VERSION}"
         done
 
     - name: Build image (rest)
@@ -155,13 +178,19 @@ runs:
       shell: bash
       run: |
         set -ex
-        for module in rest test; do
-          image="gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}"
+        load_image() {
+          local image="$1"
+          local archive
           archive="$(mktemp)"
-          docker pull --platform linux/amd64 "${image}"
           docker save --platform linux/amd64 -o "${archive}" "${image}"
           kind load image-archive "${archive}" -n "${SOLO_CLUSTER_NAME}"
           rm -f "${archive}"
+        }
+
+        for module in rest test; do
+          image="gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}"
+          docker pull --platform linux/amd64 "${image}"
+          load_image "${image}"
         done
 
     - name: Install yq

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -65,19 +65,6 @@ runs:
       run: |
         set -ex
 
-        # >>> TEMPORARY: force published-tag path for native-image PR test — REVERT AFTER TEST <<<
-        if [[ -n "${FORCE_TAG_PATH_VERSION:-}" ]]; then
-          VERSION="${FORCE_TAG_PATH_VERSION#v}"
-          TAG="${VERSION}"
-          TRIGGERED_BY_TAG=true
-          echo "Forcing tag path with VERSION=${VERSION}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "TRIGGERED_BY_TAG=${TRIGGERED_BY_TAG}" >> $GITHUB_ENV
-          exit 0
-        fi
-        # <<< TEMPORARY
-
         TAG=$(sed -nE 's/^version: (.+)$/\1/p' charts/hedera-mirror/Chart.yaml)
         VERSION=$(grep -oP 'version=\K.+' gradle.properties)
         TRIGGERED_BY_TAG=false
@@ -138,22 +125,19 @@ runs:
       shell: bash
       run: |
         set -ex
-        # kind load docker-image uses `ctr import --all-platforms`. Pulling a multi-arch GHCR
-        # tag (even with --platform) keeps the full index, so import fails with missing digests.
-        # Export a single-platform archive instead.
         load_image() {
           local image="$1"
           local archive
           archive="$(mktemp)"
+          if [[ "${TRIGGERED_BY_TAG}" == "true" ]]; then
+            docker pull --platform linux/amd64 "${image}"
+          fi
           docker save --platform linux/amd64 -o "${archive}" "${image}"
           kind load image-archive "${archive}" -n "${SOLO_CLUSTER_NAME}"
           rm -f "${archive}"
         }
 
         for module in grpc importer monitor rest-java web3; do
-          if [[ "${TRIGGERED_BY_TAG}" == "true" ]]; then
-            docker pull --platform linux/amd64 "${IMAGE_REGISTRY}/${module}:${VERSION}"
-          fi
           load_image "${IMAGE_REGISTRY}/${module}:${VERSION}"
         done
 
@@ -182,6 +166,7 @@ runs:
           local image="$1"
           local archive
           archive="$(mktemp)"
+          docker pull --platform linux/amd64 "${image}"
           docker save --platform linux/amd64 -o "${archive}" "${image}"
           kind load image-archive "${archive}" -n "${SOLO_CLUSTER_NAME}"
           rm -f "${archive}"
@@ -189,7 +174,6 @@ runs:
 
         for module in rest test; do
           image="gcr.io/mirrornode/hedera-mirror-${module}:${VERSION}"
-          docker pull --platform linux/amd64 "${image}"
           load_image "${image}"
         done
 

--- a/.github/workflows/test-native-images.yml
+++ b/.github/workflows/test-native-images.yml
@@ -3,6 +3,9 @@
 name: Test native images
 
 on:
+  # >>> TEMPORARY: exercise published-tag / load-native-images path on PRs — REVERT AFTER TEST <<<
+  pull_request:
+  # <<< TEMPORARY
   push:
     tags:
       - "v*"
@@ -25,10 +28,16 @@ defaults:
 
 env:
   LC_ALL: C.UTF-8
+  # >>> TEMPORARY: force tag path with published images — REVERT AFTER TEST <<<
+  FORCE_TAG_PATH_VERSION: v0.160.0-rc1
+  # <<< TEMPORARY
 
 jobs:
   image:
-    if: github.ref_type != 'tag'
+    # >>> TEMPORARY: skip local native builds; use FORCE_TAG_PATH_VERSION images — REVERT AFTER TEST <<<
+    # Original: if: github.ref_type != 'tag'
+    if: false
+    # <<< TEMPORARY
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-native-images.yml
+++ b/.github/workflows/test-native-images.yml
@@ -3,9 +3,6 @@
 name: Test native images
 
 on:
-  # >>> TEMPORARY: exercise published-tag / load-native-images path on PRs — REVERT AFTER TEST <<<
-  pull_request:
-  # <<< TEMPORARY
   push:
     tags:
       - "v*"
@@ -28,16 +25,10 @@ defaults:
 
 env:
   LC_ALL: C.UTF-8
-  # >>> TEMPORARY: force tag path with published images — REVERT AFTER TEST <<<
-  FORCE_TAG_PATH_VERSION: v0.160.0-rc1
-  # <<< TEMPORARY
 
 jobs:
   image:
-    # >>> TEMPORARY: skip local native builds; use FORCE_TAG_PATH_VERSION images — REVERT AFTER TEST <<<
-    # Original: if: github.ref_type != 'tag'
-    if: false
-    # <<< TEMPORARY
+    if: github.ref_type != 'tag'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description**:
The previous fix for `test-native-images` workflow when running in case of TAG did not work as it was falsely tested by not going through the problematic path.

[A run](https://github.com/hiero-ledger/hiero-mirror-node/actions/runs/30438588916/job/90532159599?pr=13992) where we definitely go through the "Load native images" step.