### PR TITLE
Add CI stage running modified tests with non-zero shard and realm

### DIFF
--- a/.github/workflows/non-zero-realm-pr.yml
+++ b/.github/workflows/non-zero-realm-pr.yml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Non-Zero Realm (PR)"
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "release/**"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  LC_ALL: C.UTF-8
+  CGO_ENABLED: 1
+  # Same non-zero values exercised by the nightly non-zero-realm.yml run
+  HIERO_MIRROR_COMMON_REALM: 127
+  HIERO_MIRROR_COMMON_SHARD: 113
+
+jobs:
+  changed-tests:
+    name: Run Modified Tests
+    runs-on: hiero-mirror-node-linux-large
+    timeout-minutes: 40
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Determine modified tests
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Compute the diff separately so a git failure (e.g. no merge base) fails the step
+          # instead of being masked as "no changed tests" by the grep pipeline's || true.
+          diff=$(git diff --name-only --diff-filter=d "${BASE_SHA}...${HEAD_SHA}")
+
+          # Only JVM modules use src/test/java; JS (rest), Go (rosetta) tests are excluded naturally.
+          changed=$(printf '%s\n' "${diff}" | grep -E '/src/test/java/.*Tests?\.java$' || true)
+
+          if [ -z "${changed}" ]; then
+            echo "No changed JVM test classes; skipping non-zero realm run."
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Group the changed tests by Gradle project so each project runs its own
+          # filtered test task (a --tests filter that matches nothing fails the build).
+          declare -A project_tests
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            module_path="${file%%/src/test/*}"           # e.g. importer, rest-java, rest/monitoring
+            project=":${module_path//\//:}"              # -> :importer, :rest-java, :rest:monitoring
+            class_path="${file#*/src/test/java/}"
+            class="${class_path%.java}"
+            class="${class//\//.}"                       # fully qualified class name
+            project_tests["${project}"]+=" --tests \"${class}\""
+          done <<< "${changed}"
+
+          : > /tmp/gradle-args
+          for project in "${!project_tests[@]}"; do
+            echo "${project}|${project_tests[${project}]}" >> /tmp/gradle-args
+          done
+
+          echo "Selected tests to run with REALM=${HIERO_MIRROR_COMMON_REALM} SHARD=${HIERO_MIRROR_COMMON_SHARD}:"
+          cat /tmp/gradle-args
+          echo "run=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Install JDK
+        if: ${{ steps.detect.outputs.run == 'true' }}
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Setup Gradle
+        if: ${{ steps.detect.outputs.run == 'true' }}
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v4
+
+      - name: Execute Gradle
+        if: ${{ steps.detect.outputs.run == 'true' }}
+        run: |
+          set -euo pipefail
+          status=0
+          while IFS='|' read -r project tests; do
+            [ -z "${project}" ] && continue
+            echo "::group::${project}:test${tests}"
+            # --rerun-tasks: HIERO_MIRROR_COMMON_* env vars are not tracked test inputs, so
+            # without it Gradle could restore a cached shard-0/realm-0 result and skip the run.
+            eval "./gradlew ${project}:test --rerun-tasks ${tests}" || status=1
+            echo "::endgroup::"
+          done < /tmp/gradle-args
+          exit "${status}"

--- a/.github/workflows/non-zero-realm-pr.yml
+++ b/.github/workflows/non-zero-realm-pr.yml
@@ -26,10 +26,13 @@ env:
   HIERO_MIRROR_COMMON_SHARD: 113
 
 jobs:
-  changed-tests:
-    name: Run Modified Tests
+  detect:
+    name: Detect Modified Tests
     runs-on: hiero-mirror-node-linux-large
-    timeout-minutes: 40
+    timeout-minutes: 10
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+      gradle_args: ${{ steps.detect.outputs.gradle_args }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -82,23 +85,45 @@ jobs:
 
           echo "Selected tests to run with REALM=${HIERO_MIRROR_COMMON_REALM} SHARD=${HIERO_MIRROR_COMMON_SHARD}:"
           cat /tmp/gradle-args
+
+          # Pass the per-project Gradle args to the downstream job as a multiline output.
+          {
+            echo "gradle_args<<GRADLE_ARGS_EOF"
+            cat /tmp/gradle-args
+            echo "GRADLE_ARGS_EOF"
+          } >> "${GITHUB_OUTPUT}"
           echo "run=true" >> "${GITHUB_OUTPUT}"
 
+  changed-tests:
+    name: Run Modified Tests
+    needs: detect
+    if: ${{ needs.detect.outputs.run == 'true' }}
+    runs-on: hiero-mirror-node-linux-large
+    timeout-minutes: 40
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Install JDK
-        if: ${{ steps.detect.outputs.run == 'true' }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 25
 
       - name: Setup Gradle
-        if: ${{ steps.detect.outputs.run == 'true' }}
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v4
 
       - name: Execute Gradle
-        if: ${{ steps.detect.outputs.run == 'true' }}
+        env:
+          GRADLE_ARGS: ${{ needs.detect.outputs.gradle_args }}
         run: |
           set -euo pipefail
+          printf '%s\n' "${GRADLE_ARGS}" > /tmp/gradle-args
           status=0
           while IFS='|' read -r project tests; do
             [ -z "${project}" ] && continue

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
@@ -218,19 +218,6 @@ class ConsensusUpdateTopicTransactionHandlerTest extends AbstractTransactionHand
         assertThat(recordItem.getEntityTransactions()).containsExactlyInAnyOrderEntriesOf(expectedEntityTransactions);
     }
 
-    @Test
-    void ciProbeNonZeroRealmStageTurnsRed() {
-        // TEMPORARY PROBE — remove once the non-zero-realm CI stage is validated.
-        // It hardcodes a shard 0 / realm 0 assumption: the topic id is built from the configured
-        // shard/realm, so this passes locally (0/0) but fails under the stage (non-zero),
-        // proving the stage actually runs the changed test and turns red on such assumptions.
-        final var recordItem = recordItemBuilder.consensusCreateTopic().build();
-        final var topicId =
-                EntityId.of(recordItem.getTransactionRecord().getReceipt().getTopicID());
-        assertThat(topicId.getShard()).isZero();
-        assertThat(topicId.getRealm()).isZero();
-    }
-
     private void assertEntity(long timestamp, EntityId topicId, Long expectedAutoRenewAccountId) {
         verify(entityListener, times(1)).onEntity(assertArg(t -> assertThat(t)
                 .isNotNull()

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
@@ -218,6 +218,19 @@ class ConsensusUpdateTopicTransactionHandlerTest extends AbstractTransactionHand
         assertThat(recordItem.getEntityTransactions()).containsExactlyInAnyOrderEntriesOf(expectedEntityTransactions);
     }
 
+    @Test
+    void ciProbeNonZeroRealmStageTurnsRed() {
+        // TEMPORARY PROBE — remove once the non-zero-realm CI stage is validated.
+        // It hardcodes a shard 0 / realm 0 assumption: the topic id is built from the configured
+        // shard/realm, so this passes locally (0/0) but fails under the stage (non-zero),
+        // proving the stage actually runs the changed test and turns red on such assumptions.
+        final var recordItem = recordItemBuilder.consensusCreateTopic().build();
+        final var topicId =
+                EntityId.of(recordItem.getTransactionRecord().getReceipt().getTopicID());
+        assertThat(topicId.getShard()).isZero();
+        assertThat(topicId.getRealm()).isZero();
+    }
+
     private void assertEntity(long timestamp, EntityId topicId, Long expectedAutoRenewAccountId) {
         verify(entityListener, times(1)).onEntity(assertArg(t -> assertThat(t)
                 .isNotNull()


### PR DESCRIPTION
**Description**:
To reduce the chance of  merging code that breaks non-zero shard and realm tests this PR introduces stage in the CI that is triggered only on test change and runs only modified tests providing them with non-zero shard and realm values.

The workflow is tested by temporarily adding a test failing with non-zero shard or realm:
<img width="925" height="467" alt="Screenshot 2026-08-11 at 14 24 18" src="https://github.com/user-attachments/assets/7ba8478c-dcb7-4cc4-8401-1dc81aafd74e" />


<img width="1460" height="750" alt="Screenshot 2026-08-11 at 14 30 46" src="https://github.com/user-attachments/assets/1475a5a5-a98f-4ab4-bbab-81905b1a6853" />


<img width="707" height="285" alt="Screenshot 2026-08-11 at 12 29 45" src="https://github.com/user-attachments/assets/c8fdeea5-2a6f-47f4-930b-105e7000b9ed" />

The test is now removed, the stage is skipped and the build is passing.



**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
