### PR TITLE
Refactor the way throttle tokens are restored on invalid arguments

### DIFF
--- a/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
@@ -40,63 +40,62 @@ class ContractController {
 
     @PostMapping(value = "/call")
     ContractCallResponse call(@RequestBody @Valid ContractCallRequest request, HttpServletResponse response) {
+        validateContractMaxGasLimit(request);
+        final var params = constructServiceParameters(request);
+
+        if (!params.getStateOverrides().isEmpty() && !web3Properties.isEnableStateOverrides()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "State overrides are not supported.");
+        }
+
+        throttleManager.throttle(request);
         try {
-            throttleManager.throttle(request);
-            validateContractMaxGasLimit(request);
-
-            final var params = constructServiceParameters(request);
-
-            if (!params.getStateOverrides().isEmpty() && !web3Properties.isEnableStateOverrides()) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "State overrides are not supported.");
-            }
-
             final var result = contractExecutionService.processCall(params);
             return new ContractCallResponse(result);
+        } catch (IllegalArgumentException e) {
+            throttleManager.restore(request.getGas());
+            throw new InvalidParametersException(e.getMessage());
         } catch (InvalidParametersException e) {
-            // The validation failed, but no processing occurred so restore the consumed tokens.
+            // Processing did not complete, so restore the consumed tokens.
             throttleManager.restore(request.getGas());
             throw e;
         }
     }
 
     private ContractExecutionParameters constructServiceParameters(ContractCallRequest request) {
-        final var fromAddress = request.getFrom() != null ? Address.fromHexString(request.getFrom()) : Address.ZERO;
-
-        Address receiver;
-
-        /*In case of an empty "to" field, we set a default value of the zero address
-        to avoid any potential NullPointerExceptions throughout the process.*/
-        if (request.getTo() == null || request.getTo().isEmpty()) {
-            receiver = Address.ZERO;
-        } else {
-            receiver = Address.fromHexString(request.getTo());
-        }
-
-        String data;
         try {
-            data = request.getData() != null ? request.getData() : HEX_PREFIX;
-        } catch (final Exception e) {
-            throw new InvalidParametersException(
-                    "data field '%s' contains invalid odd length characters".formatted(request.getData()));
+            final var fromAddress = request.getFrom() != null ? Address.fromHexString(request.getFrom()) : Address.ZERO;
+
+            Address receiver;
+
+            /*In case of an empty "to" field, we set a default value of the zero address
+            to avoid any potential NullPointerExceptions throughout the process.*/
+            if (request.getTo() == null || request.getTo().isEmpty()) {
+                receiver = Address.ZERO;
+            } else {
+                receiver = Address.fromHexString(request.getTo());
+            }
+
+            final var data = request.getData() != null ? request.getData() : HEX_PREFIX;
+            final var isStaticCall = false;
+            final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
+            final var block = request.getBlock();
+
+            return ContractExecutionParameters.builder()
+                    .block(block)
+                    .callData(hexToBytes(data))
+                    .callType(callType)
+                    .gas(request.getGas())
+                    .gasPrice(request.getGasPrice())
+                    .isEstimate(request.isEstimate())
+                    .isStatic(isStaticCall)
+                    .receiver(receiver)
+                    .sender(fromAddress)
+                    .stateOverrides(request.getStateOverrides())
+                    .value(request.getValue())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            throw new InvalidParametersException(e.getMessage());
         }
-
-        final var isStaticCall = false;
-        final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
-        final var block = request.getBlock();
-
-        return ContractExecutionParameters.builder()
-                .block(block)
-                .callData(hexToBytes(data))
-                .callType(callType)
-                .gas(request.getGas())
-                .gasPrice(request.getGasPrice())
-                .isEstimate(request.isEstimate())
-                .isStatic(isStaticCall)
-                .receiver(receiver)
-                .sender(fromAddress)
-                .stateOverrides(request.getStateOverrides())
-                .value(request.getValue())
-                .build();
     }
 
     private void validateContractMaxGasLimit(ContractCallRequest request) {

--- a/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
@@ -59,40 +59,43 @@ class ContractController {
     }
 
     private ContractExecutionParameters constructServiceParameters(ContractCallRequest request) {
-        try {
-            final var fromAddress = request.getFrom() != null ? Address.fromHexString(request.getFrom()) : Address.ZERO;
+        final var fromAddress = request.getFrom() != null ? Address.fromHexString(request.getFrom()) : Address.ZERO;
 
-            Address receiver;
+        Address receiver;
 
-            /*In case of an empty "to" field, we set a default value of the zero address
-            to avoid any potential NullPointerExceptions throughout the process.*/
-            if (request.getTo() == null || request.getTo().isEmpty()) {
-                receiver = Address.ZERO;
-            } else {
-                receiver = Address.fromHexString(request.getTo());
-            }
-
-            final var data = request.getData() != null ? request.getData() : HEX_PREFIX;
-            final var isStaticCall = false;
-            final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
-            final var block = request.getBlock();
-
-            return ContractExecutionParameters.builder()
-                    .block(block)
-                    .callData(hexToBytes(data))
-                    .callType(callType)
-                    .gas(request.getGas())
-                    .gasPrice(request.getGasPrice())
-                    .isEstimate(request.isEstimate())
-                    .isStatic(isStaticCall)
-                    .receiver(receiver)
-                    .sender(fromAddress)
-                    .stateOverrides(request.getStateOverrides())
-                    .value(request.getValue())
-                    .build();
-        } catch (IllegalArgumentException e) {
-            throw new InvalidParametersException(e.getMessage());
+        /*In case of an empty "to" field, we set a default value of the zero address
+        to avoid any potential NullPointerExceptions throughout the process.*/
+        if (request.getTo() == null || request.getTo().isEmpty()) {
+            receiver = Address.ZERO;
+        } else {
+            receiver = Address.fromHexString(request.getTo());
         }
+
+        String data;
+        try {
+            data = request.getData() != null ? request.getData() : HEX_PREFIX;
+        } catch (final Exception e) {
+            throw new InvalidParametersException(
+                    "data field '%s' contains invalid odd length characters".formatted(request.getData()));
+        }
+
+        final var isStaticCall = false;
+        final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
+        final var block = request.getBlock();
+
+        return ContractExecutionParameters.builder()
+                .block(block)
+                .callData(hexToBytes(data))
+                .callType(callType)
+                .gas(request.getGas())
+                .gasPrice(request.getGasPrice())
+                .isEstimate(request.isEstimate())
+                .isStatic(isStaticCall)
+                .receiver(receiver)
+                .sender(fromAddress)
+                .stateOverrides(request.getStateOverrides())
+                .value(request.getValue())
+                .build();
     }
 
     private void validateContractMaxGasLimit(ContractCallRequest request) {

--- a/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
@@ -51,10 +51,7 @@ class ContractController {
         try {
             final var result = contractExecutionService.processCall(params);
             return new ContractCallResponse(result);
-        } catch (IllegalArgumentException e) {
-            throttleManager.restore(request.getGas());
-            throw new InvalidParametersException(e.getMessage());
-        } catch (InvalidParametersException e) {
+        } catch (IllegalArgumentException | InvalidParametersException e) {
             // Processing did not complete, so restore the consumed tokens.
             throttleManager.restore(request.getGas());
             throw e;

--- a/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
@@ -7,9 +7,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hiero.mirror.web3.validation.HexValidator.HEX_PREFIX;
 import static org.hiero.mirror.web3.validation.HexValidator.MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -172,6 +175,7 @@ final class ContractControllerTest {
     @ValueSource(longs = {2000, -2000, 16_000_000L, 0})
     @ParameterizedTest
     void estimateGasWithInvalidGasParameter(long gas) throws Exception {
+        clearInvocations(throttleManager);
         final var errorString = gas < 21000L
                 ? numberErrorString("gas", "greater", 21000L)
                 : numberErrorString("gas", "less", 15_000_000L);
@@ -182,6 +186,8 @@ final class ContractControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content()
                         .string(convert(new GenericErrorResponse(BAD_REQUEST.getReasonPhrase(), errorString))));
+        verify(throttleManager, never()).throttle(any());
+        verify(throttleManager, never()).restore(anyLong());
     }
 
     @Test
@@ -357,6 +363,19 @@ final class ContractControllerTest {
         contractCall(request)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(convert(new GenericErrorResponse(BAD_REQUEST.getReasonPhrase(), error))));
+        verify(throttleManager).restore(request.getGas());
+    }
+
+    @Test
+    void callWithIllegalArgumentExceptionRestoresThrottle() throws Exception {
+        final var request = request();
+
+        given(service.processCall(any())).willThrow(new IllegalArgumentException("Invalid hex value"));
+        contractCall(request)
+                .andExpect(status().isBadRequest())
+                .andExpect(content()
+                        .string(convert(new GenericErrorResponse(BAD_REQUEST.getReasonPhrase(), "Invalid hex value"))));
+        verify(throttleManager).restore(request.getGas());
     }
 
     @Test
@@ -488,6 +507,7 @@ final class ContractControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"1", "1aa"})
     void callBadRequestWithInvalidHexData(String data) throws Exception {
+        clearInvocations(throttleManager);
         final var request = request();
         request.setData(data);
         request.setValue(0);
@@ -495,6 +515,38 @@ final class ContractControllerTest {
         contractCall(request)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(new StringContains("Odd number of characters")));
+
+        verify(throttleManager, never()).throttle(any());
+        verify(throttleManager, never()).restore(anyLong());
+        verify(service, never()).processCall(any());
+    }
+
+    @Test
+    void callFromWithUpperCaseHexPrefixDoesNotThrottle() throws Exception {
+        clearInvocations(throttleManager);
+        final var request = request();
+        request.setFrom("0X00000000000000000000000000000000000004e2");
+        request.setValue(0);
+
+        contractCall(request).andExpect(status().isBadRequest());
+
+        verify(throttleManager, never()).throttle(any());
+        verify(throttleManager, never()).restore(anyLong());
+        verify(service, never()).processCall(any());
+    }
+
+    @Test
+    void callToWithUpperCaseHexPrefixDoesNotThrottle() throws Exception {
+        clearInvocations(throttleManager);
+        final var request = request();
+        request.setTo("0X00000000000000000000000000000000000004e4");
+        request.setValue(0);
+
+        contractCall(request).andExpect(status().isBadRequest());
+
+        verify(throttleManager, never()).throttle(any());
+        verify(throttleManager, never()).restore(anyLong());
+        verify(service, never()).processCall(any());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR refactors the way the throttle tokens are restored when there are invalid arguments passed. Now the `IllegalArgumentException` is rethrown as `InvalidParametersException` so ensure a consistent handling.

Ref: MN-105