### PR TITLE
HIP-1081 Use block node server status details API for available blocks

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockNode.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockNode.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -125,15 +126,15 @@ public final class BlockNode implements AutoCloseable, Comparable<BlockNode> {
      *
      * @param blockNumber The block number to look for, or {@link Scheduler#EARLIEST_AVAILABLE_BLOCK_NUMBER} to ask for
      *                    the node's earliest available block
-     * @return The block number the node can serve, or -1 when it can't serve the request
+     * @return The block number the node can serve, or empty when it can't serve the request
      */
-    public long containsBlockOrEarliest(final long blockNumber) {
+    public Optional<Long> getBlockOrEarliest(final long blockNumber) {
         try {
             final var blockNodeService = BlockNodeServiceGrpc.newBlockingStub(statusChannel)
                     .withDeadlineAfter(streamProperties.getResponseTimeout());
             final var response = blockNodeService.serverStatusDetail(SERVER_STATUS_REQUEST);
 
-            long earliest = -1;
+            Long earliest = null;
             for (final var range : response.getAvailableRangesList()) {
                 final long start = range.getRangeStart();
                 final long end = range.getRangeEnd();
@@ -143,16 +144,16 @@ public final class BlockNode implements AutoCloseable, Comparable<BlockNode> {
 
                 if (blockNumber == EARLIEST_AVAILABLE_BLOCK_NUMBER) {
                     // The ranges aren't guaranteed sorted, so scan them all for the minimum
-                    earliest = earliest < 0 ? start : Math.min(earliest, start);
+                    earliest = earliest == null ? start : Math.min(earliest, start);
                 } else if (blockNumber >= start && blockNumber <= end) {
-                    return blockNumber;
+                    return Optional.of(blockNumber);
                 }
             }
 
-            return earliest;
+            return Optional.ofNullable(earliest);
         } catch (final Exception ex) {
             log.error("Failed to get server status detail for {}", this, ex);
-            return -1;
+            return Optional.empty();
         }
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockNode.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockNode.java
@@ -3,9 +3,9 @@
 package org.hiero.mirror.importer.downloader.block;
 
 import static com.hedera.hapi.block.stream.protoc.BlockItem.ItemCase.BLOCK_HEADER;
+import static org.hiero.mirror.importer.downloader.block.scheduler.Scheduler.EARLIEST_AVAILABLE_BLOCK_NUMBER;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Range;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
@@ -41,6 +41,7 @@ import org.hiero.mirror.common.domain.StreamType;
 import org.hiero.mirror.common.domain.node.RegisteredServiceEndpoint.BlockNodeApi;
 import org.hiero.mirror.common.domain.transaction.BlockFile;
 import org.hiero.mirror.importer.downloader.block.scheduler.Latency;
+import org.hiero.mirror.importer.downloader.block.scheduler.Scheduler;
 import org.hiero.mirror.importer.exception.BlockStreamException;
 import org.hiero.mirror.importer.reader.block.BlockStream;
 import org.hiero.mirror.importer.util.Utility;
@@ -57,7 +58,6 @@ public final class BlockNode implements AutoCloseable, Comparable<BlockNode> {
     static final String ERROR_METRIC_NAME = "hiero.mirror.importer.stream.error";
 
     private static final Comparator<BlockNode> COMPARATOR = Comparator.comparing(BlockNode::getProperties);
-    private static final Range<Long> EMPTY_BLOCK_RANGE = Range.closedOpen(0L, 0L);
     private static final ServerStatusRequest SERVER_STATUS_REQUEST = ServerStatusRequest.getDefaultInstance();
 
     private final AtomicInteger errors = new AtomicInteger();
@@ -120,19 +120,39 @@ public final class BlockNode implements AutoCloseable, Comparable<BlockNode> {
         }
     }
 
-    public Range<Long> getBlockRange() {
+    /**
+     * Checks the block node's available block ranges for the requested block.
+     *
+     * @param blockNumber The block number to look for, or {@link Scheduler#EARLIEST_AVAILABLE_BLOCK_NUMBER} to ask for
+     *                    the node's earliest available block
+     * @return The block number the node can serve, or -1 when it can't serve the request
+     */
+    public long containsBlockOrEarliest(final long blockNumber) {
         try {
             final var blockNodeService = BlockNodeServiceGrpc.newBlockingStub(statusChannel)
                     .withDeadlineAfter(streamProperties.getResponseTimeout());
-            final var response = blockNodeService.serverStatus(SERVER_STATUS_REQUEST);
+            final var response = blockNodeService.serverStatusDetail(SERVER_STATUS_REQUEST);
 
-            final long firstBlockNumber = response.getFirstAvailableBlock();
-            return firstBlockNumber != -1
-                    ? Range.closed(firstBlockNumber, response.getLastAvailableBlock())
-                    : EMPTY_BLOCK_RANGE;
+            long earliest = -1;
+            for (final var range : response.getAvailableRangesList()) {
+                final long start = range.getRangeStart();
+                final long end = range.getRangeEnd();
+                if (start < 0 || end < start) {
+                    continue;
+                }
+
+                if (blockNumber == EARLIEST_AVAILABLE_BLOCK_NUMBER) {
+                    // The ranges aren't guaranteed sorted, so scan them all for the minimum
+                    earliest = earliest < 0 ? start : Math.min(earliest, start);
+                } else if (blockNumber >= start && blockNumber <= end) {
+                    return blockNumber;
+                }
+            }
+
+            return earliest;
         } catch (final Exception ex) {
-            log.error("Failed to get server status for {}", this, ex);
-            return EMPTY_BLOCK_RANGE;
+            log.error("Failed to get server status detail for {}", this, ex);
+            return -1;
         }
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractScheduler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractScheduler.java
@@ -162,8 +162,9 @@ abstract class AbstractScheduler implements Scheduler {
     }
 
     private static @Nullable ScheduledBlockNode hasBlock(final long nextBlockNumber, final BlockNode node) {
-        final long availableBlockNumber = node.containsBlockOrEarliest(nextBlockNumber);
-        return availableBlockNumber >= 0 ? new ScheduledBlockNode(node, availableBlockNumber) : null;
+        return node.getBlockOrEarliest(nextBlockNumber)
+                .map(availableBlockNumber -> new ScheduledBlockNode(node, availableBlockNumber))
+                .orElse(null);
     }
 
     private static boolean nodesChanged(final List<BlockNodeProperties> current, final List<BlockNodeProperties> next) {

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractScheduler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractScheduler.java
@@ -162,18 +162,8 @@ abstract class AbstractScheduler implements Scheduler {
     }
 
     private static @Nullable ScheduledBlockNode hasBlock(final long nextBlockNumber, final BlockNode node) {
-        final var blockRange = node.getBlockRange();
-        if (blockRange.isEmpty()) {
-            return null;
-        }
-
-        if (nextBlockNumber == EARLIEST_AVAILABLE_BLOCK_NUMBER) {
-            return new ScheduledBlockNode(node, blockRange.lowerEndpoint());
-        } else if (blockRange.contains(nextBlockNumber)) {
-            return new ScheduledBlockNode(node, nextBlockNumber);
-        }
-
-        return null;
+        final long availableBlockNumber = node.containsBlockOrEarliest(nextBlockNumber);
+        return availableBlockNumber >= 0 ? new ScheduledBlockNode(node, availableBlockNumber) : null;
     }
 
     private static boolean nodesChanged(final List<BlockNodeProperties> current, final List<BlockNodeProperties> next) {

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyService.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyService.java
@@ -124,7 +124,7 @@ public final class LatencyService implements AutoCloseable {
                     return;
                 }
 
-                if (!node.getBlockRange().contains(nextBlockNumber)) {
+                if (node.containsBlockOrEarliest(nextBlockNumber) < 0) {
                     if (++skipped >= 3) {
                         // Mark the latency stale in case at least 3 times in a row the node doesn't have the block
                         node.getLatency().markStale();

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyService.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyService.java
@@ -124,7 +124,7 @@ public final class LatencyService implements AutoCloseable {
                     return;
                 }
 
-                if (node.containsBlockOrEarliest(nextBlockNumber) < 0) {
+                if (node.getBlockOrEarliest(nextBlockNumber).isEmpty()) {
                     if (++skipped >= 3) {
                         // Mark the latency stale in case at least 3 times in a row the node doesn't have the block
                         node.getLatency().markStale();

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeSubscriberTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeSubscriberTest.java
@@ -31,9 +31,10 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.BlockRange;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
+import org.hiero.block.api.protoc.ServerStatusDetailResponse;
 import org.hiero.block.api.protoc.ServerStatusRequest;
-import org.hiero.block.api.protoc.ServerStatusResponse;
 import org.hiero.block.api.protoc.SubscribeStreamRequest;
 import org.hiero.block.api.protoc.SubscribeStreamResponse;
 import org.hiero.block.api.protoc.SubscribeStreamResponse.Code;
@@ -485,16 +486,19 @@ final class BlockNodeSubscriberTest extends BlockNodeTestBase {
         calls.compute(name, (_, value) -> value == null ? 1 : value + 1);
     }
 
-    private ServerStatusResponse serverStatusResponse(long firstBlockNumber, long lastBlockNumber) {
-        return ServerStatusResponse.newBuilder()
-                .setFirstAvailableBlock(firstBlockNumber)
-                .setLastAvailableBlock(lastBlockNumber)
+    private ServerStatusDetailResponse serverStatusResponse(long firstBlockNumber, long lastBlockNumber) {
+        return ServerStatusDetailResponse.newBuilder()
+                .addAvailableRanges(
+                        BlockRange.newBuilder().setRangeStart(firstBlockNumber).setRangeEnd(lastBlockNumber))
                 .build();
     }
 
     @SneakyThrows
     private void startServer(
-            String name, Resources resources, ServerStatusResponse statusResponse, ResponsesOrError streamResponse) {
+            String name,
+            Resources resources,
+            ServerStatusDetailResponse statusResponse,
+            ResponsesOrError streamResponse) {
         if (servers.containsKey(name)) {
             var server = servers.get(name);
             server.shutdown();
@@ -503,8 +507,8 @@ final class BlockNodeSubscriberTest extends BlockNodeTestBase {
 
         var statusService = new BlockNodeServiceGrpc.BlockNodeServiceImplBase() {
             @Override
-            public void serverStatus(
-                    ServerStatusRequest request, StreamObserver<ServerStatusResponse> responseObserver) {
+            public void serverStatusDetail(
+                    ServerStatusRequest request, StreamObserver<ServerStatusDetailResponse> responseObserver) {
                 recordCall(name, statusCalls);
                 responseObserver.onNext(statusResponse);
                 responseObserver.onCompleted();

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
@@ -136,31 +137,31 @@ final class BlockNodeTest extends BlockNodeTestBase {
             20, 20
             50, 50
             100, 100
-            19, -1
-            101, -1
+            19,
+            101,
             -1, 20
             """)
-    void containsBlockOrEarliest(long blockNumber, long expected, Resources resources) {
+    void getBlockOrEarliest(long blockNumber, Long expected, Resources resources) {
         // given
         runBlockNodeService(resources, () -> serverStatusDetailResponse(20, 100));
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+        assertThat(node.getBlockOrEarliest(blockNumber)).isEqualTo(Optional.ofNullable(expected));
     }
 
     @ParameterizedTest
     @CsvSource(textBlock = """
             3, 3
             12, 12
-            7, -1
+            7,
             -1, 0
             """)
-    void containsBlockOrEarliestWithGap(long blockNumber, long expected, Resources resources) {
+    void getBlockOrEarliestWithGap(long blockNumber, Long expected, Resources resources) {
         // given the ranges [0, 5] and [10, 20], sent out of order since a node may return them in any order
         runBlockNodeService(resources, () -> serverStatusDetailResponse(10, 20, 0, 5));
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+        assertThat(node.getBlockOrEarliest(blockNumber)).isEqualTo(Optional.ofNullable(expected));
     }
 
     @ParameterizedTest
@@ -168,15 +169,15 @@ final class BlockNodeTest extends BlockNodeTestBase {
             0, 0
             7, 7
             15, 15
-            16, -1
+            16,
             -1, 0
             """)
-    void containsBlockOrEarliestWithOverlap(long blockNumber, long expected, Resources resources) {
+    void getBlockOrEarliestWithOverlap(long blockNumber, Long expected, Resources resources) {
         // given the overlapping ranges [5, 15] and [0, 10], sent out of order
         runBlockNodeService(resources, () -> serverStatusDetailResponse(5, 15, 0, 10));
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+        assertThat(node.getBlockOrEarliest(blockNumber)).isEqualTo(Optional.ofNullable(expected));
     }
 
     @ParameterizedTest
@@ -185,37 +186,37 @@ final class BlockNodeTest extends BlockNodeTestBase {
             -1, 5
             10, 5
             """)
-    void containsBlockOrEarliestSkipsMalformedRange(long rangeStart, long rangeEnd, Resources resources) {
+    void getBlockOrEarliestSkipsMalformedRange(long rangeStart, long rangeEnd, Resources resources) {
         // given a malformed range alongside a valid [20, 100] one
         runBlockNodeService(resources, () -> serverStatusDetailResponse(rangeStart, rangeEnd, 20, 100));
 
         // when, then the malformed range is ignored and the valid one is still honored
-        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(50);
-        assertThat(node.containsBlockOrEarliest(-1)).isEqualTo(20);
-        assertThat(node.containsBlockOrEarliest(15)).isEqualTo(-1);
+        assertThat(node.getBlockOrEarliest(50)).contains(50L);
+        assertThat(node.getBlockOrEarliest(-1)).contains(20L);
+        assertThat(node.getBlockOrEarliest(15)).isEmpty();
     }
 
     @Test
-    void containsBlockOrEarliestFromEmptyBlockNode(Resources resources) {
+    void getBlockOrEarliestFromEmptyBlockNode(Resources resources) {
         // given
         runBlockNodeService(resources, ServerStatusDetailResponse::getDefaultInstance);
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(0)).isEqualTo(-1);
-        assertThat(node.containsBlockOrEarliest(-1)).isEqualTo(-1);
+        assertThat(node.getBlockOrEarliest(0)).isEmpty();
+        assertThat(node.getBlockOrEarliest(-1)).isEmpty();
     }
 
     @Test
-    void containsBlockOrEarliestOnError(Resources resources) {
+    void getBlockOrEarliestOnError(Resources resources) {
         // given
         runBlockNodeService(resources, List.of(new StatusException(Status.UNIMPLEMENTED)));
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(-1);
+        assertThat(node.getBlockOrEarliest(50)).isEmpty();
     }
 
     @Test
-    void containsBlockOrEarliestTimeout(Resources resources) {
+    void getBlockOrEarliestTimeout(Resources resources) {
         // given
         streamProperties.setResponseTimeout(Duration.ofMillis(1));
         runBlockNodeService(resources, () -> {
@@ -228,7 +229,7 @@ final class BlockNodeTest extends BlockNodeTestBase {
         });
 
         // when, then
-        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(-1);
+        assertThat(node.getBlockOrEarliest(50)).isEmpty();
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
@@ -12,12 +12,12 @@ import static org.hiero.mirror.importer.downloader.block.BlockNodeTestUtils.sing
 import com.asarkar.grpc.test.GrpcCleanupExtension;
 import com.asarkar.grpc.test.Resources;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import io.grpc.BindableService;
 import io.grpc.Server;
+import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.BlockingClientCall;
@@ -35,9 +35,10 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.BlockRange;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
+import org.hiero.block.api.protoc.ServerStatusDetailResponse;
 import org.hiero.block.api.protoc.ServerStatusRequest;
-import org.hiero.block.api.protoc.ServerStatusResponse;
 import org.hiero.block.api.protoc.SubscribeStreamRequest;
 import org.hiero.block.api.protoc.SubscribeStreamResponse;
 import org.hiero.mirror.common.domain.node.RegisteredServiceEndpoint.BlockNodeApi;
@@ -130,39 +131,104 @@ final class BlockNodeTest extends BlockNodeTestBase {
         assertThat(all).containsExactly(first, second, third, forth);
     }
 
-    @Test
-    void getBlockRange(Resources resources) {
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            20, 20
+            50, 50
+            100, 100
+            19, -1
+            101, -1
+            -1, 20
+            """)
+    void containsBlockOrEarliest(long blockNumber, long expected, Resources resources) {
         // given
-        runBlockNodeService(resources, () -> serverStatusResponse(20, 100));
+        runBlockNodeService(resources, () -> serverStatusDetailResponse(20, 100));
 
         // when, then
-        assertThat(node.getBlockRange()).isEqualTo(Range.closed(20L, 100L));
+        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            3, 3
+            12, 12
+            7, -1
+            -1, 0
+            """)
+    void containsBlockOrEarliestWithGap(long blockNumber, long expected, Resources resources) {
+        // given the ranges [0, 5] and [10, 20], sent out of order since a node may return them in any order
+        runBlockNodeService(resources, () -> serverStatusDetailResponse(10, 20, 0, 5));
+
+        // when, then
+        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, 0
+            7, 7
+            15, 15
+            16, -1
+            -1, 0
+            """)
+    void containsBlockOrEarliestWithOverlap(long blockNumber, long expected, Resources resources) {
+        // given the overlapping ranges [5, 15] and [0, 10], sent out of order
+        runBlockNodeService(resources, () -> serverStatusDetailResponse(5, 15, 0, 10));
+
+        // when, then
+        assertThat(node.containsBlockOrEarliest(blockNumber)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            0, -1
+            -1, 5
+            10, 5
+            """)
+    void containsBlockOrEarliestSkipsMalformedRange(long rangeStart, long rangeEnd, Resources resources) {
+        // given a malformed range alongside a valid [20, 100] one
+        runBlockNodeService(resources, () -> serverStatusDetailResponse(rangeStart, rangeEnd, 20, 100));
+
+        // when, then the malformed range is ignored and the valid one is still honored
+        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(50);
+        assertThat(node.containsBlockOrEarliest(-1)).isEqualTo(20);
+        assertThat(node.containsBlockOrEarliest(15)).isEqualTo(-1);
     }
 
     @Test
-    void getBlockRangeFromEmptyBlockNode(Resources resources) {
+    void containsBlockOrEarliestFromEmptyBlockNode(Resources resources) {
         // given
-        runBlockNodeService(resources, () -> serverStatusResponse(-1, -1));
+        runBlockNodeService(resources, ServerStatusDetailResponse::getDefaultInstance);
 
         // when, then
-        assertThat(node.getBlockRange().isEmpty()).isTrue();
+        assertThat(node.containsBlockOrEarliest(0)).isEqualTo(-1);
+        assertThat(node.containsBlockOrEarliest(-1)).isEqualTo(-1);
     }
 
     @Test
-    void getBlockRangeTimeout(Resources resources) {
+    void containsBlockOrEarliestOnError(Resources resources) {
+        // given
+        runBlockNodeService(resources, List.of(new StatusException(Status.UNIMPLEMENTED)));
+
+        // when, then
+        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(-1);
+    }
+
+    @Test
+    void containsBlockOrEarliestTimeout(Resources resources) {
         // given
         streamProperties.setResponseTimeout(Duration.ofMillis(1));
         runBlockNodeService(resources, () -> {
             try {
                 Thread.sleep(20);
-                return serverStatusResponse(20, 100);
+                return serverStatusDetailResponse(20, 100);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         });
 
         // when, then
-        assertThat(node.getBlockRange().isEmpty()).isTrue();
+        assertThat(node.containsBlockOrEarliest(50)).isEqualTo(-1);
     }
 
     @Test
@@ -524,11 +590,18 @@ final class BlockNodeTest extends BlockNodeTestBase {
         assertThat(meterRegistry.find(ERROR_METRIC_NAME).counter().count()).isEqualTo(2);
     }
 
-    private static ServerStatusResponse serverStatusResponse(final long first, final long last) {
-        return ServerStatusResponse.newBuilder()
-                .setFirstAvailableBlock(first)
-                .setLastAvailableBlock(last)
-                .build();
+    /**
+     * @param bounds Flattened inclusive range bounds, e.g. {@code serverStatusDetailResponse(0, 5, 10, 20)} for the
+     *     ranges [0, 5] and [10, 20]
+     */
+    private static ServerStatusDetailResponse serverStatusDetailResponse(final long... bounds) {
+        final var builder = ServerStatusDetailResponse.newBuilder();
+        for (int i = 0; i < bounds.length; i += 2) {
+            builder.addAvailableRanges(
+                    BlockRange.newBuilder().setRangeStart(bounds[i]).setRangeEnd(bounds[i + 1]));
+        }
+
+        return builder.build();
     }
 
     private BiFunction<BlockStream, String, Boolean> accumulate(Collection<BlockStream> collection) {
@@ -587,11 +660,11 @@ final class BlockNodeTest extends BlockNodeTestBase {
                 streamProperties);
     }
 
-    private void runBlockNodeService(Resources resources, Supplier<ServerStatusResponse> responseProvider) {
+    private void runBlockNodeService(Resources resources, Supplier<ServerStatusDetailResponse> responseProvider) {
         var service = new BlockNodeServiceGrpc.BlockNodeServiceImplBase() {
             @Override
-            public void serverStatus(
-                    ServerStatusRequest request, StreamObserver<ServerStatusResponse> responseObserver) {
+            public void serverStatusDetail(
+                    ServerStatusRequest request, StreamObserver<ServerStatusDetailResponse> responseObserver) {
                 responseObserver.onNext(responseProvider.get());
                 responseObserver.onCompleted();
             }
@@ -603,12 +676,13 @@ final class BlockNodeTest extends BlockNodeTestBase {
         final var iter = responseOrError.iterator();
         final var service = new BlockNodeServiceGrpc.BlockNodeServiceImplBase() {
             @Override
-            public void serverStatus(
-                    final ServerStatusRequest request, final StreamObserver<ServerStatusResponse> responseObserver) {
+            public void serverStatusDetail(
+                    final ServerStatusRequest request,
+                    final StreamObserver<ServerStatusDetailResponse> responseObserver) {
                 if (iter.hasNext()) {
                     final var object = iter.next();
-                    if (object instanceof ServerStatusResponse serverStatusResponse) {
-                        responseObserver.onNext(serverStatusResponse);
+                    if (object instanceof ServerStatusDetailResponse response) {
+                        responseObserver.onNext(response);
                         responseObserver.onCompleted();
                         return;
                     } else if (object instanceof Throwable error) {

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractSchedulerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractSchedulerTest.java
@@ -21,8 +21,9 @@ import java.time.Duration;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.BlockRange;
+import org.hiero.block.api.protoc.ServerStatusDetailResponse;
 import org.hiero.block.api.protoc.ServerStatusRequest;
-import org.hiero.block.api.protoc.ServerStatusResponse;
 import org.hiero.mirror.importer.downloader.block.BlockNode;
 import org.hiero.mirror.importer.downloader.block.BlockNodeDiscoveryService;
 import org.hiero.mirror.importer.downloader.block.BlockNodeProperties;
@@ -72,17 +73,16 @@ abstract class AbstractSchedulerTest {
         doReturn(List.of(nodeA)).when(blockNodeDiscoveryService).getBlockNodes();
         scheduler = createScheduler();
         final var removed = scheduler.getNode(0).blockNode();
-        assertThat(removed.getBlockRange().isEmpty()).isFalse();
+        assertThat(removed.containsBlockOrEarliest(0)).isZero();
 
         // when nodeA is no longer discovered (replaced by nodeB)
         final var nodeB = runBlockNodeService(0, resources, withAllBlocks());
         doReturn(List.of(nodeB)).when(blockNodeDiscoveryService).getBlockNodes();
         scheduler.getNode(0);
 
-        // then the removed node's channel is shut down so its status request now fails and yields an empty range
-        await().atMost(Duration.ofSeconds(2))
-                .untilAsserted(
-                        () -> assertThat(removed.getBlockRange().isEmpty()).isTrue());
+        // then the removed node's channel is shut down so its status request now fails and yields no block
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(removed.containsBlockOrEarliest(0))
+                .isEqualTo(-1));
     }
 
     @Test
@@ -98,6 +98,22 @@ abstract class AbstractSchedulerTest {
         assertThatThrownBy(() -> scheduler.getNode(1))
                 .isInstanceOf(NoBlockNodeAvailableException.class)
                 .hasMessageContaining("No block node can provide block 1");
+    }
+
+    @Test
+    void nodeWithGap(Resources resources) {
+        // given a node which has blocks [0, 5] and [10, 20] but nothing in between
+        var blockNodeProperties = runBlockNodeService(0, resources, withRanges(10, 20, 0, 5));
+        doReturn(List.of(blockNodeProperties)).when(blockNodeDiscoveryService).getBlockNodes();
+        scheduler = createScheduler();
+
+        // when, then
+        assertScheduledBlockNode(scheduler.getNode(3), 3, blockNodeProperties);
+        assertScheduledBlockNode(scheduler.getNode(12), 12, blockNodeProperties);
+        assertScheduledBlockNode(scheduler.getNode(Scheduler.EARLIEST_AVAILABLE_BLOCK_NUMBER), 0, blockNodeProperties);
+        assertThatThrownBy(() -> scheduler.getNode(7))
+                .isInstanceOf(NoBlockNodeAvailableException.class)
+                .hasMessageContaining("No block node can provide block 7");
     }
 
     @Test
@@ -140,11 +156,11 @@ abstract class AbstractSchedulerTest {
 
     @SneakyThrows
     protected BlockNodeProperties runBlockNodeService(
-            int priority, Resources resources, ServerStatusResponse response) {
+            int priority, Resources resources, ServerStatusDetailResponse response) {
         var service = new BlockNodeServiceGrpc.BlockNodeServiceImplBase() {
             @Override
-            public void serverStatus(
-                    ServerStatusRequest request, StreamObserver<ServerStatusResponse> responseObserver) {
+            public void serverStatusDetail(
+                    ServerStatusRequest request, StreamObserver<ServerStatusDetailResponse> responseObserver) {
                 responseObserver.onNext(response);
                 responseObserver.onCompleted();
             }
@@ -167,14 +183,30 @@ abstract class AbstractSchedulerTest {
         }
     }
 
-    protected static ServerStatusResponse withAllBlocks() {
+    protected static ServerStatusDetailResponse withAllBlocks() {
         return withBlocks(0, Long.MAX_VALUE);
     }
 
-    protected static ServerStatusResponse withBlocks(long first, long last) {
-        return ServerStatusResponse.newBuilder()
-                .setFirstAvailableBlock(first)
-                .setLastAvailableBlock(last)
-                .build();
+    protected static ServerStatusDetailResponse withBlocks(long first, long last) {
+        return withRanges(first, last);
+    }
+
+    /**
+     * Builds a server status detail response from pairs of inclusive range bounds.
+     *
+     * @param bounds Flattened range bounds, e.g. {@code withRanges(0, 5, 10, 20)} for blocks [0, 5] and [10, 20]
+     */
+    protected static ServerStatusDetailResponse withRanges(long... bounds) {
+        if (bounds.length % 2 != 0) {
+            throw new IllegalArgumentException("bounds must have an even number of elements");
+        }
+
+        var builder = ServerStatusDetailResponse.newBuilder();
+        for (int i = 0; i < bounds.length; i += 2) {
+            builder.addAvailableRanges(
+                    BlockRange.newBuilder().setRangeStart(bounds[i]).setRangeEnd(bounds[i + 1]));
+        }
+
+        return builder.build();
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractSchedulerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/AbstractSchedulerTest.java
@@ -73,7 +73,7 @@ abstract class AbstractSchedulerTest {
         doReturn(List.of(nodeA)).when(blockNodeDiscoveryService).getBlockNodes();
         scheduler = createScheduler();
         final var removed = scheduler.getNode(0).blockNode();
-        assertThat(removed.containsBlockOrEarliest(0)).isZero();
+        assertThat(removed.getBlockOrEarliest(0)).contains(0L);
 
         // when nodeA is no longer discovered (replaced by nodeB)
         final var nodeB = runBlockNodeService(0, resources, withAllBlocks());
@@ -81,8 +81,8 @@ abstract class AbstractSchedulerTest {
         scheduler.getNode(0);
 
         // then the removed node's channel is shut down so its status request now fails and yields no block
-        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(removed.containsBlockOrEarliest(0))
-                .isEqualTo(-1));
+        await().atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(removed.getBlockOrEarliest(0)).isEmpty());
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyServiceTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import org.hiero.mirror.importer.downloader.block.BlockNode;
 import org.hiero.mirror.importer.downloader.block.cutover.CutoverService;
 import org.hiero.mirror.importer.reader.block.BlockStreamReader;
@@ -47,7 +48,9 @@ final class LatencyServiceTest {
         // given
         final var blockNode = mock(BlockNode.class);
         // the node has every block
-        doAnswer(invocation -> invocation.<Long>getArgument(0)).when(blockNode).containsBlockOrEarliest(anyLong());
+        doAnswer(invocation -> Optional.of(invocation.<Long>getArgument(0)))
+                .when(blockNode)
+                .getBlockOrEarliest(anyLong());
         doReturn(0L).when(cutoverService).getNextBlockNumber();
 
         // when
@@ -59,7 +62,7 @@ final class LatencyServiceTest {
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(blockNode).streamBlocks(anyLong(), anyLong(), any(), any()));
         verify(cutoverService).getNextBlockNumber();
-        verify(blockNode).containsBlockOrEarliest(anyLong());
+        verify(blockNode).getBlockOrEarliest(anyLong());
 
         // when schedule again
         latencyService.schedule();
@@ -68,7 +71,7 @@ final class LatencyServiceTest {
         await().atMost(Duration.ofSeconds(2))
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(cutoverService, times(2)).getNextBlockNumber());
-        verify(blockNode).containsBlockOrEarliest(anyLong());
+        verify(blockNode).getBlockOrEarliest(anyLong());
         verify(blockNode).streamBlocks(anyLong(), anyLong(), any(), any());
 
         // when next block advances
@@ -79,7 +82,7 @@ final class LatencyServiceTest {
         await().atMost(Duration.ofSeconds(2))
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(cutoverService, times(3)).getNextBlockNumber());
-        verify(blockNode, times(2)).containsBlockOrEarliest(anyLong());
+        verify(blockNode, times(2)).getBlockOrEarliest(anyLong());
         verify(blockNode, times(2)).streamBlocks(anyLong(), anyLong(), any(), any());
     }
 
@@ -87,7 +90,7 @@ final class LatencyServiceTest {
     void scheduleBlockNodeSkipped() {
         // given
         final var blockNode = mock(BlockNode.class);
-        doReturn(-1L).when(blockNode).containsBlockOrEarliest(anyLong());
+        doReturn(Optional.empty()).when(blockNode).getBlockOrEarliest(anyLong());
         final var latency = mock(Latency.class);
         doReturn(latency).when(blockNode).getLatency();
         doReturn(1L).when(cutoverService).getNextBlockNumber();
@@ -100,7 +103,7 @@ final class LatencyServiceTest {
                     latencyService.schedule();
                     verify(latency, atLeast(1)).markStale();
                 });
-        verify(blockNode, atLeast(3)).containsBlockOrEarliest(anyLong());
+        verify(blockNode, atLeast(3)).getBlockOrEarliest(anyLong());
         verify(blockNode, never()).streamBlocks(anyLong(), anyLong(), any(), any());
         verify(cutoverService, atLeast(3)).getNextBlockNumber();
     }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyServiceTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/scheduler/LatencyServiceTest.java
@@ -6,13 +6,13 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.collect.Range;
 import java.time.Duration;
 import java.util.List;
 import org.hiero.mirror.importer.downloader.block.BlockNode;
@@ -46,7 +46,8 @@ final class LatencyServiceTest {
     void schedule() {
         // given
         final var blockNode = mock(BlockNode.class);
-        doReturn(Range.closed(0L, Long.MAX_VALUE)).when(blockNode).getBlockRange();
+        // the node has every block
+        doAnswer(invocation -> invocation.<Long>getArgument(0)).when(blockNode).containsBlockOrEarliest(anyLong());
         doReturn(0L).when(cutoverService).getNextBlockNumber();
 
         // when
@@ -58,7 +59,7 @@ final class LatencyServiceTest {
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(blockNode).streamBlocks(anyLong(), anyLong(), any(), any()));
         verify(cutoverService).getNextBlockNumber();
-        verify(blockNode).getBlockRange();
+        verify(blockNode).containsBlockOrEarliest(anyLong());
 
         // when schedule again
         latencyService.schedule();
@@ -67,7 +68,7 @@ final class LatencyServiceTest {
         await().atMost(Duration.ofSeconds(2))
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(cutoverService, times(2)).getNextBlockNumber());
-        verify(blockNode).getBlockRange();
+        verify(blockNode).containsBlockOrEarliest(anyLong());
         verify(blockNode).streamBlocks(anyLong(), anyLong(), any(), any());
 
         // when next block advances
@@ -78,7 +79,7 @@ final class LatencyServiceTest {
         await().atMost(Duration.ofSeconds(2))
                 .pollInterval(Duration.ofMillis(10))
                 .untilAsserted(() -> verify(cutoverService, times(3)).getNextBlockNumber());
-        verify(blockNode, times(2)).getBlockRange();
+        verify(blockNode, times(2)).containsBlockOrEarliest(anyLong());
         verify(blockNode, times(2)).streamBlocks(anyLong(), anyLong(), any(), any());
     }
 
@@ -86,7 +87,7 @@ final class LatencyServiceTest {
     void scheduleBlockNodeSkipped() {
         // given
         final var blockNode = mock(BlockNode.class);
-        doReturn(Range.closedOpen(0L, 1L)).when(blockNode).getBlockRange();
+        doReturn(-1L).when(blockNode).containsBlockOrEarliest(anyLong());
         final var latency = mock(Latency.class);
         doReturn(latency).when(blockNode).getLatency();
         doReturn(1L).when(cutoverService).getNextBlockNumber();
@@ -99,7 +100,7 @@ final class LatencyServiceTest {
                     latencyService.schedule();
                     verify(latency, atLeast(1)).markStale();
                 });
-        verify(blockNode, atLeast(3)).getBlockRange();
+        verify(blockNode, atLeast(3)).containsBlockOrEarliest(anyLong());
         verify(blockNode, never()).streamBlocks(anyLong(), anyLong(), any(), any());
         verify(cutoverService, atLeast(3)).getNextBlockNumber();
     }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
@@ -30,9 +30,10 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.hiero.block.api.protoc.BlockEnd;
 import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.BlockRange;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
+import org.hiero.block.api.protoc.ServerStatusDetailResponse;
 import org.hiero.block.api.protoc.ServerStatusRequest;
-import org.hiero.block.api.protoc.ServerStatusResponse;
 import org.hiero.block.api.protoc.SubscribeStreamRequest;
 import org.hiero.block.api.protoc.SubscribeStreamResponse;
 import org.hiero.mirror.importer.downloader.block.BlockNodeProperties;
@@ -219,10 +220,12 @@ public final class BlockNodeSimulator implements AutoCloseable {
     private final class StatusService extends BlockNodeServiceGrpc.BlockNodeServiceImplBase {
 
         @Override
-        public void serverStatus(ServerStatusRequest request, StreamObserver<ServerStatusResponse> responseObserver) {
-            var response = ServerStatusResponse.newBuilder()
-                    .setFirstAvailableBlock(firstBlockNumber)
-                    .setLastAvailableBlock(lastBlockNumber)
+        public void serverStatusDetail(
+                ServerStatusRequest request, StreamObserver<ServerStatusDetailResponse> responseObserver) {
+            var response = ServerStatusDetailResponse.newBuilder()
+                    .addAvailableRanges(BlockRange.newBuilder()
+                            .setRangeStart(firstBlockNumber)
+                            .setRangeEnd(lastBlockNumber))
                     .build();
             responseObserver.onNext(response);
             responseObserver.onCompleted();


### PR DESCRIPTION
**Description**:

This PR switches to the server status details API for available blocks of a block node server.

**Related issue(s)**:

Fixes #13938

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
