### PR TITLE
Specify explicit cucumberTags in dev's helmrelease

### DIFF
--- a/clusters/preprod/dev/helmrelease.yaml
+++ b/clusters/preprod/dev/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
             test:
               acceptance:
                 network: OTHER
+      cucumberTags: "@acceptance and not @contractbase"
       enabled: true
     web3:
       env:


### PR DESCRIPTION
**Description**:
- Added explicit `cucumberTags` directive into dev's helmrelease

**Related issue(s)**:
- https://github.com/hashgraph/infrastructure/issues/10919

**Notes for reviewer**:
Adding this due to two contractbase failures that happened in the in-cluster acceptance-tests.

