### PR TITLE
Fix missing contract_transaction rows when empty contract ID

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
@@ -147,9 +147,8 @@ public class RecordItem implements StreamItem {
     }
 
     public void addContractTransaction(EntityId entityId) {
-        if (EntityId.isEmpty(entityId)
-                || contractTransactionPredicate == null
-                || !contractTransactionPredicate.test(entityId)) {
+        // Explicitly allow empty entity IDs for failed transactions
+        if (contractTransactionPredicate == null || !contractTransactionPredicate.test(entityId)) {
             return;
         }
         getContractTransactions().computeIfAbsent(entityId.getId(), key -> ContractTransaction.builder()

--- a/common/src/test/java/org/hiero/mirror/common/domain/transaction/RecordItemTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/domain/transaction/RecordItemTest.java
@@ -804,6 +804,22 @@ class RecordItemTest {
     }
 
     @Test
+    void testAddContractTransactionEmpty() {
+        final var recordItem = RecordItem.builder()
+                .contractTransactionPredicate(_ -> true)
+                .hapiVersion(DEFAULT_HAPI_VERSION)
+                .transactionRecord(TRANSACTION_RECORD)
+                .transaction(DEFAULT_TRANSACTION)
+                .build();
+        recordItem.addContractTransaction(EntityId.EMPTY);
+        assertThat(recordItem.populateContractTransactions())
+                .hasSize(1)
+                .first()
+                .extracting(ContractTransaction::getEntityId)
+                .isEqualTo(0L);
+    }
+
+    @Test
     void testAddContractTransactionDisabled() {
         var random = new SecureRandom();
         long id = random.nextLong(2000) + 2000L;

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/AbstractStreamFileParser.java
@@ -8,9 +8,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.mirror.common.domain.StreamFile;
@@ -32,7 +32,7 @@ public abstract class AbstractStreamFileParser<T extends StreamFile<?>> implemen
     protected final StreamFileRepository<T, Long> streamFileRepository;
 
     private final AtomicReference<T> last;
-    private final Map<StreamType, ParserMetric> parserMetrics = new HashMap<>();
+    private final Map<StreamType, ParserMetric> parserMetrics = new ConcurrentHashMap<>();
 
     protected AbstractStreamFileParser(
             MeterRegistry meterRegistry,

--- a/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
@@ -1,0 +1,16 @@
+-- Inserts missing contract_transaction entries with 0 entity_id caused by a change in 0.159.2. The timestamp
+-- 1784869200000000000 (2026-07-24T00:00:00Z) is around when 0.159.2 was created and deployed and used to optimize
+-- the performance by skipping rows that did not have the regression.
+
+with cr as materialized (
+    select consensus_timestamp, contract_id, payer_account_id
+    from contract_result
+    where contract_id = 0 and consensus_timestamp >= 1784869200000000000
+)
+insert into contract_transaction (consensus_timestamp, entity_id, contract_ids, payer_account_id)
+select ct.consensus_timestamp, cr.contract_id, 0 || ct.contract_ids as contract_ids, cr.payer_account_id
+from cr
+         join contract_transaction ct
+              on ct.consensus_timestamp = cr.consensus_timestamp and ct.entity_id = cr.payer_account_id
+where ct.consensus_timestamp >= 1784869200000000000 and not (contract_ids @> array[0]::bigint[])
+order by cr.consensus_timestamp asc on conflict do nothing;

--- a/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
@@ -6,6 +6,13 @@ with cr as materialized (
     select consensus_timestamp, contract_id, payer_account_id
     from contract_result
     where contract_id = 0 and consensus_timestamp >= 1784869200000000000
+),
+updates as (
+    update contract_transaction ct
+    set contract_ids = 0 || ct.contract_ids
+    from cr
+    where cr.consensus_timestamp = ct.consensus_timestamp and ct.consensus_timestamp >= 1784869200000000000
+              and not (contract_ids @> array[0]::bigint[])
 )
 insert into contract_transaction (consensus_timestamp, entity_id, contract_ids, payer_account_id)
 select ct.consensus_timestamp, cr.contract_id, 0 || ct.contract_ids as contract_ids, cr.payer_account_id

--- a/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v1/V1.127.0__fix_empty_contract_transaction.sql
@@ -13,4 +13,4 @@ from cr
          join contract_transaction ct
               on ct.consensus_timestamp = cr.consensus_timestamp and ct.entity_id = cr.payer_account_id
 where ct.consensus_timestamp >= 1784869200000000000 and not (contract_ids @> array[0]::bigint[])
-order by cr.consensus_timestamp asc on conflict do nothing;
+on conflict do nothing;

--- a/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
@@ -6,6 +6,13 @@ with cr as materialized (
     select consensus_timestamp, contract_id, payer_account_id
     from contract_result
     where contract_id = 0 and consensus_timestamp >= 1784869200000000000
+),
+updates as (
+    update contract_transaction ct
+    set contract_ids = 0 || ct.contract_ids
+    from cr
+    where cr.consensus_timestamp = ct.consensus_timestamp and ct.consensus_timestamp >= 1784869200000000000
+          and not (contract_ids @> array[0]::bigint[])
 )
 insert into contract_transaction (consensus_timestamp, entity_id, contract_ids, payer_account_id)
 select ct.consensus_timestamp, cr.contract_id, 0 || ct.contract_ids as contract_ids, cr.payer_account_id

--- a/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
@@ -1,0 +1,16 @@
+-- Inserts missing contract_transaction entries with 0 entity_id caused by a change in 0.159.2. The timestamp
+-- 1784869200000000000 (2026-07-24T00:00:00Z) is around when 0.159.2 was created and deployed and used to optimize
+-- the performance by skipping rows that did not have the regression.
+
+with cr as materialized (
+    select consensus_timestamp, contract_id, payer_account_id
+    from contract_result
+    where contract_id = 0 and consensus_timestamp >= 1784869200000000000
+)
+insert into contract_transaction (consensus_timestamp, entity_id, contract_ids, payer_account_id)
+select ct.consensus_timestamp, cr.contract_id, 0 || ct.contract_ids as contract_ids, cr.payer_account_id
+from cr
+         join contract_transaction ct
+              on ct.consensus_timestamp = cr.consensus_timestamp and ct.entity_id = cr.payer_account_id
+where ct.consensus_timestamp >= 1784869200000000000 and not (contract_ids @> array[0]::bigint[])
+order by cr.consensus_timestamp asc on conflict do nothing;

--- a/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
+++ b/importer/src/main/resources/db/migration/v2/V2.32.0__fix_empty_contract_transaction.sql
@@ -13,4 +13,4 @@ from cr
          join contract_transaction ct
               on ct.consensus_timestamp = cr.consensus_timestamp and ct.entity_id = cr.payer_account_id
 where ct.consensus_timestamp >= 1784869200000000000 and not (contract_ids @> array[0]::bigint[])
-order by cr.consensus_timestamp asc on conflict do nothing;
+on conflict do nothing;

--- a/importer/src/test/java/org/hiero/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -210,7 +210,6 @@ final class ContractResultServiceImplTest {
         ids.add(Objects.requireNonNullElse(rootId, EntityId.EMPTY).getId());
         ids.add(EntityId.of(recordItem.getTransactionBody().getTransactionID().getAccountID())
                 .getId());
-        ids.remove(0L); // Do not store EntityId.EMPTY
 
         var idsList = new ArrayList<>(ids);
         idsList.sort(Long::compareTo);

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/FixContractTransactionContractZeroTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/FixContractTransactionContractZeroTest.java
@@ -40,12 +40,12 @@ final class FixContractTransactionContractZeroTest extends ImporterIntegrationTe
     }
 
     @Test
-    void insertsMissingContractZeroTransaction() {
-        // given - a contract result for contract 0 whose transaction has no entity_id = 0 fan out row
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
-        var otherEntityId = domainBuilder.id();
-        var contractIds = List.of(1001L, 1002L);
+    void updatesAndInsertsContractZeroRow() {
+        // given - a contract result for contract 0 whose fan out omits 0 entirely
+        final long timestamp = MIGRATION_TIMESTAMP + 1000;
+        final var payerId = domainBuilder.id();
+        final var otherEntityId = domainBuilder.id();
+        final var contractIds = List.of(payerId, otherEntityId);
 
         persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
         persistContractTransaction(timestamp, payerId, contractIds, payerId);
@@ -54,130 +54,120 @@ final class FixContractTransactionContractZeroTest extends ImporterIntegrationTe
         // when
         runMigration();
 
-        // then - 0 is prepended, and the pre-existing rows keep their original arrays
+        // then - every row for the transaction carries 0, including the inserted one, which derives its array from the
+        // pre-update snapshot and so must prepend 0 itself
+        final var expected = List.of(CONTRACT_ZERO_ID, payerId, otherEntityId);
         assertThat(findAllContractTransactions())
                 .containsExactlyInAnyOrder(
-                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, List.of(0L, 1001L, 1002L), payerId),
-                        new ContractTransactionRow(timestamp, payerId, contractIds, payerId),
-                        new ContractTransactionRow(timestamp, otherEntityId, contractIds, payerId));
+                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, expected, payerId),
+                        new ContractTransactionRow(timestamp, payerId, expected, payerId),
+                        new ContractTransactionRow(timestamp, otherEntityId, expected, payerId));
     }
 
     @Test
-    void insertsForMultipleTransactions() {
+    void updatesMultipleTransactions() {
         // given - two impacted transactions with different payers and arrays
-        var firstTimestamp = MIGRATION_TIMESTAMP;
-        var secondTimestamp = MIGRATION_TIMESTAMP + 5000;
-        var firstPayerId = domainBuilder.id();
-        var secondPayerId = domainBuilder.id();
+        final long timestamp1 = MIGRATION_TIMESTAMP;
+        final long timestamp2 = MIGRATION_TIMESTAMP + 5000;
+        final var payer1 = domainBuilder.id();
+        final var payer2 = domainBuilder.id();
 
-        persistContractResult(firstTimestamp, CONTRACT_ZERO_ID, firstPayerId);
-        persistContractTransaction(firstTimestamp, firstPayerId, List.of(2001L), firstPayerId);
-        persistContractResult(secondTimestamp, CONTRACT_ZERO_ID, secondPayerId);
-        persistContractTransaction(secondTimestamp, secondPayerId, List.of(3001L, 3002L), secondPayerId);
+        persistContractResult(timestamp1, CONTRACT_ZERO_ID, payer1);
+        persistContractTransaction(timestamp1, payer1, List.of(payer1), payer1);
+        persistContractResult(timestamp2, CONTRACT_ZERO_ID, payer2);
+        persistContractTransaction(timestamp2, payer2, List.of(payer2), payer2);
 
         // when
         runMigration();
 
         // then
+        final var expected1 = List.of(CONTRACT_ZERO_ID, payer1);
+        final var expected2 = List.of(CONTRACT_ZERO_ID, payer2);
         assertThat(findAllContractTransactions())
-                .contains(
-                        new ContractTransactionRow(firstTimestamp, CONTRACT_ZERO_ID, List.of(0L, 2001L), firstPayerId),
-                        new ContractTransactionRow(
-                                secondTimestamp, CONTRACT_ZERO_ID, List.of(0L, 3001L, 3002L), secondPayerId))
-                .hasSize(4);
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(timestamp1, payer1, expected1, payer1),
+                        new ContractTransactionRow(timestamp1, CONTRACT_ZERO_ID, expected1, payer1),
+                        new ContractTransactionRow(timestamp2, payer2, expected2, payer2),
+                        new ContractTransactionRow(timestamp2, CONTRACT_ZERO_ID, expected2, payer2));
     }
 
     @Test
     void respectsTimestampLowerBound() {
         // given - one transaction immediately before the bound and one exactly on it
-        var beforeTimestamp = MIGRATION_TIMESTAMP - 1;
-        var atTimestamp = MIGRATION_TIMESTAMP;
-        var beforePayerId = domainBuilder.id();
-        var atPayerId = domainBuilder.id();
+        final long beforeTimestamp = MIGRATION_TIMESTAMP - 1;
+        final long atTimestamp = MIGRATION_TIMESTAMP;
+        final var beforePayerId = domainBuilder.id();
+        final var atPayerId = domainBuilder.id();
+        final var beforeContractIds = List.of(CONTRACT_ZERO_ID, beforePayerId);
 
         persistContractResult(beforeTimestamp, CONTRACT_ZERO_ID, beforePayerId);
-        persistContractTransaction(beforeTimestamp, beforePayerId, List.of(4001L), beforePayerId);
+        persistContractTransaction(beforeTimestamp, beforePayerId, beforeContractIds, beforePayerId);
         persistContractResult(atTimestamp, CONTRACT_ZERO_ID, atPayerId);
-        persistContractTransaction(atTimestamp, atPayerId, List.of(5001L), atPayerId);
+        persistContractTransaction(atTimestamp, atPayerId, List.of(atPayerId), atPayerId);
 
         // when
         runMigration();
 
-        // then - the bound is inclusive, and nothing before it is touched
+        // then - the bound is inclusive, and neither the update nor the insert reaches before it
+        final var expected = List.of(CONTRACT_ZERO_ID, atPayerId);
         assertThat(findAllContractTransactions())
                 .containsExactlyInAnyOrder(
-                        new ContractTransactionRow(beforeTimestamp, beforePayerId, List.of(4001L), beforePayerId),
-                        new ContractTransactionRow(atTimestamp, atPayerId, List.of(5001L), atPayerId),
-                        new ContractTransactionRow(atTimestamp, CONTRACT_ZERO_ID, List.of(0L, 5001L), atPayerId));
+                        new ContractTransactionRow(beforeTimestamp, beforePayerId, beforeContractIds, beforePayerId),
+                        new ContractTransactionRow(atTimestamp, atPayerId, expected, atPayerId),
+                        new ContractTransactionRow(atTimestamp, CONTRACT_ZERO_ID, expected, atPayerId));
     }
 
     @Test
-    void noopWhenContractZeroRowAlreadyExists() {
-        // given - the fan out row already exists, so the insert must not overwrite its array
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
-        var existingContractIds = List.of(6001L);
-
-        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
-        persistContractTransaction(timestamp, payerId, existingContractIds, payerId);
-        persistContractTransaction(timestamp, CONTRACT_ZERO_ID, existingContractIds, payerId);
-
-        // when
-        runMigration();
-
-        // then
-        assertThat(findAllContractTransactions())
-                .containsExactlyInAnyOrder(
-                        new ContractTransactionRow(timestamp, payerId, existingContractIds, payerId),
-                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, existingContractIds, payerId));
-    }
-
-    @Test
-    void noopWhenPayerContractIdsAlreadyContainsZero() {
-        // given - the payer row lists contract 0 but the entity_id = 0 row is still missing.
-        // The migration guards on the payer's array rather than on the missing row, so this stays unfixed.
-        // If the guard is changed to a not exists on entity_id = 0, this expectation must flip.
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
-        var contractIds = List.of(0L, 7001L);
+    void noopWhenAlreadyCorrect() {
+        // given - a transaction ingested after the importer fix: entity 0 row present and 0 in every array
+        final long timestamp = MIGRATION_TIMESTAMP + 1000;
+        final var payerId = domainBuilder.id();
+        final var otherEntityId = domainBuilder.id();
+        final var contractIds = List.of(CONTRACT_ZERO_ID, payerId, otherEntityId);
 
         persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
         persistContractTransaction(timestamp, payerId, contractIds, payerId);
+        persistContractTransaction(timestamp, otherEntityId, contractIds, payerId);
+        persistContractTransaction(timestamp, CONTRACT_ZERO_ID, contractIds, payerId);
 
         // when
         runMigration();
 
-        // then
+        // then - no second 0 is prepended and no duplicate row is inserted
         assertThat(findAllContractTransactions())
-                .containsExactly(new ContractTransactionRow(timestamp, payerId, contractIds, payerId));
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(timestamp, payerId, contractIds, payerId),
+                        new ContractTransactionRow(timestamp, otherEntityId, contractIds, payerId),
+                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, contractIds, payerId));
     }
 
     @Test
-    void noopWhenPayerTransactionMissing() {
-        // given - a contract result whose payer has no fan out row to copy contract_ids from
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
-        var otherEntityId = domainBuilder.id();
-        var contractIds = List.of(8001L);
+    void updatesWhenPayerRowMissing() {
+        // given - no fan out row for the payer, so the insert has nothing to copy from. The update joins on
+        // consensus_timestamp only, so it is broader than the insert and still runs.
+        final long timestamp = MIGRATION_TIMESTAMP + 1000;
+        final var payerId = domainBuilder.id();
+        final var otherEntityId = domainBuilder.id();
 
         persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
-        persistContractTransaction(timestamp, otherEntityId, contractIds, payerId);
+        persistContractTransaction(timestamp, otherEntityId, List.of(payerId, otherEntityId), payerId);
 
         // when
         runMigration();
 
         // then
+        final var expected = List.of(CONTRACT_ZERO_ID, payerId, otherEntityId);
         assertThat(findAllContractTransactions())
-                .containsExactly(new ContractTransactionRow(timestamp, otherEntityId, contractIds, payerId));
+                .containsExactly(new ContractTransactionRow(timestamp, otherEntityId, expected, payerId));
     }
 
     @Test
     void noopWhenContractResultIsNotContractZero() {
-        // given - a normal contract result, which the migration must ignore
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
-        var contractId = domainBuilder.id();
-        var contractIds = List.of(contractId);
+        // given - a normal contract result, which neither sub-statement may touch
+        final long timestamp = MIGRATION_TIMESTAMP + 1000;
+        final var payerId = domainBuilder.id();
+        final var contractId = domainBuilder.id();
+        final var contractIds = List.of(contractId);
 
         persistContractResult(timestamp, contractId, payerId);
         persistContractTransaction(timestamp, payerId, contractIds, payerId);
@@ -193,18 +183,28 @@ final class FixContractTransactionContractZeroTest extends ImporterIntegrationTe
     @Test
     void isIdempotent() {
         // given
-        var timestamp = MIGRATION_TIMESTAMP + 1000;
-        var payerId = domainBuilder.id();
+        final long timestamp = MIGRATION_TIMESTAMP + 1000;
+        final var payerId = domainBuilder.id();
+        final var otherEntityId = domainBuilder.id();
+        final var contractIds = List.of(payerId, otherEntityId);
 
         persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
-        persistContractTransaction(timestamp, payerId, List.of(9001L), payerId);
+        persistContractTransaction(timestamp, payerId, contractIds, payerId);
+        persistContractTransaction(timestamp, otherEntityId, contractIds, payerId);
 
-        // when - the payer row still lacks 0 after the first pass, so the second pass relies on the conflict clause
+        // when - the first pass leaves 0 in every array, so the second matches nothing and never reaches the conflict
+        // clause. A second 0 must not be prepended.
         runMigration();
-        var afterFirstRun = findAllContractTransactions();
+        final var afterFirstRun = findAllContractTransactions();
         runMigration();
 
         // then
+        final var expected = List.of(CONTRACT_ZERO_ID, payerId, otherEntityId);
+        assertThat(afterFirstRun)
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(timestamp, payerId, expected, payerId),
+                        new ContractTransactionRow(timestamp, otherEntityId, expected, payerId),
+                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, expected, payerId));
         assertThat(findAllContractTransactions()).containsExactlyInAnyOrderElementsOf(afterFirstRun);
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/migration/FixContractTransactionContractZeroTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/migration/FixContractTransactionContractZeroTest.java
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package org.hiero.mirror.importer.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.hiero.mirror.common.domain.entity.EntityId;
+import org.hiero.mirror.importer.DisableRepeatableSqlMigration;
+import org.hiero.mirror.importer.ImporterIntegrationTest;
+import org.hiero.mirror.importer.TestUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.Profiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(initializers = FixContractTransactionContractZeroTest.Initializer.class)
+@DisablePartitionMaintenance
+@DisableRepeatableSqlMigration
+@RequiredArgsConstructor
+@Tag("migration")
+final class FixContractTransactionContractZeroTest extends ImporterIntegrationTest {
+
+    private static final long MIGRATION_TIMESTAMP = 1784869200000000000L;
+    private static final long CONTRACT_ZERO_ID = 0L;
+
+    @Test
+    void empty() {
+        runMigration();
+        assertThat(findAllContractTransactions()).isEmpty();
+    }
+
+    @Test
+    void insertsMissingContractZeroTransaction() {
+        // given - a contract result for contract 0 whose transaction has no entity_id = 0 fan out row
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+        var otherEntityId = domainBuilder.id();
+        var contractIds = List.of(1001L, 1002L);
+
+        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
+        persistContractTransaction(timestamp, payerId, contractIds, payerId);
+        persistContractTransaction(timestamp, otherEntityId, contractIds, payerId);
+
+        // when
+        runMigration();
+
+        // then - 0 is prepended, and the pre-existing rows keep their original arrays
+        assertThat(findAllContractTransactions())
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, List.of(0L, 1001L, 1002L), payerId),
+                        new ContractTransactionRow(timestamp, payerId, contractIds, payerId),
+                        new ContractTransactionRow(timestamp, otherEntityId, contractIds, payerId));
+    }
+
+    @Test
+    void insertsForMultipleTransactions() {
+        // given - two impacted transactions with different payers and arrays
+        var firstTimestamp = MIGRATION_TIMESTAMP;
+        var secondTimestamp = MIGRATION_TIMESTAMP + 5000;
+        var firstPayerId = domainBuilder.id();
+        var secondPayerId = domainBuilder.id();
+
+        persistContractResult(firstTimestamp, CONTRACT_ZERO_ID, firstPayerId);
+        persistContractTransaction(firstTimestamp, firstPayerId, List.of(2001L), firstPayerId);
+        persistContractResult(secondTimestamp, CONTRACT_ZERO_ID, secondPayerId);
+        persistContractTransaction(secondTimestamp, secondPayerId, List.of(3001L, 3002L), secondPayerId);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions())
+                .contains(
+                        new ContractTransactionRow(firstTimestamp, CONTRACT_ZERO_ID, List.of(0L, 2001L), firstPayerId),
+                        new ContractTransactionRow(
+                                secondTimestamp, CONTRACT_ZERO_ID, List.of(0L, 3001L, 3002L), secondPayerId))
+                .hasSize(4);
+    }
+
+    @Test
+    void respectsTimestampLowerBound() {
+        // given - one transaction immediately before the bound and one exactly on it
+        var beforeTimestamp = MIGRATION_TIMESTAMP - 1;
+        var atTimestamp = MIGRATION_TIMESTAMP;
+        var beforePayerId = domainBuilder.id();
+        var atPayerId = domainBuilder.id();
+
+        persistContractResult(beforeTimestamp, CONTRACT_ZERO_ID, beforePayerId);
+        persistContractTransaction(beforeTimestamp, beforePayerId, List.of(4001L), beforePayerId);
+        persistContractResult(atTimestamp, CONTRACT_ZERO_ID, atPayerId);
+        persistContractTransaction(atTimestamp, atPayerId, List.of(5001L), atPayerId);
+
+        // when
+        runMigration();
+
+        // then - the bound is inclusive, and nothing before it is touched
+        assertThat(findAllContractTransactions())
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(beforeTimestamp, beforePayerId, List.of(4001L), beforePayerId),
+                        new ContractTransactionRow(atTimestamp, atPayerId, List.of(5001L), atPayerId),
+                        new ContractTransactionRow(atTimestamp, CONTRACT_ZERO_ID, List.of(0L, 5001L), atPayerId));
+    }
+
+    @Test
+    void noopWhenContractZeroRowAlreadyExists() {
+        // given - the fan out row already exists, so the insert must not overwrite its array
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+        var existingContractIds = List.of(6001L);
+
+        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
+        persistContractTransaction(timestamp, payerId, existingContractIds, payerId);
+        persistContractTransaction(timestamp, CONTRACT_ZERO_ID, existingContractIds, payerId);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions())
+                .containsExactlyInAnyOrder(
+                        new ContractTransactionRow(timestamp, payerId, existingContractIds, payerId),
+                        new ContractTransactionRow(timestamp, CONTRACT_ZERO_ID, existingContractIds, payerId));
+    }
+
+    @Test
+    void noopWhenPayerContractIdsAlreadyContainsZero() {
+        // given - the payer row lists contract 0 but the entity_id = 0 row is still missing.
+        // The migration guards on the payer's array rather than on the missing row, so this stays unfixed.
+        // If the guard is changed to a not exists on entity_id = 0, this expectation must flip.
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+        var contractIds = List.of(0L, 7001L);
+
+        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
+        persistContractTransaction(timestamp, payerId, contractIds, payerId);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions())
+                .containsExactly(new ContractTransactionRow(timestamp, payerId, contractIds, payerId));
+    }
+
+    @Test
+    void noopWhenPayerTransactionMissing() {
+        // given - a contract result whose payer has no fan out row to copy contract_ids from
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+        var otherEntityId = domainBuilder.id();
+        var contractIds = List.of(8001L);
+
+        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
+        persistContractTransaction(timestamp, otherEntityId, contractIds, payerId);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions())
+                .containsExactly(new ContractTransactionRow(timestamp, otherEntityId, contractIds, payerId));
+    }
+
+    @Test
+    void noopWhenContractResultIsNotContractZero() {
+        // given - a normal contract result, which the migration must ignore
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+        var contractId = domainBuilder.id();
+        var contractIds = List.of(contractId);
+
+        persistContractResult(timestamp, contractId, payerId);
+        persistContractTransaction(timestamp, payerId, contractIds, payerId);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions())
+                .containsExactly(new ContractTransactionRow(timestamp, payerId, contractIds, payerId));
+    }
+
+    @Test
+    void isIdempotent() {
+        // given
+        var timestamp = MIGRATION_TIMESTAMP + 1000;
+        var payerId = domainBuilder.id();
+
+        persistContractResult(timestamp, CONTRACT_ZERO_ID, payerId);
+        persistContractTransaction(timestamp, payerId, List.of(9001L), payerId);
+
+        // when - the payer row still lacks 0 after the first pass, so the second pass relies on the conflict clause
+        runMigration();
+        var afterFirstRun = findAllContractTransactions();
+        runMigration();
+
+        // then
+        assertThat(findAllContractTransactions()).containsExactlyInAnyOrderElementsOf(afterFirstRun);
+    }
+
+    private void persistContractResult(final long consensusTimestamp, final long contractId, final long payerId) {
+        domainBuilder
+                .contractResult()
+                .customize(cr -> cr.consensusTimestamp(consensusTimestamp)
+                        .contractId(contractId)
+                        .payerAccountId(EntityId.of(payerId)))
+                .persist();
+    }
+
+    private void persistContractTransaction(
+            final long consensusTimestamp, final long entityId, final List<Long> contractIds, final long payerId) {
+        domainBuilder
+                .contractTransaction()
+                .customize(ct -> ct.consensusTimestamp(consensusTimestamp)
+                        .contractIds(contractIds)
+                        .entityId(entityId)
+                        .payerAccountId(payerId))
+                .persist();
+    }
+
+    private List<ContractTransactionRow> findAllContractTransactions() {
+        return jdbcOperations.query(
+                """
+                select consensus_timestamp, entity_id, contract_ids, payer_account_id
+                from contract_transaction
+                order by consensus_timestamp, entity_id
+                """,
+                (rs, rowNum) -> new ContractTransactionRow(
+                        rs.getLong("consensus_timestamp"),
+                        rs.getLong("entity_id"),
+                        toList(rs.getArray("contract_ids")),
+                        rs.getLong("payer_account_id")));
+    }
+
+    @SneakyThrows
+    private List<Long> toList(final Array array) {
+        return array == null ? List.of() : Arrays.asList((Long[]) array.getArray());
+    }
+
+    @SneakyThrows
+    private void runMigration() {
+        final var migrationFilepath = isV1()
+                ? "v1/V1.127.0__fix_empty_contract_transaction.sql"
+                : "v2/V2.32.0__fix_empty_contract_transaction.sql";
+        final var file = TestUtils.getResource("db/migration/" + migrationFilepath);
+        ownerJdbcTemplate.update(FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    }
+
+    /** Ordering of contract_ids is significant: the migration prepends rather than appends. */
+    private record ContractTransactionRow(
+            long consensusTimestamp, long entityId, List<Long> contractIds, long payerAccountId) {}
+
+    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            final var environment = configurableApplicationContext.getEnvironment();
+            final var version = environment.acceptsProfiles(Profiles.of("v2")) ? "2.31.0" : "1.126.0";
+            TestPropertyValues.of("spring.flyway.target=" + version).applyTo(environment);
+        }
+    }
+}

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
@@ -240,11 +240,11 @@ class EntityRecordItemListenerEthereumTest extends AbstractEntityRecordItemListe
         // given
         final var result = ResponseCodeEnum.INSUFFICIENT_GAS;
         final var recordItem = recordItemBuilder
-                .ethereumTransaction(false)
-                .record(r -> r.setContractCallResult(
-                        r.getContractCallResultBuilder().clearContractID().clearLogInfo()))
+                .ethereumTransaction(true)
+                .record(r -> r.setContractCreateResult(
+                        r.getContractCreateResultBuilder().clearContractID().clearLogInfo()))
                 .record(r -> r.getReceiptBuilder().setStatus(result))
-                .sidecarRecords(s -> s.clear())
+                .sidecarRecords(List::clear)
                 .build();
         final long consensusTimestamp = recordItem.getConsensusTimestamp();
         final var contractIds = List.of(0L, recordItem.getPayerAccountId().getId());

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
@@ -17,13 +17,16 @@ import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionRecord.Builder;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.hiero.mirror.common.domain.contract.ContractResult;
+import org.hiero.mirror.common.domain.contract.ContractTransaction;
 import org.hiero.mirror.common.domain.contract.ContractTransactionHash;
 import org.hiero.mirror.common.domain.entity.Entity;
 import org.hiero.mirror.common.domain.entity.EntityId;
@@ -31,6 +34,7 @@ import org.hiero.mirror.common.domain.transaction.EthereumTransaction;
 import org.hiero.mirror.common.domain.transaction.RecordItem;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.parser.record.ethereum.LegacyEthereumTransactionParserTest;
+import org.hiero.mirror.importer.repository.ContractTransactionRepository;
 import org.hiero.mirror.importer.repository.EthereumTransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +49,7 @@ class EntityRecordItemListenerEthereumTest extends AbstractEntityRecordItemListe
     private static final Version HAPI_VERSION_0_46_0 = new Version(0, 46, 0);
     private static final long SIGNER_NONCE = 10L;
 
+    private final ContractTransactionRepository contractTransactionRepository;
     private final EthereumTransactionRepository ethereumTransactionRepository;
 
     private static Stream<Arguments> provideSignerNonceArguments() {
@@ -228,6 +233,44 @@ class EntityRecordItemListenerEthereumTest extends AbstractEntityRecordItemListe
                 .returns(expectedHash, EthereumTransaction::getHash)
                 .returns(body.getMaxGasAllowance(), EthereumTransaction::getMaxGasAllowance);
         softly.assertThat(transactionRepository.count()).isOne();
+    }
+
+    @Test
+    void ethereumTransactionNoContractId() {
+        // given
+        final var result = ResponseCodeEnum.INSUFFICIENT_GAS;
+        final var recordItem = recordItemBuilder
+                .ethereumTransaction(false)
+                .record(r -> r.setContractCallResult(
+                        r.getContractCallResultBuilder().clearContractID().clearLogInfo()))
+                .record(r -> r.getReceiptBuilder().setStatus(result))
+                .sidecarRecords(s -> s.clear())
+                .build();
+        final long consensusTimestamp = recordItem.getConsensusTimestamp();
+        final var contractIds = List.of(0L, recordItem.getPayerAccountId().getId());
+
+        // when
+        parseRecordItemAndCommit(recordItem);
+
+        softly.assertThat(contractResultRepository.findAll())
+                .hasSize(1)
+                .first()
+                .returns(consensusTimestamp, ContractResult::getConsensusTimestamp)
+                .returns(0L, ContractResult::getContractId);
+        softly.assertThat(contractTransactionRepository.findAll())
+                .hasSize(2)
+                .allSatisfy(ct -> assertThat(ct)
+                        .returns(consensusTimestamp, ContractTransaction::getConsensusTimestamp)
+                        .returns(contractIds, ContractTransaction::getContractIds)
+                        .returns(recordItem.getPayerAccountId().getId(), ContractTransaction::getPayerAccountId))
+                .anyMatch(ct -> ct.getEntityId() == 0L);
+        softly.assertThat(contractTransactionHashRepository.findAll())
+                .hasSize(1)
+                .first()
+                .returns(consensusTimestamp, ContractTransactionHash::getConsensusTimestamp)
+                .returns(0L, ContractTransactionHash::getEntityId)
+                .returns(recordItem.getPayerAccountId().getId(), ContractTransactionHash::getPayerAccountId)
+                .returns(result.getNumber(), ContractTransactionHash::getTransactionResult);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

* Fix missing contract_transaction rows when empty contract ID
* Fix non concurrent map used in parser thread

**Related issue(s)**:

Fixes #14002

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
