### PR TITLE
Bootstrap improvement

### DIFF
--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -190,6 +190,7 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
 
   - `PGSSLMODE` defaults to `verify-full`, so credentials and data stay encrypted in transit - this matters since bootstrap is often run from a separate machine than the database.
   - If your server's certificate isn't already trusted by your system (common for Cloud SQL, StackGres, or any private CA), set `PGSSLROOTCERT` to the CA certificate's path.
+  - If you're connecting directly to a Cloud SQL instance's private IP (not through the Cloud SQL Auth Proxy), use `PGSSLMODE="verify-ca"` instead of `verify-full` - Cloud SQL's server certificate doesn't include an IP SAN, so `verify-full`'s hostname check will fail with an `x509: cannot validate certificate` error even though the connection itself is fine.
   - If your PostgreSQL server doesn't have TLS set up at all (e.g. a local/dev instance), set `PGSSLMODE="disable"`.
   - Available `PGSSLMODE` values, from least to most secure:
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -178,6 +178,30 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
   - Replace `your_postgres_password` with the password for the PostgreSQL superuser (`postgres`).
   - `PGHOST` should be set to the IP address or hostname of your PostgreSQL server.
 
+- **Configure TLS for the PostgreSQL Connection:**
+
+  ```bash
+  # TLS mode for PostgreSQL connections
+  export PGSSLMODE="verify-full"
+
+  # CA certificate for verifying the server (uncomment if your DB uses a private CA)
+  # export PGSSLROOTCERT="/path/to/ca.pem"
+  ```
+
+  - `PGSSLMODE` defaults to `verify-full`, so credentials and data stay encrypted in transit - this matters since bootstrap is often run from a separate machine than the database.
+  - If your server's certificate isn't already trusted by your system (common for Cloud SQL, StackGres, or any private CA), set `PGSSLROOTCERT` to the CA certificate's path.
+  - If your PostgreSQL server doesn't have TLS set up at all (e.g. a local/dev instance), set `PGSSLMODE="disable"`.
+  - Available `PGSSLMODE` values, from least to most secure:
+
+    | Value         | What it does                                                                                              |
+    | ------------- | --------------------------------------------------------------------------------------------------------- |
+    | `disable`     | No TLS at all - plaintext only                                                                            |
+    | `allow`       | Tries plaintext first, upgrades to TLS only if the server insists                                         |
+    | `prefer`      | Tries TLS first, silently falls back to plaintext if unavailable                                          |
+    | `require`     | Always encrypts, but doesn't check the server's certificate (still vulnerable to a MITM with a fake cert) |
+    | `verify-ca`   | Encrypts and checks the cert is signed by a trusted CA, but not that the hostname matches                 |
+    | `verify-full` | Encrypts, checks the CA, and checks the hostname matches - full protection (our default)                  |
+
 - **Set the `IS_GCP_CLOUD_SQL` variable to `true` if you are using a GCP Cloud SQL database:**
 
   ```bash
@@ -337,7 +361,7 @@ After downloading the data, it's crucial to ensure version compatibility between
 
 ### 5. Initialize the Database
 
-The `bootstrap init` command creates the database, roles, and permissions, validates the special files (`MIRRORNODE_VERSION.gz` and `schema.sql.gz`), and executes the schema.
+The `bootstrap init` command creates the database, roles, and permissions, validates the special files (`MIRRORNODE_VERSION.gz` and `schema.sql.gz`), and executes the schema. Before touching anything, it first checks that it can connect to the database with your configured credentials and TLS settings, so a wrong password, unreachable host, or bad `PGSSLROOTCERT` path fails immediately with a clear error.
 
 **Instructions:**
 
@@ -613,6 +637,7 @@ During the import process, the binary tracks the status of each file in `bootstr
   - Monitor system resources (CPU, memory, I/O) on both the bootstrap machine and the database server during the import process.
 - **Security Considerations:**
   - Secure your `bootstrap.env` file and any other files containing sensitive information.
+  - PostgreSQL connections default to `PGSSLMODE="verify-full"`, keeping credentials and data encrypted in transit. Only relax this for trusted local/dev setups.
 - **Debug Mode:**
   - Set `DEBUG_MODE=true` environment variable for verbose logging:
     ```bash
@@ -627,6 +652,7 @@ During the import process, the binary tracks the status of each file in `bootstr
   - Confirm that `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` in `bootstrap.env` are correctly set.
   - Ensure that the database server allows connections from your machine (check `pg_hba.conf` and firewall rules).
   - Verify that the database port (`PGPORT`) is correct and accessible.
+  - If the error mentions a certificate or TLS handshake, check `PGSSLMODE` and `PGSSLROOTCERT`: for a local/dev server without TLS set up, use `PGSSLMODE="disable"`; otherwise make sure `PGSSLROOTCERT` points to a valid, readable CA certificate file.
 - **Import Failures:**
   - Review `bootstrap-logs/bootstrap.log` for detailed error messages.
   - Check `bootstrap-logs/tracking.json` to identify which files failed validation or import.

--- a/tools/bootstrap/README.md
+++ b/tools/bootstrap/README.md
@@ -61,7 +61,7 @@ internal/
 
 ### `init` - Initialize Database
 
-Creates the database, users, and applies the schema from `schema.sql.gz`.
+Creates the database, users, and applies the schema from `schema.sql.gz`. Checks that the database is reachable before touching anything, so bad credentials or TLS config fail fast with a clear error.
 
 ```bash
 ./bootstrap init -c bootstrap.env -d /path/to/data
@@ -122,6 +122,8 @@ export PGPORT="5432"
 export PGUSER="postgres"
 export PGPASSWORD="admin_password"
 export PGDATABASE="postgres"
+export PGSSLMODE="verify-full"        # "disable" only for trusted local/dev connections
+# export PGSSLROOTCERT="/path/to/ca.pem"  # needed for verify-full/verify-ca against a private CA
 export OWNER_PASSWORD="mirror_node_password"
 export REST_PASSWORD="mirror_rest_password"
 export GRPC_PASSWORD="mirror_grpc_password"

--- a/tools/bootstrap/bootstrap.env
+++ b/tools/bootstrap/bootstrap.env
@@ -5,6 +5,12 @@ export PGDATABASE="postgres"
 export PGHOST="127.0.0.1"
 export PGPORT="5432"
 
+# TLS mode for PostgreSQL connections. Only use "disable" for local/dev without TLS.
+export PGSSLMODE="verify-full"
+
+# CA cert for verifying the server (needed for verify-full/verify-ca unless your system already trusts it)
+# export PGSSLROOTCERT="/path/to/ca.pem"
+
 # Is the DB a GCP Cloud SQL instance?
 export IS_GCP_CLOUD_SQL="false"
 

--- a/tools/bootstrap/cmd/import.go
+++ b/tools/bootstrap/cmd/import.go
@@ -94,14 +94,14 @@ func runImport(ctx context.Context, dataDir, manifestFile string, maxJobs int) e
 			}
 		}
 	}
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0600); err != nil {
 		return fmt.Errorf("failed to write PID file: %w", err)
 	}
 	defer os.Remove(pidFile)
 
 	// Setup file logging (bootstrap.log) in bootstrap-logs/ directory
 	logFilePath := filepath.Join(logsDir, "bootstrap.log")
-	logFile, err = os.OpenFile(logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	logFile, err = os.OpenFile(logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open log file: %w", err)
 	}
@@ -476,7 +476,7 @@ func runImport(ctx context.Context, dataDir, manifestFile string, maxJobs int) e
 			discrepancyCount++
 			// Lazy file creation on first discrepancy, then append
 			if discrepancyFile == nil {
-				discrepancyFile, _ = os.OpenFile(discrepancyPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+				discrepancyFile, _ = os.OpenFile(discrepancyPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 			}
 			if discrepancyFile != nil {
 				fmt.Fprintf(discrepancyFile, "%s: expected=%d, imported=%d\n",

--- a/tools/bootstrap/cmd/init.go
+++ b/tools/bootstrap/cmd/init.go
@@ -140,6 +140,8 @@ func runInit(ctx context.Context, dataDir, schemaFile string) error {
 		AdminUser:           cfg.PGUser,
 		AdminPassword:       cfg.PGPassword,
 		AdminDatabase:       cfg.PGDatabase,
+		PGSSLMode:           cfg.PGSSLMode,
+		PGSSLRootCert:       cfg.PGSSLRootCert,
 		OwnerPassword:       cfg.OwnerPassword,
 		GraphQLPassword:     cfg.GraphQLPassword,
 		GRPCPassword:        cfg.GRPCPassword,

--- a/tools/bootstrap/internal/config/config.go
+++ b/tools/bootstrap/internal/config/config.go
@@ -6,13 +6,14 @@ package config
 import (
 	"fmt"
 	"github.com/spf13/viper"
+	"net"
 	"net/url"
 	"os"
 	"strings"
 )
 
-// defaultSSLMode is used when PGSSLMode is unset.
-const defaultSSLMode = "verify-full"
+// DefaultSSLMode is used when PGSSLMode is unset.
+const DefaultSSLMode = "verify-full"
 
 // Config holds all configuration values for the bootstrap process.
 type Config struct {
@@ -58,7 +59,7 @@ func DefaultConfig() *Config {
 		PGPort:              "5432",
 		PGUser:              "postgres",
 		PGDatabase:          "mirror_node",
-		PGSSLMode:           defaultSSLMode,
+		PGSSLMode:           DefaultSSLMode,
 		IsGCPCloudSQL:       false,
 		CreateMirrorAPIUser: true,
 		DecompressorThreads: 4,
@@ -77,7 +78,7 @@ func LoadFromEnvFile(path string) (*Config, error) {
 	v.SetDefault("PGPORT", "5432")
 	v.SetDefault("PGUSER", "postgres")
 	v.SetDefault("PGDATABASE", "mirror_node")
-	v.SetDefault("PGSSLMODE", defaultSSLMode)
+	v.SetDefault("PGSSLMODE", DefaultSSLMode)
 	v.SetDefault("IS_GCP_CLOUD_SQL", false)
 	v.SetDefault("CREATE_MIRROR_API_USER", true)
 	v.SetDefault("DECOMPRESSOR_THREADS", 4)
@@ -213,30 +214,34 @@ func (c *Config) LoadFromEnv() {
 	}
 }
 
-// sslMode falls back to defaultSSLMode if PGSSLMode isn't set.
+// sslMode falls back to DefaultSSLMode if PGSSLMode isn't set.
 func (c *Config) sslMode() string {
 	if c.PGSSLMode == "" {
-		return defaultSSLMode
+		return DefaultSSLMode
 	}
 	return c.PGSSLMode
 }
 
-// ConnectionString returns the PostgreSQL connection string.
-func (c *Config) ConnectionString() string {
-	s := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		c.PGHost, c.PGPort, c.PGUser, c.PGPassword, c.PGDatabase, c.sslMode())
-	if c.PGSSLRootCert != "" {
-		s += fmt.Sprintf(" sslrootcert=%s", c.PGSSLRootCert)
-	}
-	return s
-}
-
 // PgxConnectionString returns the connection string in pgx format.
 func (c *Config) PgxConnectionString() string {
-	s := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		c.PGUser, c.PGPassword, c.PGHost, c.PGPort, c.PGDatabase, c.sslMode())
-	if c.PGSSLRootCert != "" {
-		s += "&sslrootcert=" + url.QueryEscape(c.PGSSLRootCert)
+	return BuildConnURL(c.PGUser, c.PGPassword, c.PGHost, c.PGPort, c.PGDatabase, c.sslMode(), c.PGSSLRootCert)
+}
+
+// BuildConnURL creates a postgres:// URL, escaping every provided value
+// so special chars like @ : / ? in a password or path can't break the URL structure.
+func BuildConnURL(user, password, host, port, database, sslMode, sslRootCert string) string {
+	query := url.Values{}
+	query.Set("sslmode", sslMode)
+	if sslRootCert != "" {
+		query.Set("sslrootcert", sslRootCert)
 	}
-	return s
+
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, password),
+		Host:     net.JoinHostPort(host, port),
+		Path:     "/" + database,
+		RawQuery: query.Encode(),
+	}
+	return u.String()
 }

--- a/tools/bootstrap/internal/config/config.go
+++ b/tools/bootstrap/internal/config/config.go
@@ -6,9 +6,13 @@ package config
 import (
 	"fmt"
 	"github.com/spf13/viper"
+	"net/url"
 	"os"
 	"strings"
 )
+
+// defaultSSLMode is used when PGSSLMode is unset.
+const defaultSSLMode = "verify-full"
 
 // Config holds all configuration values for the bootstrap process.
 type Config struct {
@@ -18,6 +22,9 @@ type Config struct {
 	PGUser     string `mapstructure:"PGUSER"`
 	PGPassword string `mapstructure:"PGPASSWORD"`
 	PGDatabase string `mapstructure:"PGDATABASE"`
+	// PGSSLMode is a libpq sslmode (verify-full, require, disable, ...).
+	PGSSLMode     string `mapstructure:"PGSSLMODE"`
+	PGSSLRootCert string `mapstructure:"PGSSLROOTCERT"`
 
 	// GCP settings
 	IsGCPCloudSQL       bool `mapstructure:"IS_GCP_CLOUD_SQL"`
@@ -51,6 +58,7 @@ func DefaultConfig() *Config {
 		PGPort:              "5432",
 		PGUser:              "postgres",
 		PGDatabase:          "mirror_node",
+		PGSSLMode:           defaultSSLMode,
 		IsGCPCloudSQL:       false,
 		CreateMirrorAPIUser: true,
 		DecompressorThreads: 4,
@@ -69,6 +77,7 @@ func LoadFromEnvFile(path string) (*Config, error) {
 	v.SetDefault("PGPORT", "5432")
 	v.SetDefault("PGUSER", "postgres")
 	v.SetDefault("PGDATABASE", "mirror_node")
+	v.SetDefault("PGSSLMODE", defaultSSLMode)
 	v.SetDefault("IS_GCP_CLOUD_SQL", false)
 	v.SetDefault("CREATE_MIRROR_API_USER", true)
 	v.SetDefault("DECOMPRESSOR_THREADS", 4)
@@ -141,6 +150,8 @@ func manualPopulate(v *viper.Viper, cfg *Config) {
 	cfg.PGUser = v.GetString("PGUSER")
 	cfg.PGPassword = v.GetString("PGPASSWORD")
 	cfg.PGDatabase = v.GetString("PGDATABASE")
+	cfg.PGSSLMode = v.GetString("PGSSLMODE")
+	cfg.PGSSLRootCert = v.GetString("PGSSLROOTCERT")
 	cfg.IsGCPCloudSQL = v.GetBool("IS_GCP_CLOUD_SQL")
 	cfg.CreateMirrorAPIUser = v.GetBool("CREATE_MIRROR_API_USER")
 	cfg.GraphQLPassword = v.GetString("GRAPHQL_PASSWORD")
@@ -202,14 +213,30 @@ func (c *Config) LoadFromEnv() {
 	}
 }
 
+// sslMode falls back to defaultSSLMode if PGSSLMode isn't set.
+func (c *Config) sslMode() string {
+	if c.PGSSLMode == "" {
+		return defaultSSLMode
+	}
+	return c.PGSSLMode
+}
+
 // ConnectionString returns the PostgreSQL connection string.
 func (c *Config) ConnectionString() string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		c.PGHost, c.PGPort, c.PGUser, c.PGPassword, c.PGDatabase)
+	s := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		c.PGHost, c.PGPort, c.PGUser, c.PGPassword, c.PGDatabase, c.sslMode())
+	if c.PGSSLRootCert != "" {
+		s += fmt.Sprintf(" sslrootcert=%s", c.PGSSLRootCert)
+	}
+	return s
 }
 
 // PgxConnectionString returns the connection string in pgx format.
 func (c *Config) PgxConnectionString() string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		c.PGUser, c.PGPassword, c.PGHost, c.PGPort, c.PGDatabase)
+	s := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		c.PGUser, c.PGPassword, c.PGHost, c.PGPort, c.PGDatabase, c.sslMode())
+	if c.PGSSLRootCert != "" {
+		s += "&sslrootcert=" + url.QueryEscape(c.PGSSLRootCert)
+	}
+	return s
 }

--- a/tools/bootstrap/internal/config/config_test.go
+++ b/tools/bootstrap/internal/config/config_test.go
@@ -26,6 +26,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.PGDatabase != "mirror_node" {
 		t.Errorf("Expected PGDatabase=mirror_node, got %s", cfg.PGDatabase)
 	}
+	if cfg.PGSSLMode != "verify-full" {
+		t.Errorf("Expected PGSSLMode=verify-full, got %s", cfg.PGSSLMode)
+	}
 	if cfg.IsGCPCloudSQL {
 		t.Error("Expected IsGCPCloudSQL=false")
 	}
@@ -81,11 +84,35 @@ export DECOMPRESSOR_THREADS=8
 	if cfg.PGPort != "5433" {
 		t.Errorf("Expected PGPort=5433, got %s", cfg.PGPort)
 	}
+	if cfg.PGSSLMode != "verify-full" {
+		t.Errorf("Expected PGSSLMode=verify-full when unset, got %s", cfg.PGSSLMode)
+	}
 	if !cfg.IsGCPCloudSQL {
 		t.Error("Expected IsGCPCloudSQL=true")
 	}
 	if cfg.DecompressorThreads != 8 {
 		t.Errorf("Expected DecompressorThreads=8, got %d", cfg.DecompressorThreads)
+	}
+}
+
+func TestLoadFromEnvFile_SSLModeOverride(t *testing.T) {
+	content := `export PGSSLMODE="disable"
+export PGSSLROOTCERT="/etc/ssl/ca.pem"
+`
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "bootstrap.env")
+	os.WriteFile(envFile, []byte(content), 0644)
+
+	cfg, err := LoadFromEnvFile(envFile)
+	if err != nil {
+		t.Fatalf("LoadFromEnvFile failed: %v", err)
+	}
+
+	if cfg.PGSSLMode != "disable" {
+		t.Errorf("Expected PGSSLMode=disable, got %s", cfg.PGSSLMode)
+	}
+	if cfg.PGSSLRootCert != "/etc/ssl/ca.pem" {
+		t.Errorf("Expected PGSSLRootCert=/etc/ssl/ca.pem, got %s", cfg.PGSSLRootCert)
 	}
 }
 
@@ -280,7 +307,25 @@ func TestConnectionString(t *testing.T) {
 	}
 
 	conn := cfg.ConnectionString()
-	expected := "host=localhost port=5432 user=user password=pass dbname=db sslmode=disable"
+	expected := "host=localhost port=5432 user=user password=pass dbname=db sslmode=verify-full"
+	if conn != expected {
+		t.Errorf("Expected %q, got %q", expected, conn)
+	}
+}
+
+func TestConnectionString_ExplicitSSLModeAndRootCert(t *testing.T) {
+	cfg := &Config{
+		PGHost:        "localhost",
+		PGPort:        "5432",
+		PGUser:        "user",
+		PGPassword:    "pass",
+		PGDatabase:    "db",
+		PGSSLMode:     "disable",
+		PGSSLRootCert: "/etc/ssl/ca.pem",
+	}
+
+	conn := cfg.ConnectionString()
+	expected := "host=localhost port=5432 user=user password=pass dbname=db sslmode=disable sslrootcert=/etc/ssl/ca.pem"
 	if conn != expected {
 		t.Errorf("Expected %q, got %q", expected, conn)
 	}
@@ -296,7 +341,25 @@ func TestPgxConnectionString(t *testing.T) {
 	}
 
 	conn := cfg.PgxConnectionString()
-	expected := "postgres://user:pass@localhost:5432/db?sslmode=disable"
+	expected := "postgres://user:pass@localhost:5432/db?sslmode=verify-full"
+	if conn != expected {
+		t.Errorf("Expected %q, got %q", expected, conn)
+	}
+}
+
+func TestPgxConnectionString_ExplicitSSLModeAndRootCert(t *testing.T) {
+	cfg := &Config{
+		PGHost:        "localhost",
+		PGPort:        "5432",
+		PGUser:        "user",
+		PGPassword:    "pass",
+		PGDatabase:    "db",
+		PGSSLMode:     "require",
+		PGSSLRootCert: "/etc/ssl/ca.pem",
+	}
+
+	conn := cfg.PgxConnectionString()
+	expected := "postgres://user:pass@localhost:5432/db?sslmode=require&sslrootcert=%2Fetc%2Fssl%2Fca.pem"
 	if conn != expected {
 		t.Errorf("Expected %q, got %q", expected, conn)
 	}

--- a/tools/bootstrap/internal/config/config_test.go
+++ b/tools/bootstrap/internal/config/config_test.go
@@ -3,8 +3,10 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -297,40 +299,6 @@ func TestLoadFromEnv_ZeroMaxJobs(t *testing.T) {
 	}
 }
 
-func TestConnectionString(t *testing.T) {
-	cfg := &Config{
-		PGHost:     "localhost",
-		PGPort:     "5432",
-		PGUser:     "user",
-		PGPassword: "pass",
-		PGDatabase: "db",
-	}
-
-	conn := cfg.ConnectionString()
-	expected := "host=localhost port=5432 user=user password=pass dbname=db sslmode=verify-full"
-	if conn != expected {
-		t.Errorf("Expected %q, got %q", expected, conn)
-	}
-}
-
-func TestConnectionString_ExplicitSSLModeAndRootCert(t *testing.T) {
-	cfg := &Config{
-		PGHost:        "localhost",
-		PGPort:        "5432",
-		PGUser:        "user",
-		PGPassword:    "pass",
-		PGDatabase:    "db",
-		PGSSLMode:     "disable",
-		PGSSLRootCert: "/etc/ssl/ca.pem",
-	}
-
-	conn := cfg.ConnectionString()
-	expected := "host=localhost port=5432 user=user password=pass dbname=db sslmode=disable sslrootcert=/etc/ssl/ca.pem"
-	if conn != expected {
-		t.Errorf("Expected %q, got %q", expected, conn)
-	}
-}
-
 func TestPgxConnectionString(t *testing.T) {
 	cfg := &Config{
 		PGHost:     "localhost",
@@ -362,6 +330,38 @@ func TestPgxConnectionString_ExplicitSSLModeAndRootCert(t *testing.T) {
 	expected := "postgres://user:pass@localhost:5432/db?sslmode=require&sslrootcert=%2Fetc%2Fssl%2Fca.pem"
 	if conn != expected {
 		t.Errorf("Expected %q, got %q", expected, conn)
+	}
+}
+
+func TestPgxConnectionString_EscapesComponents(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{"special chars in password", &Config{PGHost: "localhost", PGPort: "5432", PGUser: "postgres", PGPassword: "p@ss:w/rd?#&=", PGDatabase: "mirror_node"}},
+		{"space in password", &Config{PGHost: "localhost", PGPort: "5432", PGUser: "postgres", PGPassword: "pass word", PGDatabase: "mirror_node"}},
+		{"at sign in user", &Config{PGHost: "localhost", PGPort: "5432", PGUser: "user@domain", PGPassword: "pass", PGDatabase: "mirror_node"}},
+		{"ipv6 host", &Config{PGHost: "::1", PGPort: "5432", PGUser: "postgres", PGPassword: "pass", PGDatabase: "mirror_node"}},
+		{"space in database", &Config{PGHost: "localhost", PGPort: "5432", PGUser: "postgres", PGPassword: "pass", PGDatabase: "mirror node"}},
+	}
+
+	for _, tc := range tests {
+		parsed, err := url.Parse(tc.cfg.PgxConnectionString())
+		if err != nil {
+			t.Errorf("%s: connection string should parse as a URL: %v", tc.name, err)
+			continue
+		}
+		password, _ := parsed.User.Password()
+		if parsed.User.Username() != tc.cfg.PGUser || password != tc.cfg.PGPassword {
+			t.Errorf("%s: credentials did not survive escaping, got user=%q password=%q",
+				tc.name, parsed.User.Username(), password)
+		}
+		if parsed.Hostname() != tc.cfg.PGHost {
+			t.Errorf("%s: expected host %q, got %q", tc.name, tc.cfg.PGHost, parsed.Hostname())
+		}
+		if strings.TrimPrefix(parsed.Path, "/") != tc.cfg.PGDatabase {
+			t.Errorf("%s: expected database %q, got %q", tc.name, tc.cfg.PGDatabase, parsed.Path)
+		}
 	}
 }
 

--- a/tools/bootstrap/internal/database/init.go
+++ b/tools/bootstrap/internal/database/init.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// InitScriptURL is the URL to download the init.sh script from
-	InitScriptURL = "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/refs/heads/main/importer/src/main/resources/db/scripts/init.sh"
+	InitScriptURL = "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/846f9fa0ae4f4069434eca07024767519144294e/importer/src/main/resources/db/scripts/init.sh"
 )
 
 // InitConfig holds configuration for database initialization.

--- a/tools/bootstrap/internal/database/init.go
+++ b/tools/bootstrap/internal/database/init.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +30,8 @@ type InitConfig struct {
 	AdminUser     string
 	AdminPassword string
 	AdminDatabase string
+	PGSSLMode     string
+	PGSSLRootCert string
 
 	// User passwords to set
 	OwnerPassword    string
@@ -56,6 +59,23 @@ const (
 	SkipDBInitFlag = "SKIP_DB_INIT"
 )
 
+func sslModeOrDefault(mode string) string {
+	if mode == "" {
+		return "verify-full"
+	}
+	return mode
+}
+
+// buildConnString builds a connection string to AdminHost/AdminPort with cfg's TLS settings.
+func buildConnString(user, password, dbname string, cfg InitConfig) string {
+	connString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		user, password, cfg.AdminHost, cfg.AdminPort, dbname, sslModeOrDefault(cfg.PGSSLMode))
+	if cfg.PGSSLRootCert != "" {
+		connString += "&sslrootcert=" + url.QueryEscape(cfg.PGSSLRootCert)
+	}
+	return connString
+}
+
 // Initialize performs full database initialization: downloads and runs init.sh to create
 // database and roles, executes schema.sql to create tables, verifies setup, and creates
 // success flag on completion. Skips if already initialized.
@@ -74,6 +94,12 @@ func Initialize(ctx context.Context, cfg InitConfig) error {
 
 	if _, err := os.Stat(schemaPath); os.IsNotExist(err) {
 		return fmt.Errorf("schema.sql not found at %s", schemaPath)
+	}
+
+	// Fail fast if we can't even connect, before touching anything
+	adminConnString := buildConnString(cfg.AdminUser, cfg.AdminPassword, cfg.AdminDatabase, cfg)
+	if err := TestConnection(ctx, adminConnString); err != nil {
+		return fmt.Errorf("cannot connect to database: %w", err)
 	}
 
 	// Download init.sh
@@ -154,6 +180,8 @@ func runInitScript(ctx context.Context, scriptPath string, cfg InitConfig) error
 		fmt.Sprintf("PGUSER=%s", cfg.AdminUser),
 		fmt.Sprintf("PGPASSWORD=%s", cfg.AdminPassword),
 		fmt.Sprintf("PGDATABASE=%s", cfg.AdminDatabase),
+		fmt.Sprintf("PGSSLMODE=%s", sslModeOrDefault(cfg.PGSSLMode)),
+		fmt.Sprintf("PGSSLROOTCERT=%s", cfg.PGSSLRootCert),
 		fmt.Sprintf("OWNER_PASSWORD=%s", cfg.OwnerPassword),
 		fmt.Sprintf("GRAPHQL_PASSWORD=%s", cfg.GraphQLPassword),
 		fmt.Sprintf("GRPC_PASSWORD=%s", cfg.GRPCPassword),
@@ -190,6 +218,8 @@ func executeSchema(ctx context.Context, cfg InitConfig, schemaPath string) error
 		"PGUSER=mirror_node",
 		fmt.Sprintf("PGPASSWORD=%s", cfg.OwnerPassword),
 		"PGDATABASE=mirror_node",
+		fmt.Sprintf("PGSSLMODE=%s", sslModeOrDefault(cfg.PGSSLMode)),
+		fmt.Sprintf("PGSSLROOTCERT=%s", cfg.PGSSLRootCert),
 	)
 
 	output, err := cmd.CombinedOutput()
@@ -202,8 +232,7 @@ func executeSchema(ctx context.Context, cfg InitConfig, schemaPath string) error
 
 // verifyTables checks that expected tables exist in the database.
 func verifyTables(ctx context.Context, cfg InitConfig) error {
-	connString := fmt.Sprintf("postgres://mirror_node:%s@%s:%s/mirror_node?sslmode=disable",
-		cfg.OwnerPassword, cfg.AdminHost, cfg.AdminPort)
+	connString := buildConnString("mirror_node", cfg.OwnerPassword, "mirror_node", cfg)
 
 	conn, err := pgx.Connect(ctx, connString)
 	if err != nil {

--- a/tools/bootstrap/internal/database/init.go
+++ b/tools/bootstrap/internal/database/init.go
@@ -9,13 +9,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+
+	"mirrornode-bootstrap/internal/config"
 )
 
 const (
@@ -69,19 +70,14 @@ const (
 
 func sslModeOrDefault(mode string) string {
 	if mode == "" {
-		return "verify-full"
+		return config.DefaultSSLMode
 	}
 	return mode
 }
 
-// buildConnString builds a connection string to AdminHost/AdminPort with cfg's TLS settings.
 func buildConnString(user, password, dbname string, cfg InitConfig) string {
-	connString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		user, password, cfg.AdminHost, cfg.AdminPort, dbname, sslModeOrDefault(cfg.PGSSLMode))
-	if cfg.PGSSLRootCert != "" {
-		connString += "&sslrootcert=" + url.QueryEscape(cfg.PGSSLRootCert)
-	}
-	return connString
+	return config.BuildConnURL(user, password, cfg.AdminHost, cfg.AdminPort, dbname,
+		sslModeOrDefault(cfg.PGSSLMode), cfg.PGSSLRootCert)
 }
 
 // Initialize performs full database initialization: downloads and runs init.sh to create

--- a/tools/bootstrap/internal/database/init.go
+++ b/tools/bootstrap/internal/database/init.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,8 +19,15 @@ import (
 )
 
 const (
+	// InitScriptCommitSHA pins init.sh to a commit
+	InitScriptCommitSHA = "846f9fa0ae4f4069434eca07024767519144294e"
+
 	// InitScriptURL is the URL to download the init.sh script from
-	InitScriptURL = "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/846f9fa0ae4f4069434eca07024767519144294e/importer/src/main/resources/db/scripts/init.sh"
+	InitScriptURL = "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/" + InitScriptCommitSHA +
+		"/importer/src/main/resources/db/scripts/init.sh"
+
+	// InitScriptSHA256 is the expected checksum of the script at InitScriptURL
+	InitScriptSHA256 = "903fd0d0e3c43d0f4839f0603de69290474646d4d050619205483ea87a48974c"
 )
 
 // InitConfig holds configuration for database initialization.
@@ -104,11 +112,13 @@ func Initialize(ctx context.Context, cfg InitConfig) error {
 
 	// Download init.sh
 	initURL := cfg.InitScriptURL
+	expectedHash := ""
 	if initURL == "" {
 		initURL = InitScriptURL
+		expectedHash = InitScriptSHA256
 	}
 
-	initScript, err := downloadInitScript(initURL)
+	initScript, err := downloadInitScript(initURL, expectedHash)
 	if err != nil {
 		return fmt.Errorf("failed to download init.sh: %w", err)
 	}
@@ -138,7 +148,8 @@ func Initialize(ctx context.Context, cfg InitConfig) error {
 }
 
 // downloadInitScript downloads init.sh to a temporary file.
-func downloadInitScript(url string) (string, error) {
+// Verify content before writing it to disk (requires expectedHash to be set)
+func downloadInitScript(url, expectedHash string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
@@ -149,13 +160,25 @@ func downloadInitScript(url string) (string, error) {
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
 	}
 
+	script, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if expectedHash != "" {
+		actualHash := fmt.Sprintf("%x", sha256.Sum256(script))
+		if actualHash != expectedHash {
+			return "", fmt.Errorf("checksum mismatch for %s: expected %s, got %s", url, expectedHash, actualHash)
+		}
+	}
+
 	tmpFile, err := os.CreateTemp("", "init-*.sh")
 	if err != nil {
 		return "", err
 	}
 	defer tmpFile.Close()
 
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+	if _, err := tmpFile.Write(script); err != nil {
 		os.Remove(tmpFile.Name())
 		return "", err
 	}

--- a/tools/bootstrap/internal/database/init_test.go
+++ b/tools/bootstrap/internal/database/init_test.go
@@ -35,7 +35,7 @@ func TestInitScriptURL(t *testing.T) {
 		t.Error("InitScriptURL constant should not be empty")
 	}
 
-	expected := "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/refs/heads/main/importer/src/main/resources/db/scripts/init.sh"
+	expected := "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/846f9fa0ae4f4069434eca07024767519144294e/importer/src/main/resources/db/scripts/init.sh"
 	if InitScriptURL != expected {
 		t.Errorf("InitScriptURL mismatch:\nexpected: %s\ngot: %s", expected, InitScriptURL)
 	}

--- a/tools/bootstrap/internal/database/init_test.go
+++ b/tools/bootstrap/internal/database/init_test.go
@@ -152,7 +152,7 @@ func TestInitialize_MissingSchemaFile(t *testing.T) {
 	}
 }
 
-func TestInitialize_SchemaFileFound(t *testing.T) {
+func TestInitialize_FailsFastWhenDBUnreachable(t *testing.T) {
 	logsDir := t.TempDir()
 	dataDir := t.TempDir()
 
@@ -162,11 +162,10 @@ func TestInitialize_SchemaFileFound(t *testing.T) {
 		t.Fatalf("Failed to create schema.sql: %v", err)
 	}
 
-	// Create a mock server for init.sh that returns an error script
-	// This tests that we properly reach the download phase
+	downloaded := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloaded = true // should never happen - the connection check must fail first
 		w.WriteHeader(http.StatusOK)
-		// Return a script that exits with error (to prevent full execution)
 		w.Write([]byte("#!/bin/bash\nexit 1\n"))
 	}))
 	defer server.Close()
@@ -175,18 +174,23 @@ func TestInitialize_SchemaFileFound(t *testing.T) {
 		LogsDir:       logsDir,
 		DataDir:       dataDir,
 		InitScriptURL: server.URL,
+		AdminHost:     "127.0.0.1",
+		AdminPort:     "1", // nothing listens here, so this fails fast
+		PGSSLMode:     "disable",
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	err := Initialize(ctx, cfg)
-	// We expect an error from init.sh failing
 	if err == nil {
-		t.Error("Expected init.sh to fail")
+		t.Fatal("Expected error when database is unreachable")
 	}
-	if err != nil && !contains(err.Error(), "init.sh failed") {
-		t.Errorf("Expected 'init.sh failed' error, got: %v", err)
+	if !contains(err.Error(), "cannot connect to database") {
+		t.Errorf("Expected 'cannot connect to database' error, got: %v", err)
+	}
+	if downloaded {
+		t.Error("init.sh should not be downloaded when the admin connection check fails")
 	}
 }
 
@@ -253,6 +257,46 @@ exit 0
 
 	err := runInitScript(ctx, scriptPath, cfg)
 	if err != nil {
+		t.Errorf("runInitScript failed: %v", err)
+	}
+}
+
+func TestSSLModeOrDefault(t *testing.T) {
+	if got := sslModeOrDefault(""); got != "verify-full" {
+		t.Errorf("Expected verify-full for empty mode, got %s", got)
+	}
+	if got := sslModeOrDefault("disable"); got != "disable" {
+		t.Errorf("Expected disable to pass through unchanged, got %s", got)
+	}
+}
+
+func TestRunInitScript_SSLModeEnvVars(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test_ssl_env.sh")
+
+	script := `#!/bin/bash
+if [ "$PGSSLMODE" != "verify-full" ]; then exit 1; fi
+if [ "$PGSSLROOTCERT" != "/etc/ssl/ca.pem" ]; then exit 2; fi
+exit 0
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create test script: %v", err)
+	}
+
+	cfg := InitConfig{
+		AdminHost:     "localhost",
+		AdminPort:     "5432",
+		AdminUser:     "postgres",
+		AdminPassword: "test",
+		OwnerPassword: "owner123",
+		PGSSLRootCert: "/etc/ssl/ca.pem",
+		// PGSSLMode left empty on purpose - checking the default kicks in
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := runInitScript(ctx, scriptPath, cfg); err != nil {
 		t.Errorf("runInitScript failed: %v", err)
 	}
 }

--- a/tools/bootstrap/internal/database/init_test.go
+++ b/tools/bootstrap/internal/database/init_test.go
@@ -4,6 +4,8 @@ package database
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,7 +37,7 @@ func TestInitScriptURL(t *testing.T) {
 		t.Error("InitScriptURL constant should not be empty")
 	}
 
-	expected := "https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/846f9fa0ae4f4069434eca07024767519144294e/importer/src/main/resources/db/scripts/init.sh"
+	expected := fmt.Sprintf("https://raw.githubusercontent.com/hiero-ledger/hiero-mirror-node/%s/importer/src/main/resources/db/scripts/init.sh", InitScriptCommitSHA)
 	if InitScriptURL != expected {
 		t.Errorf("InitScriptURL mismatch:\nexpected: %s\ngot: %s", expected, InitScriptURL)
 	}
@@ -57,7 +59,7 @@ func TestDownloadInitScript_Success(t *testing.T) {
 	defer server.Close()
 
 	// Download the script
-	path, err := downloadInitScript(server.URL)
+	path, err := downloadInitScript(server.URL, "")
 	if err != nil {
 		t.Fatalf("downloadInitScript failed: %v", err)
 	}
@@ -93,16 +95,57 @@ func TestDownloadInitScript_HTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := downloadInitScript(server.URL)
+	_, err := downloadInitScript(server.URL, "")
 	if err == nil {
 		t.Error("Expected error for HTTP 404, got nil")
 	}
 }
 
 func TestDownloadInitScript_InvalidURL(t *testing.T) {
-	_, err := downloadInitScript("http://invalid.invalid.invalid/notfound")
+	_, err := downloadInitScript("http://invalid.invalid.invalid/notfound", "")
 	if err == nil {
 		t.Error("Expected error for invalid URL, got nil")
+	}
+}
+
+func TestDownloadInitScript_ChecksumMatch(t *testing.T) {
+	scriptContent := "#!/bin/bash\necho 'test script'\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(scriptContent))
+	}))
+	defer server.Close()
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(scriptContent)))
+	path, err := downloadInitScript(server.URL, hash)
+	if err != nil {
+		t.Fatalf("downloadInitScript failed on a matching checksum: %v", err)
+	}
+	defer os.Remove(path)
+}
+
+func TestDownloadInitScript_ChecksumMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("#!/bin/bash\necho 'tampered'\n"))
+	}))
+	defer server.Close()
+
+	t.Setenv("TMPDIR", tmpDir)
+
+	_, err := downloadInitScript(server.URL, InitScriptSHA256)
+	if err == nil {
+		t.Fatal("Expected a checksum mismatch error")
+	}
+	if !contains(err.Error(), "checksum mismatch") {
+		t.Errorf("Expected 'checksum mismatch' error, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to read temp dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("A tampered script should not be written to disk, found %d file(s)", len(entries))
 	}
 }
 

--- a/tools/bootstrap/internal/importer/importer.go
+++ b/tools/bootstrap/internal/importer/importer.go
@@ -29,6 +29,14 @@ var (
 	partitionDatePattern = regexp.MustCompile(`_p(\d{4})_(\d{2})`)
 )
 
+// quoteIdentifier applies Postgres quote_ident escaping so name can't break out of the identifier position.
+func quoteIdentifier(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty table/partition identifier derived from filename")
+	}
+	return pgx.Identifier{name}.Sanitize(), nil
+}
+
 // ImportResult contains the results of an import operation.
 type ImportResult struct {
 	RowsImported int64
@@ -82,8 +90,13 @@ func IsSpecialFile(filename string) bool {
 func TruncateBeforeImport(ctx context.Context, conn *pgx.Conn, filename string) error {
 	target := GetTableOrPartition(filename)
 
-	query := fmt.Sprintf("TRUNCATE TABLE %s", target)
-	_, err := conn.Exec(ctx, query)
+	quoted, err := quoteIdentifier(target)
+	if err != nil {
+		return err
+	}
+
+	query := fmt.Sprintf("TRUNCATE TABLE %s", quoted)
+	_, err = conn.Exec(ctx, query)
 	return err
 }
 
@@ -102,7 +115,12 @@ func TruncateBeforeImportTx(ctx context.Context, tx pgx.Tx, filename string) (bo
 		return false, nil
 	}
 
-	query := fmt.Sprintf("TRUNCATE TABLE %s", target)
+	quoted, err := quoteIdentifier(target)
+	if err != nil {
+		return false, err
+	}
+
+	query := fmt.Sprintf("TRUNCATE TABLE %s", quoted)
 	_, err = tx.Exec(ctx, query)
 	if err != nil {
 		return false, fmt.Errorf("truncate failed: %w", err)
@@ -213,8 +231,14 @@ func ImportFile(ctx context.Context, conn *pgx.Conn, filePath string, decompress
 	tableName := GetTableName(filePath)
 	result.TableName = tableName
 
+	quotedTable, err := quoteIdentifier(tableName)
+	if err != nil {
+		result.Error = err
+		return result
+	}
+
 	// Build COPY command
-	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN WITH (FORMAT csv)", tableName, columns)
+	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN WITH (FORMAT csv)", quotedTable, columns)
 
 	// Execute COPY - streams directly from reader
 	pgConn := conn.PgConn()
@@ -310,6 +334,12 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 	tableName := GetTableName(filePath)
 	result.TableName = tableName
 
+	quotedTable, err := quoteIdentifier(tableName)
+	if err != nil {
+		result.Error = err
+		return result
+	}
+
 	truncated, err := TruncateBeforeImportTx(ctx, tx, filePath)
 	if err != nil {
 		result.Error = fmt.Errorf("truncate failed: %w", err)
@@ -329,7 +359,7 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 			result.Error = err
 			return result
 		}
-		deleteSQL := fmt.Sprintf("DELETE FROM %s WHERE %s >= $1 AND %s < $2", tableName, tsCol, tsCol)
+		deleteSQL := fmt.Sprintf("DELETE FROM %s WHERE %s >= $1 AND %s < $2", quotedTable, tsCol, tsCol)
 		if _, err := tx.Exec(ctx, deleteSQL, startNs, endNs); err != nil {
 			result.Error = fmt.Errorf("delete range failed for %s.%s [%d, %d): %w", tableName, tsCol, startNs, endNs, err)
 			return result
@@ -370,7 +400,7 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 	columns := parseHeaderToColumns(headerLine)
 
 	// Build COPY command
-	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN WITH (FORMAT csv)", tableName, columns)
+	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN WITH (FORMAT csv)", quotedTable, columns)
 
 	// Execute COPY within transaction - use tx.Conn().PgConn() to ensure
 	// the COPY is part of the transaction and connection is properly cleaned up

--- a/tools/bootstrap/internal/importer/importer.go
+++ b/tools/bootstrap/internal/importer/importer.go
@@ -192,7 +192,7 @@ func ImportFile(ctx context.Context, conn *pgx.Conn, filePath string, decompress
 	baseName := filepath.Base(filePath)
 
 	// Set application name for progress tracking
-	_, err = conn.Exec(ctx, fmt.Sprintf("SET application_name = 'bootstrap_copy_%s'", baseName))
+	_, err = conn.Exec(ctx, "SELECT set_config('application_name', $1, false)", "bootstrap_copy_"+baseName)
 	if err != nil {
 		result.Error = fmt.Errorf("set application_name failed: %w", err)
 		return result
@@ -225,7 +225,11 @@ func ImportFile(ctx context.Context, conn *pgx.Conn, filePath string, decompress
 	result.BytesRead = int64(len(headerLine))
 
 	// Parse header to get column list
-	columns := parseHeaderToColumns(headerLine)
+	columns, err := parseHeaderToColumns(headerLine)
+	if err != nil {
+		result.Error = fmt.Errorf("header parse failed: %w", err)
+		return result
+	}
 
 	// Get table name
 	tableName := GetTableName(filePath)
@@ -323,7 +327,7 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 	defer tx.Rollback(ctx) // No-op if committed
 
 	// Set application name for progress tracking (within transaction)
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET application_name = 'bootstrap_copy_%s'", baseName))
+	_, err = tx.Exec(ctx, "SELECT set_config('application_name', $1, false)", "bootstrap_copy_"+baseName)
 	if err != nil {
 		result.Error = fmt.Errorf("set application_name failed: %w", err)
 		return result
@@ -397,7 +401,11 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 	result.BytesRead = int64(len(headerLine))
 
 	// Parse header to get column list
-	columns := parseHeaderToColumns(headerLine)
+	columns, err := parseHeaderToColumns(headerLine)
+	if err != nil {
+		result.Error = fmt.Errorf("header parse failed: %w", err)
+		return result
+	}
 
 	// Build COPY command
 	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN WITH (FORMAT csv)", quotedTable, columns)
@@ -433,10 +441,10 @@ func ImportWithValidation(ctx context.Context, conn *pgx.Conn, filePath string, 
 }
 
 // parseHeaderToColumns converts a CSV header line to a quoted column list.
-func parseHeaderToColumns(header []byte) string {
+func parseHeaderToColumns(header []byte) (string, error) {
 	header = trimRight(header, '\r', '\n')
 
-	var columns []string
+	var rawColumns []string
 	var current strings.Builder
 	inQuotes := false
 
@@ -446,15 +454,24 @@ func parseHeaderToColumns(header []byte) string {
 		case ch == '"':
 			inQuotes = !inQuotes
 		case ch == ',' && !inQuotes:
-			columns = append(columns, fmt.Sprintf(`"%s"`, current.String()))
+			rawColumns = append(rawColumns, current.String())
 			current.Reset()
 		default:
 			current.WriteByte(ch)
 		}
 	}
-	columns = append(columns, fmt.Sprintf(`"%s"`, current.String()))
+	rawColumns = append(rawColumns, current.String())
 
-	return strings.Join(columns, ",")
+	columns := make([]string, len(rawColumns))
+	for i, col := range rawColumns {
+		quoted, err := quoteIdentifier(col)
+		if err != nil {
+			return "", fmt.Errorf("column %d: %w", i, err)
+		}
+		columns[i] = quoted
+	}
+
+	return strings.Join(columns, ","), nil
 }
 
 // trimRight trims specified bytes from the right side.

--- a/tools/bootstrap/internal/importer/importer_test.go
+++ b/tools/bootstrap/internal/importer/importer_test.go
@@ -59,6 +59,35 @@ func TestGetTableOrPartition(t *testing.T) {
 	}
 }
 
+func TestQuoteIdentifier(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected string
+	}{
+		{"account_balance", `"account_balance"`},
+		{"account_balance_p2024_01", `"account_balance_p2024_01"`},
+		{"flyway_schema_history", `"flyway_schema_history"`},
+		{"_leading_underscore", `"_leading_underscore"`},
+		{"123_starts_with_digit", `"123_starts_with_digit"`},
+		{"has-hyphen", `"has-hyphen"`},
+		{"account_balance; DROP TABLE flyway_schema_history; --", `"account_balance; DROP TABLE flyway_schema_history; --"`},
+		{`account_balance" CASCADE; DROP TABLE flyway_schema_history; --`, `"account_balance"" CASCADE; DROP TABLE flyway_schema_history; --"`},
+	}
+	for _, tc := range cases {
+		quoted, err := quoteIdentifier(tc.name)
+		if err != nil {
+			t.Errorf("quoteIdentifier(%q): expected no error, got %v", tc.name, err)
+		}
+		if quoted != tc.expected {
+			t.Errorf("quoteIdentifier(%q): expected %q, got %q", tc.name, tc.expected, quoted)
+		}
+	}
+
+	if _, err := quoteIdentifier(""); err == nil {
+		t.Error("quoteIdentifier(\"\"): expected error for empty identifier, got nil")
+	}
+}
+
 func TestIsPartitioned(t *testing.T) {
 	tests := []struct {
 		filename    string

--- a/tools/bootstrap/internal/importer/importer_test.go
+++ b/tools/bootstrap/internal/importer/importer_test.go
@@ -140,23 +140,35 @@ func TestIsSpecialFile(t *testing.T) {
 
 func TestParseHeaderToColumns(t *testing.T) {
 	tests := []struct {
-		header   string
-		expected string
+		header    string
+		expected  string
+		expectErr bool
 	}{
-		{"col1,col2,col3\n", `"col1","col2","col3"`},
-		{"id,name,value\r\n", `"id","name","value"`},
-		{"single\n", `"single"`},
-		{"col_with_underscore,another_one\n", `"col_with_underscore","another_one"`},
+		{"col1,col2,col3\n", `"col1","col2","col3"`, false},
+		{"id,name,value\r\n", `"id","name","value"`, false},
+		{"single\n", `"single"`, false},
+		{"col_with_underscore,another_one\n", `"col_with_underscore","another_one"`, false},
 		// Edge cases
-		{"a,b,c", `"a","b","c"`},     // No newline
-		{"\n", `""`},                 // Just newline
-		{"", `""`},                   // Empty
-		{"col1\r", `"col1"`},         // Just CR
-		{"a,b,c\r\n", `"a","b","c"`}, // CRLF
+		{"a,b,c", `"a","b","c"`, false},     // No newline
+		{"\n", "", true},                    // Just newline -> empty column name
+		{"", "", true},                      // Empty -> empty column name
+		{"col1\r", `"col1"`, false},         // Just CR
+		{"a,b,c\r\n", `"a","b","c"`, false}, // CRLF
+		// A header field containing SQL-breaking characters must come out as a single, safely quoted identifier
+		{"foo\",bar); DROP TABLE x; --\n", `"foo,bar); DROP TABLE x; --"`, false},
 	}
 
 	for _, tc := range tests {
-		result := parseHeaderToColumns([]byte(tc.header))
+		result, err := parseHeaderToColumns([]byte(tc.header))
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("parseHeaderToColumns(%q): expected error, got none", tc.header)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseHeaderToColumns(%q): unexpected error: %v", tc.header, err)
+		}
 		if result != tc.expected {
 			t.Errorf("parseHeaderToColumns(%q): expected %q, got %q", tc.header, tc.expected, result)
 		}
@@ -294,7 +306,7 @@ func BenchmarkGetTableOrPartition(b *testing.B) {
 func BenchmarkParseHeaderToColumns(b *testing.B) {
 	header := []byte("consensus_timestamp,payer_account_id,amount,node_account_id,type,result,scheduled\n")
 	for i := 0; i < b.N; i++ {
-		parseHeaderToColumns(header)
+		_, _ = parseHeaderToColumns(header)
 	}
 }
 

--- a/tools/bootstrap/internal/manifest/manifest.go
+++ b/tools/bootstrap/internal/manifest/manifest.go
@@ -94,7 +94,41 @@ func Load(manifestPath, dataDir string) (*Manifest, error) {
 
 	m.subdirs = detectSubdirs(dataDir, m.entries)
 
+	if err := m.validatePathsWithinDataDir(); err != nil {
+		return nil, err
+	}
+
 	return m, nil
+}
+
+// validatePathsWithinDataDir catches symlinks that point outside the data directory.
+// Missing files are skipped - those get reported per file during import.
+func (m *Manifest) validatePathsWithinDataDir() error {
+	base, err := resolveAbs(m.dataDir)
+	if err != nil {
+		return nil
+	}
+
+	for _, e := range m.entries {
+		target, err := resolveAbs(m.FullPath(e))
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(base, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("manifest entry %q resolves outside the data directory - check for symbolic links", e.Filename)
+		}
+	}
+
+	return nil
+}
+
+func resolveAbs(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
 }
 
 // detectSubdirs checks whether data files are nested in table subdirectories

--- a/tools/bootstrap/internal/manifest/manifest.go
+++ b/tools/bootstrap/internal/manifest/manifest.go
@@ -63,6 +63,9 @@ func Load(manifestPath, dataDir string) (*Manifest, error) {
 		if filename == "" {
 			continue
 		}
+		if !filepath.IsLocal(filename) {
+			return nil, fmt.Errorf("manifest contains a suspicious filename %q - it should stay within the data directory", filename)
+		}
 
 		// Parse row count (may be "N/A")
 		var rowCount int64 = -1

--- a/tools/bootstrap/internal/manifest/manifest_test.go
+++ b/tools/bootstrap/internal/manifest/manifest_test.go
@@ -403,6 +403,36 @@ invalid_size.csv.gz,100,notanumber,abc
 	}
 }
 
+func TestLoad_RejectsPathTraversal(t *testing.T) {
+	tests := []string{
+		"../../../../etc/passwd",
+		"/etc/passwd",
+		"table/../../etc/passwd",
+	}
+
+	for _, filename := range tests {
+		content := "filename,row_count,file_size,blake3_hash\n" + filename + ",100,200,abc\n"
+		path := createTestManifest(t, content)
+
+		if _, err := Load(path, "/data"); err == nil {
+			t.Errorf("Load should reject filename %q", filename)
+		}
+	}
+}
+
+func TestLoad_AllowsSubdirFilename(t *testing.T) {
+	content := "filename,row_count,file_size,blake3_hash\naccount_balance/account_balance_p2024_01.csv.gz,100,200,abc\n"
+	path := createTestManifest(t, content)
+
+	m, err := Load(path, "/data")
+	if err != nil {
+		t.Fatalf("Load should accept a one-level subdir filename: %v", err)
+	}
+	if m.Count() != 1 {
+		t.Errorf("Expected 1 entry, got %d", m.Count())
+	}
+}
+
 func TestNormalizeFilename(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/tools/bootstrap/internal/manifest/manifest_test.go
+++ b/tools/bootstrap/internal/manifest/manifest_test.go
@@ -5,6 +5,7 @@ package manifest
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -427,6 +428,57 @@ func TestLoad_AllowsSubdirFilename(t *testing.T) {
 	m, err := Load(path, "/data")
 	if err != nil {
 		t.Fatalf("Load should accept a one-level subdir filename: %v", err)
+	}
+	if m.Count() != 1 {
+		t.Errorf("Expected 1 entry, got %d", m.Count())
+	}
+}
+
+func TestLoad_RejectsSymlinkEscape(t *testing.T) {
+	dataDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.csv.gz")
+	if err := os.WriteFile(outside, []byte("data"), 0600); err != nil {
+		t.Fatalf("Failed to create outside file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dataDir, "entity.csv.gz")); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	path := createTestManifest(t, "filename,row_count,file_size,blake3_hash\nentity.csv.gz,100,200,abc\n")
+
+	_, err := Load(path, dataDir)
+	if err == nil {
+		t.Fatal("Load should reject a symlink pointing outside the data directory")
+	}
+	if !strings.Contains(err.Error(), "resolves outside the data directory") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestLoad_AllowsSymlinkWithinDataDir(t *testing.T) {
+	dataDir := t.TempDir()
+	real := filepath.Join(dataDir, "real.csv.gz")
+	if err := os.WriteFile(real, []byte("data"), 0600); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+	if err := os.Symlink(real, filepath.Join(dataDir, "entity.csv.gz")); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	path := createTestManifest(t, "filename,row_count,file_size,blake3_hash\nentity.csv.gz,100,200,abc\n")
+
+	if _, err := Load(path, dataDir); err != nil {
+		t.Errorf("Load should accept a symlink that stays inside the data directory: %v", err)
+	}
+}
+
+func TestLoad_MissingFilesAreNotFatal(t *testing.T) {
+	dataDir := t.TempDir()
+	path := createTestManifest(t, "filename,row_count,file_size,blake3_hash\nentity.csv.gz,100,200,abc\n")
+
+	m, err := Load(path, dataDir)
+	if err != nil {
+		t.Fatalf("Load should not fail on files that don't exist yet: %v", err)
 	}
 	if m.Count() != 1 {
 		t.Errorf("Expected 1 entry, got %d", m.Count())

--- a/tools/bootstrap/internal/tracking/tracker.go
+++ b/tools/bootstrap/internal/tracking/tracker.go
@@ -89,7 +89,7 @@ func (t *Tracker) save() error {
 
 	// Write to temp file and rename for atomic update
 	tmpPath := t.path + ".tmp"
-	if err := os.WriteFile(tmpPath, content, 0644); err != nil {
+	if err := os.WriteFile(tmpPath, content, 0600); err != nil {
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 


### PR DESCRIPTION
**Description**:
- Quote table/partition identifiers in `TRUNCATE/COPY/DELETE` to prevent SQL injection via filenames
- Default PostgreSQL connections to `sslmode=verify-full`, configurable via newly added `PGSSLMODE`/`PGSSLROOTCERT` variables in `bootstrap.env` instead of using hardcoded cleartext
- Pin `init.sh` download to a commit SHA instead of the main branch, will be updated periodically on DB exports.
- Parameterize `application_name` and quote `COPY` column names to prevent SQL injection via filenames/CSV headers
- Reject manifest entries with paths that require traversal, or absolute filenames at load time
- Tighten bootstrap's log/tracking/PID files to owner-only (`0600`) permissions

**Related issue(s)**:
- Several reported internal `MN-` issues

**Notes for reviewer**:

**Checklist**
- [x] Documented (`README.md` and `bootstrap.md` updated)
- [x] Tested:
  - Good path DB init and data bootstrap, followed by an importer start-up test to verify cleanliness
  - Manually tested all scenarios that the changes in this PR patch
  - Added Go tests for the added/modified scenarios
