### PR TITLE
Adjust cluster-mgmt scripts to support single-zone deployments

### DIFF
--- a/tools/cluster-management/change-machine-type.sh
+++ b/tools/cluster-management/change-machine-type.sh
@@ -61,6 +61,7 @@ do
  unrouteTraffic "${namespace}"
  pauseCitus "${namespace}"
 done
+captureCitusPoolTotals
 resizeCitusNodePools 0
 for pool in "${POOLS_TO_UPDATE[@]}"
 do

--- a/tools/cluster-management/copy-live-environment.sh
+++ b/tools/cluster-management/copy-live-environment.sh
@@ -167,18 +167,30 @@ function runBackupsForAllNamespaces() {
 }
 
 function getBackupPaths() {
-  kubectl get sgshardedclusters --all-namespaces -o json \
-    | jq '[
-        .items[]
-        | {
-            (.metadata.namespace): {
-              (.metadata.name): (
-                .spec.configurations.backups[0].paths // []
-              )
-            }
+  # StackGres actually keeps backup paths on each member's .status.backupPaths, not the
+  # sharded cluster's spec - fall back to spec.paths to keep previous default unchanged
+  local sharded members
+  sharded="$(kubectl get sgshardedclusters --all-namespaces -o json)"
+  members="$(kubectl get sgclusters --all-namespaces -o json)"
+  jq -n --argjson sharded "${sharded}" --argjson members "${members}" '[
+      $sharded.items[]
+      | .metadata.namespace as $ns
+      | .metadata.name as $name
+      | ([
+          $members.items[]
+          | select(.metadata.namespace == $ns
+              and ((.metadata.ownerReferences // []) | any(.name == $name)))
+          | (.status.backupPaths // [])[]
+        ] | unique) as $statusPaths
+      | {
+          ($ns): {
+            ($name): (if ($statusPaths | length) > 0
+              then $statusPaths
+              else (.spec.configurations.backups[0].paths // []) end)
           }
-      ]
-      | add'
+        }
+    ]
+    | add'
 }
 
 function getLatestBackup() {

--- a/tools/cluster-management/utils/snapshot-utils.sh
+++ b/tools/cluster-management/utils/snapshot-utils.sh
@@ -649,6 +649,12 @@ function replaceDisks() {
     log "Waiting for disks to be created"
     wait
 
+    # minio-sg-snapshot etc. have no pvcName - skip them or the jq below wouldn't work
+    CITUS_DISK_SNAPSHOTS="$(jq '[.[] | select(any(.description[]?; has("pvcName")))]' <<<"${SNAPSHOTS_TO_RESTORE}")"
+    CITUS_COORDINATOR_NODE_COUNT="$(jq '[.[] | select(any(.description[]?; .pvcName | test("coord")))] | length' <<<"${CITUS_DISK_SNAPSHOTS}")"
+    CITUS_WORKER_NODE_COUNT="$(jq '[.[] | select((any(.description[]?; .pvcName | test("coord"))) | not)] | length' <<<"${CITUS_DISK_SNAPSHOTS}")"
+    export CITUS_COORDINATOR_NODE_COUNT CITUS_WORKER_NODE_COUNT
+    log "Citus totals from snapshots: coordinator=${CITUS_COORDINATOR_NODE_COUNT}, worker=${CITUS_WORKER_NODE_COUNT}"
     resizeCitusNodePools 1
   else
     log "REPLACE_DISKS is set to false. Skipping disk replacement"

--- a/tools/cluster-management/utils/utils.sh
+++ b/tools/cluster-management/utils/utils.sh
@@ -88,7 +88,7 @@ function getCitusClusters() {
                .spec.postgres.version as $pgVersion|
                ((.metadata.labels["stackgres.io/coordinator"] // "false")| test("true")) as $isCoordinator |
                .spec.configurations.patroni.initialConfig.citus.group as $citusGroup|
-               .status.podStatuses[]|
+               (.status.podStatuses // [])[]|
                  {
                    citusGroup: $citusGroup,
                    clusterName: $metadata.name,
@@ -428,9 +428,59 @@ function waitForRecordStreamSync() {
   done
 }
 
+function resyncCitusNodeAddresses() {
+  local namespace="${1}"
+
+  log "Verifying Citus node addresses match current pod IPs"
+
+  local distNodes
+  distNodes=$(kubectl exec -n "${namespace}" "${HELM_RELEASE_NAME}-citus-coord-0" -c postgres-util -- \
+    psql -U postgres -d mirror_node -P format=unaligned -t -F',' \
+    -c "select nodeid, groupid, nodename, nodeport from pg_dist_node where noderole = 'primary' order by nodeid")
+
+  local staleUpdates=()
+  while IFS=',' read -r nodeid groupid nodename nodeport; do
+    [[ -z "${nodeid}" ]] && continue
+    local currentIp
+    currentIp=$(kubectl get pods -n "${namespace}" -l "citus-group=${groupid},role=primary" \
+      -o jsonpath='{.items[0].status.podIP}')
+    if [[ -z "${currentIp}" ]]; then
+      log "WARN: no primary pod found for citus-group ${groupid}; skipping nodeid ${nodeid}"
+      continue
+    fi
+    if [[ "${currentIp}" != "${nodename}" ]]; then
+      log "Node ${nodeid} (group ${groupid}) stale: registered ${nodename}:${nodeport}, actual ${currentIp}:${nodeport}"
+      staleUpdates+=("${nodeid}:${currentIp}:${nodeport}")
+    fi
+  done <<<"${distNodes}"
+
+  if [[ ${#staleUpdates[@]} -eq 0 ]]; then
+    log "All Citus node addresses are up to date"
+    return 0
+  fi
+
+  # citus_update_node enforces a unique (host, port) pair, so jumping straight to the real
+  # port can collide with another stale entry - stage everyone through a scratch port first
+  local i=0 entry
+  for entry in "${staleUpdates[@]}"; do
+    IFS=':' read -r nodeid currentIp nodeport <<<"${entry}"
+    kubectl exec -n "${namespace}" "${HELM_RELEASE_NAME}-citus-coord-0" -c postgres-util -- \
+      psql -U postgres -d mirror_node -c "SELECT citus_update_node(${nodeid}, '${currentIp}', $((19000 + i)));" >/dev/null
+    i=$((i + 1))
+  done
+
+  for entry in "${staleUpdates[@]}"; do
+    IFS=':' read -r nodeid currentIp nodeport <<<"${entry}"
+    kubectl exec -n "${namespace}" "${HELM_RELEASE_NAME}-citus-coord-0" -c postgres-util -- \
+      psql -U postgres -d mirror_node -c "SELECT citus_update_node(${nodeid}, '${currentIp}', ${nodeport});" >/dev/null
+    log "Updated nodeid ${nodeid} -> ${currentIp}:${nodeport}"
+  done
+}
+
 function routeTraffic() {
   local namespace="${1}"
 
+  resyncCitusNodeAddresses "${namespace}"
   checkCitusMetadataSyncStatus "${namespace}"
   runTestQueries "${namespace}"
   scaleDeployment "${namespace}" 1 "app.kubernetes.io/component=importer"
@@ -823,6 +873,14 @@ function waitForClusterOperations() {
   done
 }
 
+function captureCitusPoolTotals() {
+  # Snapshot the current per-role totals so a later scale-up can restore the same count
+  CITUS_COORDINATOR_NODE_COUNT="$(kubectl get nodes -l 'citus-role=coordinator' --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  CITUS_WORKER_NODE_COUNT="$(kubectl get nodes -l 'citus-role=worker' --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  export CITUS_COORDINATOR_NODE_COUNT CITUS_WORKER_NODE_COUNT
+  log "Captured Citus node totals: coordinator=${CITUS_COORDINATOR_NODE_COUNT}, worker=${CITUS_WORKER_NODE_COUNT}"
+}
+
 function resizeCitusNodePools() {
   local numNodes="${1}"
 
@@ -842,12 +900,40 @@ function resizeCitusNodePools() {
   fi
 
   for pool in "${citusPools[@]}"; do
-    log "Scaling pool ${pool} to ${numNodes} nodes"
+    local targetNodes="${numNodes}"
+
+    # --num-nodes is per-zone, so convert our per-role total to per-zone using this pool's
+    # zone count - fall back to numNodes if we don't have a total to work with
+    if [[ "${numNodes}" -gt 0 ]]; then
+      local poolJson role zones total
+      poolJson="$(gcloud container node-pools describe "${pool}" \
+        --project="${GCP_TARGET_PROJECT}" \
+        --location="${GCP_K8S_TARGET_CLUSTER_REGION}" \
+        --cluster="${GCP_K8S_TARGET_CLUSTER_NAME}" \
+        --format="json(config.labels, locations)" 2>/dev/null || true)"
+      [[ -z "${poolJson}" ]] && poolJson='{}'
+      role="$(jq -r '.config.labels["citus-role"] // ""' <<<"${poolJson}")"
+      zones="$(jq -r '.locations | length' <<<"${poolJson}")"
+      case "${role}" in
+        coordinator) total="${CITUS_COORDINATOR_NODE_COUNT:-}" ;;
+        worker) total="${CITUS_WORKER_NODE_COUNT:-}" ;;
+        *) total="" ;;
+      esac
+      if [[ "${total:-0}" -gt 0 ]]; then
+        if [[ "${zones}" -gt 0 && $(( total % zones )) -eq 0 ]]; then
+          targetNodes=$(( total / zones ))
+        else
+          log "WARN: ${role} total ${total} not divisible by ${zones} zone(s) for ${pool}; using ${numNodes}/zone"
+        fi
+      fi
+    fi
+
+    log "Scaling pool ${pool} to ${targetNodes} nodes"
     waitForClusterOperations "${pool}"
 
     gcloud container clusters resize "${GCP_K8S_TARGET_CLUSTER_NAME}" \
       --node-pool="${pool}" \
-      --num-nodes="${numNodes}" \
+      --num-nodes="${targetNodes}" \
       --location="${GCP_K8S_TARGET_CLUSTER_REGION}" \
       --project="${GCP_TARGET_PROJECT}" --quiet &
   done
@@ -1012,6 +1098,9 @@ function waitForPodReady() {
 
 AUTO_CONFIRM="${AUTO_CONFIRM:-false}"
 AUTO_UNROUTE="${AUTO_UNROUTE:-true}"
+# Per-role totals (all zones) for scale-up - resizeCitusNodePools converts to per-zone; empty means just use numNodes/zone
+CITUS_COORDINATOR_NODE_COUNT="${CITUS_COORDINATOR_NODE_COUNT:-}"
+CITUS_WORKER_NODE_COUNT="${CITUS_WORKER_NODE_COUNT:-}"
 CITUS_NAMESPACES=
 COMMON_NAMESPACE="${COMMON_NAMESPACE:-common}"
 DISK_PREFIX=


### PR DESCRIPTION
**Description**:
Added support for single-zone Citus clusters, while retaining full multi-zone support:
- Fix `resizeCitusNodePools`: `gcloud clusters resize --num-nodes` is per-zone, not total; convert per-role totals to per-zone using each pool's own zone count, falling back to the old behavior when no total is available
- Add `captureCitusPoolTotals` to snapshot current per-role node counts before a machine-type change scales pools down, so scale-up restores the same topology
- Add `resyncCitusNodeAddresses` (called in `routeTraffic`): after node pools recycle, pod IPs change but `pg_dist_node` keeps stale entries; detect and repair via `citus_update_node`, staged through temporary ports to avoid a unique (host, port) collision
- Fix `getCitusClusters`: null-guard `.status.podStatuses` for clusters where a shard pod hasn't started yet
- Fix `replaceDisks`: exclude non-disk snapshot entries (e.g. minio-sg-snapshot) from per-role disk counts; they have no pvcName and previously crashed the count

Bonus fix to an issue that has caused the end of the stackgres-copy workflow to get stuck in single and multi-zone runs alike:
- Fix `getBackupPaths`: read backup paths from each member SGCluster's `.status.backupPaths` instead of the sharded cluster's (empty) spec field; the previous field caused restored clusters to search the wrong WAL path and loop on Archive does not exist

**Related issue(s)**:
Fixes #13780 

**Notes for reviewer**:
The changes to all of the scripts and utility functions were tested based on the mapping below, in both single-zone and multi-zone setups.

First level script name is the executed one, second level scripts are being called internally within the executed script.
The three executed scripts provide full coverage.
```
- change-machine-type.sh
  - upgrade-k8s-version-citus.sh
  - upgrade-citus-version.sh
  - minor-postgres-version-upgrade.sh
  - reduce-citus-disk-size.sh
  - restore-stackgres-backup.sh
- copy-live-environment.sh
  - volume-snapshot.sh
- restore-volume-snapshot.sh
```

Credit to @jnels124 for his help and advice.

**Checklist**

- [x] Documented: comments added at the relevant code sections.
- [x] Tested: 
  - A full suite of the utility scripts ran against both multi and single-zone cluster setups.
  - K6 performance against the single-zone cluster and compared to the most recent multi-zone run, results posted to Notion.
