### PR TITLE
chore: update solo version to 0.79.1

### DIFF
--- a/.github/workflows/wrb-differential.yaml
+++ b/.github/workflows/wrb-differential.yaml
@@ -34,7 +34,7 @@ jobs:
       SOLO_NAMESPACE: mirror
       SOLO_CLUSTER_SETUP_NAMESPACE: solo
       SOLO_DEPLOYMENT: solo-deployment
-      SOLO_VERSION: v0.77.0
+      SOLO_VERSION: v0.79.1
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary
- Bumps the pinned Solo CLI version used in `wrb-differential.yaml`'s `differential` job from `v0.77.0` to `v0.79.1` (`SOLO_VERSION` env, used for `npm install -g @hiero-ledger/solo@${SOLO_VERSION}`).