### PR TITLE
Fix Long overflow in range parameters

### DIFF
--- a/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeRequest.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/dto/NetworkNodeRequest.java
@@ -4,10 +4,12 @@ package org.hiero.mirror.restjava.dto;
 
 import static org.hiero.mirror.restjava.common.Constants.FILE_ID;
 import static org.hiero.mirror.restjava.common.Constants.LIMIT;
+import static org.hiero.mirror.restjava.common.Constants.MAX_REPEATED_QUERY_PARAMETERS;
 import static org.hiero.mirror.restjava.common.Constants.NODE_ID;
 import static org.hiero.mirror.restjava.common.Constants.ORDER;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +37,7 @@ public class NetworkNodeRequest {
 
     @RestJavaQueryParam(name = NODE_ID, required = false)
     @Builder.Default
+    @Size(max = MAX_REPEATED_QUERY_PARAMETERS)
     private List<NumberRangeParameter> nodeIds = List.of();
 
     @RestJavaQueryParam(name = LIMIT, required = false)

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/EntityIdRangeParameter.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/EntityIdRangeParameter.java
@@ -44,19 +44,24 @@ public record EntityIdRangeParameter(RangeOperator operator, Long value) impleme
         }
 
         var properties = CommonProperties.getInstance();
-        return switch (parts.size()) {
-            case 1 -> EntityId.of(properties.getShard(), properties.getRealm(), parts.get(0));
-            case 2 -> EntityId.of(properties.getShard(), parts.get(0), parts.get(1));
-            case 3 -> EntityId.of(parts.get(0), parts.get(1), parts.get(2));
-            default -> throw new IllegalArgumentException("Invalid entity ID");
-        };
+        var result =
+                switch (parts.size()) {
+                    case 1 -> EntityId.of(properties.getShard(), properties.getRealm(), parts.get(0));
+                    case 2 -> EntityId.of(properties.getShard(), parts.get(0), parts.get(1));
+                    case 3 -> EntityId.of(parts.get(0), parts.get(1), parts.get(2));
+                    default -> throw new IllegalArgumentException("Invalid entity ID");
+                };
+
+        // A shard >= 512 packs into the sign bit, producing a negative encoded id. Used as a range bound (e.g.
+        // gt:512.0.0) that inverts to match the entire non-negative id space, so reject it before it becomes a bound.
+        if (result.getId() < 0) {
+            throw new IllegalArgumentException("Invalid entity ID");
+        }
+
+        return result;
     }
 
     public long getInclusiveValue() {
-        return switch (operator) {
-            case GT -> value + 1;
-            case LT -> value - 1;
-            default -> value;
-        };
+        return RangeParameter.toInclusive(operator, value);
     }
 }

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/NumberRangeParameter.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/NumberRangeParameter.java
@@ -33,12 +33,6 @@ public record NumberRangeParameter(RangeOperator operator, Long value) implement
     }
 
     public long getInclusiveValue() {
-        if (operator == RangeOperator.GT) {
-            return value + 1;
-        } else if (operator == RangeOperator.LT) {
-            return value - 1;
-        } else {
-            return value;
-        }
+        return RangeParameter.toInclusive(operator, value);
     }
 }

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/RangeParameter.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/RangeParameter.java
@@ -22,4 +22,21 @@ public interface RangeParameter<T> {
     default boolean isEmpty() {
         return RangeOperator.UNKNOWN.equals(operator());
     }
+
+    // Converts an exclusive operator (GT/LT) to its inclusive value, guarding against overflow
+    static long toInclusive(RangeOperator operator, long value) {
+        if (operator == RangeOperator.GT) {
+            if (value == Long.MAX_VALUE) {
+                throw new IllegalArgumentException("Invalid range");
+            }
+            return value + 1;
+        } else if (operator == RangeOperator.LT) {
+            if (value == Long.MIN_VALUE) {
+                throw new IllegalArgumentException("Invalid range");
+            }
+            return value - 1;
+        } else {
+            return value;
+        }
+    }
 }

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/RequestParameterArgumentResolver.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/parameter/RequestParameterArgumentResolver.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.restjava.parameter;
 
+import static org.hiero.mirror.restjava.common.Constants.MAX_REPEATED_QUERY_PARAMETERS;
+
 import jakarta.inject.Named;
 import java.lang.reflect.Field;
 import java.util.Collection;
@@ -230,6 +232,12 @@ public class RequestParameterArgumentResolver implements HandlerMethodArgumentRe
 
         if (!isMultiValue && paramValues.length > 1) {
             throw new IllegalArgumentException("Only a single instance is supported for " + paramName);
+        }
+
+        // Cap repeated multi-valued parameters regardless of whether the DTO field declares a @Size constraint.
+        if (isMultiValue && paramValues.length > MAX_REPEATED_QUERY_PARAMETERS) {
+            throw new IllegalArgumentException(
+                    "Too many values for " + paramName + " (maximum " + MAX_REPEATED_QUERY_PARAMETERS + ")");
         }
 
         // Add to property values - WebDataBinder will handle type conversion

--- a/rest-java/src/main/java/org/hiero/mirror/restjava/service/Bound.java
+++ b/rest-java/src/main/java/org/hiero/mirror/restjava/service/Bound.java
@@ -3,8 +3,6 @@
 package org.hiero.mirror.restjava.service;
 
 import static org.hiero.mirror.restjava.common.RangeOperator.EQ;
-import static org.hiero.mirror.restjava.common.RangeOperator.GT;
-import static org.hiero.mirror.restjava.common.RangeOperator.LT;
 
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -61,16 +59,9 @@ public class Bound {
     }
 
     public long adjustUpperBound() {
-        if (this.upper == null) {
-            return Long.MAX_VALUE;
-        }
-
-        long upperBound = this.upper.value();
-        if (this.upper.operator() == RangeOperator.LT) {
-            upperBound--;
-        }
-
-        return upperBound;
+        return this.upper == null
+                ? Long.MAX_VALUE
+                : RangeParameter.toInclusive(this.upper.operator(), this.upper.value());
     }
 
     public RangeParameter<Long> adjustLowerRange() {
@@ -84,16 +75,7 @@ public class Bound {
     }
 
     public long getAdjustedLowerRangeValue() {
-        if (this.lower == null) {
-            return 0;
-        }
-
-        long lowerBound = this.lower.value();
-        if (this.lower.operator() == RangeOperator.GT) {
-            lowerBound++;
-        }
-
-        return lowerBound;
+        return this.lower == null ? 0 : RangeParameter.toInclusive(this.lower.operator(), this.lower.value());
     }
 
     public void adjustUpperRange() {
@@ -106,15 +88,7 @@ public class Bound {
     // Gets a range value if the operator is converted from GT/LT to EQ/GTE/LTE
     public long getInclusiveRangeValue(boolean upper) {
         var rangeParameter = upper ? this.getUpper() : this.getLower();
-        var operator = rangeParameter.operator();
-        long value = rangeParameter.value();
-        if (operator == GT) {
-            value += 1L;
-        } else if (operator == LT) {
-            value -= 1L;
-        }
-
-        return value;
+        return RangeParameter.toInclusive(rangeParameter.operator(), rangeParameter.value());
     }
 
     public int getCardinality(RangeOperator... operators) {

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/common/EntityIdRangeParameterTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/common/EntityIdRangeParameterTest.java
@@ -82,4 +82,39 @@ class EntityIdRangeParameterTest {
     void testInvalidEntity(String input) {
         assertThrows(InvalidEntityException.class, () -> EntityIdRangeParameter.valueOf(input));
     }
+
+    @Test
+    void getInclusiveValue() {
+        assertThat(new EntityIdRangeParameter(RangeOperator.GT, 2000L).getInclusiveValue())
+                .isEqualTo(2001L);
+        assertThat(new EntityIdRangeParameter(RangeOperator.LT, 2000L).getInclusiveValue())
+                .isEqualTo(1999L);
+        assertThat(new EntityIdRangeParameter(EQ, 2000L).getInclusiveValue()).isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("getInclusiveValue rejects an unsatisfiable edge bound instead of wrapping to the opposite id bound")
+    void getInclusiveValueRejectsUnsatisfiableBound() {
+        assertThrows(IllegalArgumentException.class, () -> new EntityIdRangeParameter(RangeOperator.GT, Long.MAX_VALUE)
+                .getInclusiveValue());
+        assertThrows(IllegalArgumentException.class, () -> new EntityIdRangeParameter(RangeOperator.LT, Long.MIN_VALUE)
+                .getInclusiveValue());
+
+        assertThrows(IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("gt:511.65535.274877906943")
+                .getInclusiveValue());
+        assertThrows(IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("lt:512.0.0")
+                .getInclusiveValue());
+    }
+
+    @Test
+    @DisplayName("valueOf rejects ids whose shard packs into the sign bit (negative encoded id would invert bounds)")
+    void valueOfRejectsNegativeEncodingId() {
+        // shard 512 sets bit 63 -> Long.MIN_VALUE; gt:512.0.0 would otherwise become an inclusive bound of
+        // Long.MIN_VALUE+1, matching the entire non-negative id space. Must be rejected at parse for every operator.
+        assertThrows(IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("gt:512.0.0"));
+        assertThrows(IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("lt:512.0.0"));
+        assertThrows(IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("eq:512.0.0"));
+        assertThrows(
+                IllegalArgumentException.class, () -> EntityIdRangeParameter.valueOf("gt:1023.65535.274877906943"));
+    }
 }

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/common/NumberRangeParameterTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/common/NumberRangeParameterTest.java
@@ -37,6 +37,25 @@ final class NumberRangeParameterTest {
         assertThat(NumberRangeParameter.valueOf(input)).isEqualTo(NumberRangeParameter.EMPTY);
     }
 
+    @Test
+    void getInclusiveValue() {
+        assertThat(new NumberRangeParameter(RangeOperator.GT, 2000L).getInclusiveValue())
+                .isEqualTo(2001L);
+        assertThat(new NumberRangeParameter(RangeOperator.LT, 2000L).getInclusiveValue())
+                .isEqualTo(1999L);
+        assertThat(new NumberRangeParameter(RangeOperator.EQ, 2000L).getInclusiveValue())
+                .isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("getInclusiveValue rejects an unsatisfiable edge bound instead of wrapping to the opposite bound")
+    void getInclusiveValueRejectsUnsatisfiableBound() {
+        assertThrows(IllegalArgumentException.class, () -> new NumberRangeParameter(RangeOperator.GT, Long.MAX_VALUE)
+                .getInclusiveValue());
+        assertThrows(IllegalArgumentException.class, () -> new NumberRangeParameter(RangeOperator.LT, Long.MIN_VALUE)
+                .getInclusiveValue());
+    }
+
     @ParameterizedTest
     @ValueSource(
             strings = {

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/controller/AllowancesControllerTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/controller/AllowancesControllerTest.java
@@ -384,7 +384,11 @@ final class AllowancesControllerTest extends ControllerTest {
             "?owner=true&token.id=gt:0.0.1000&limit=1&order=asc,token.id parameter must have account.id present",
             "?owner=true&account.id=gte:0.0.1000&token.id=ne:0.0.1000&limit=1&order=asc,Unsupported range operator ne for token.id",
             "?owner=true&account.id=gte:0.0.1000&account.id=lte:0.0.999&token.id=eq:0.0.1000&limit=1&order=asc,Invalid range provided for account.id",
-            "?owner=true&account.id=gte:0.0.1000&token.id=gt:0.0.1000&&token.id=lt:0.0.800&limit=1&order=asc,Invalid range provided for token.id"
+            "?owner=true&account.id=gte:0.0.1000&token.id=gt:0.0.1000&&token.id=lt:0.0.800&limit=1&order=asc,Invalid range provided for token.id",
+            // gt at the max encodable id (Long.MAX_VALUE) would overflow the inclusive bound
+            "?owner=true&account.id=gt:511.65535.274877906943&limit=1&order=asc,Invalid range",
+            // shard 512 encodes to a negative id (rejected at parse); gt on it would otherwise match the whole id space
+            "?owner=true&account.id=gt:512.0.0&limit=1&order=asc,Failed to convert 'account.id'"
         })
         void invalidRange(String uriParams, String message) {
             // Given

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/parameter/RequestParameterArgumentResolverTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/parameter/RequestParameterArgumentResolverTest.java
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.restjava.parameter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hiero.mirror.restjava.common.Constants.MAX_REPEATED_QUERY_PARAMETERS;
+
+import java.util.stream.IntStream;
+import lombok.Data;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.support.DefaultDataBinderFactory;
+import org.springframework.web.context.request.ServletWebRequest;
+
+final class RequestParameterArgumentResolverTest {
+
+    private static final String PARAM = "ids";
+
+    private final RequestParameterArgumentResolver resolver = new RequestParameterArgumentResolver();
+
+    @Test
+    void rejectsTooManyRepeatedValues() {
+        final var webRequest = requestWithValues(MAX_REPEATED_QUERY_PARAMETERS + 1);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(methodParameter(), null, webRequest, binderFactory()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Too many values for " + PARAM);
+    }
+
+    @Test
+    void allowsValuesUpToLimit() throws Exception {
+        final var webRequest = requestWithValues(MAX_REPEATED_QUERY_PARAMETERS);
+
+        final var result = resolver.resolveArgument(methodParameter(), null, webRequest, binderFactory());
+
+        assertThat(result).isInstanceOf(TestRequest.class);
+        assertThat(((TestRequest) result).getIds()).hasSize(MAX_REPEATED_QUERY_PARAMETERS);
+    }
+
+    @Test
+    void allowsSingleValue() {
+        final var webRequest = requestWithValues(1);
+
+        assertThatCode(() -> resolver.resolveArgument(methodParameter(), null, webRequest, binderFactory()))
+                .doesNotThrowAnyException();
+    }
+
+    private ServletWebRequest requestWithValues(int count) {
+        final var request = new MockHttpServletRequest();
+        final var values = IntStream.range(0, count).mapToObj(Integer::toString).toArray(String[]::new);
+        request.addParameter(PARAM, values);
+        return new ServletWebRequest(request);
+    }
+
+    private DefaultDataBinderFactory binderFactory() {
+        return new DefaultDataBinderFactory(null);
+    }
+
+    private MethodParameter methodParameter() {
+        try {
+            return new MethodParameter(getClass().getDeclaredMethod("handler", TestRequest.class), 0);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private void handler(TestRequest request) {}
+
+    @Data
+    public static class TestRequest {
+
+        @RestJavaQueryParam(name = PARAM, required = false)
+        private String @Nullable [] ids;
+    }
+}

--- a/rest-java/src/test/java/org/hiero/mirror/restjava/service/BoundTest.java
+++ b/rest-java/src/test/java/org/hiero/mirror/restjava/service/BoundTest.java
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.restjava.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.hiero.mirror.restjava.common.RangeOperator;
+import org.hiero.mirror.restjava.parameter.NumberRangeParameter;
+import org.junit.jupiter.api.Test;
+
+final class BoundTest {
+
+    private static final String PARAM = "account.id";
+
+    private static Bound bound(boolean primarySortField, NumberRangeParameter... params) {
+        return new Bound(params, primarySortField, PARAM, null);
+    }
+
+    @Test
+    void adjustsNormalBounds() {
+        final var lower = bound(false, new NumberRangeParameter(RangeOperator.GT, 5L));
+        assertThat(lower.getAdjustedLowerRangeValue()).isEqualTo(6L);
+
+        final var upper = bound(false, new NumberRangeParameter(RangeOperator.LT, 5L));
+        assertThat(upper.adjustUpperBound()).isEqualTo(4L);
+    }
+
+    @Test
+    void rejectsGtAtLongMaxValue() {
+        // Without the guard, GT Long.MAX_VALUE increments to Long.MIN_VALUE
+        assertThatThrownBy(() -> bound(true, new NumberRangeParameter(RangeOperator.GT, Long.MAX_VALUE)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid range");
+    }
+
+    @Test
+    void rejectsLtAtLongMinValue() {
+        // Without the guard, LT Long.MIN_VALUE decrements to Long.MAX_VALUE
+        assertThatThrownBy(() -> bound(true, new NumberRangeParameter(RangeOperator.LT, Long.MIN_VALUE)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid range");
+    }
+
+    @Test
+    void rejectsEdgeBoundEvenWhenNotPrimarySortField() {
+        // The overflow guard fires during construction (via the adjust* calls), so it covers non-primary/secondary
+        // bounds too, which the primarySortField-gated lower > upper check would otherwise skip.
+        assertThatThrownBy(() -> bound(false, new NumberRangeParameter(RangeOperator.GT, Long.MAX_VALUE)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> bound(false, new NumberRangeParameter(RangeOperator.LT, Long.MIN_VALUE)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
**Description**:
Hardens query-parameter handling in rest-java against malformed/boundary range inputs and unbounded multi-valued parameters. Consolidates the exclusive→inclusive range conversion into one guarded helper and adds an entity-id range-validation.

In the example below can be seen that a gt:9223372036854775807 (Long.MAX_VALUE) filter computes its inclusive bound as value + 1, which silently overflows to Long.MIN_VALUE — turning an empty "greater than the maximum" range into an unbounded "greater than the minimum" scan.

<img width="1081" height="438" alt="Screenshot 2026-08-05 at 13 11 59" src="https://github.com/user-attachments/assets/17171a8a-d740-438f-934b-519fcfb56212" />
rameter cap.
<img width="1077" height="730" alt="Screenshot 2026-08-05 at 13 11 48" src="https://github.com/user-attachments/assets/2066f03d-8932-43b9-b66c-8d54f467fe58" />



**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
