### PR TITLE
Create new opcode context per processOpcodeCall in tests

### DIFF
--- a/.github/workflows/non-zero-realm-pr.yml
+++ b/.github/workflows/non-zero-realm-pr.yml
@@ -68,15 +68,33 @@ jobs:
           # Group the changed tests by Gradle project so each project runs its own
           # filtered test task (a --tests filter that matches nothing fails the build).
           declare -A project_tests
+          matched=0                                      # always-set counter; ${#project_tests[@]} trips set -u when empty
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
-            module_path="${file%%/src/test/*}"           # e.g. importer, rest-java, rest/monitoring
-            project=":${module_path//\//:}"              # -> :importer, :rest-java, :rest:monitoring
             class_path="${file#*/src/test/java/}"
             class="${class_path%.java}"
             class="${class//\//.}"                       # fully qualified class name
+            simple="${class##*.}"                        # simple (top-level) class name
+
+            # Skip abstract test bases (e.g. AbstractContractCallServiceOpcodeTracerTest,
+            # Web3IntegrationTest): they hold no runnable tests, so a --tests filter naming
+            # them matches nothing and fails the build. Their subclasses run when changed.
+            if grep -qE "abstract[[:space:]]+class[[:space:]]+${simple}\b" "${file}"; then
+              echo "Skipping abstract test base ${class}"
+              continue
+            fi
+
+            module_path="${file%%/src/test/*}"           # e.g. importer, rest-java, rest/monitoring
+            project=":${module_path//\//:}"              # -> :importer, :rest-java, :rest:monitoring
             project_tests["${project}"]+=" --tests \"${class}\""
+            matched=$((matched + 1))
           done <<< "${changed}"
+
+          if [ "${matched}" -eq 0 ]; then
+            echo "Only abstract test bases changed; skipping non-zero realm run."
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
 
           : > /tmp/gradle-args
           for project in "${!project_tests[@]}"; do

--- a/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
@@ -10,8 +10,8 @@ import static org.hiero.mirror.web3.utils.ContractCallTestUtil.ESTIMATE_GAS_ERRO
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_LIMIT;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
 import static org.hiero.mirror.web3.utils.ContractCallTestUtil.longValueOf;
-import static org.hiero.mirror.web3.utils.OpcodeTracerUtil.OPTIONS;
 import static org.hiero.mirror.web3.utils.OpcodeTracerUtil.gasComparator;
+import static org.hiero.mirror.web3.utils.OpcodeTracerUtil.options;
 import static org.hiero.mirror.web3.utils.OpcodeTracerUtil.toHumanReadableMessage;
 import static org.mockito.Mockito.doAnswer;
 
@@ -121,7 +121,7 @@ abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContr
     @SneakyThrows
     protected void verifyThrowingOpcodeTracerCall(
             final ContractDebugParameters params, final ContractFunctionProviderRecord function) {
-        final var actual = ContractCallContext.run(ctx -> contractDebugService.processOpcodeCall(params, OPTIONS));
+        final var actual = ContractCallContext.run(ctx -> contractDebugService.processOpcodeCall(params, options()));
         assertThat(actual.transactionProcessingResult().isSuccessful()).isFalse();
         assertThat(actual.transactionProcessingResult()
                         .functionResult()
@@ -137,7 +137,7 @@ abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContr
     }
 
     protected void verifySuccessfulOpcodeTracerCall(final ContractDebugParameters params) {
-        final var actual = ContractCallContext.run(ctx -> contractDebugService.processOpcodeCall(params, OPTIONS));
+        final var actual = ContractCallContext.run(ctx -> contractDebugService.processOpcodeCall(params, options()));
         final var expected = new OpcodesProcessingResult(
                 resultCaptor,
                 params.getReceiver(),

--- a/web3/src/test/java/org/hiero/mirror/web3/utils/OpcodeTracerUtil.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/utils/OpcodeTracerUtil.java
@@ -19,6 +19,8 @@ public class OpcodeTracerUtil {
     private static final TransactionIdOrHashParameter DUMMY_TRANSACTION_ID =
             new TransactionIdParameter(EntityId.EMPTY, Instant.EPOCH);
 
+    private static final OpcodesProperties OPCODES_PROPERTIES = new OpcodesProperties();
+
     /**
      * Builds a fresh {@link OpcodeContext} for a single opcode-trace call. Production creates a new context per request
      * (see OpcodeServiceImpl#processOpcodeCall); tests must do the same because the context accumulates mutable state
@@ -26,8 +28,7 @@ public class OpcodeTracerUtil {
      * tests lets earlier tests fill the trace to its cap, which corrupts assertions in later tests.
      */
     public static OpcodeContext options() {
-        return new OpcodeContext(
-                new OpcodeRequest(DUMMY_TRANSACTION_ID, false, false, false), 0, new OpcodesProperties());
+        return new OpcodeContext(new OpcodeRequest(DUMMY_TRANSACTION_ID, false, false, false), 0, OPCODES_PROPERTIES);
     }
 
     public static String toHumanReadableMessage(final String solidityError) {

--- a/web3/src/test/java/org/hiero/mirror/web3/utils/OpcodeTracerUtil.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/utils/OpcodeTracerUtil.java
@@ -19,8 +19,16 @@ public class OpcodeTracerUtil {
     private static final TransactionIdOrHashParameter DUMMY_TRANSACTION_ID =
             new TransactionIdParameter(EntityId.EMPTY, Instant.EPOCH);
 
-    public static final OpcodeContext OPTIONS =
-            new OpcodeContext(new OpcodeRequest(DUMMY_TRANSACTION_ID, false, false, false), 0, new OpcodesProperties());
+    /**
+     * Builds a fresh {@link OpcodeContext} for a single opcode-trace call. Production creates a new context per request
+     * (see OpcodeServiceImpl#processOpcodeCall); tests must do the same because the context accumulates mutable state
+     * (opcodes, capture budgets, per-depth counters) as opcodes are recorded. Sharing a single static instance across
+     * tests lets earlier tests fill the trace to its cap, which corrupts assertions in later tests.
+     */
+    public static OpcodeContext options() {
+        return new OpcodeContext(
+                new OpcodeRequest(DUMMY_TRANSACTION_ID, false, false, false), 0, new OpcodesProperties());
+    }
 
     public static String toHumanReadableMessage(final String solidityError) {
         return BytesDecoder.maybeDecodeSolidityErrorStringToReadableMessage(solidityError);


### PR DESCRIPTION
**Description**:

- Create fresh OpcodeContext per processOpcodeCall in tests to avoid context contamination.
- In the "Detect Modified Tests" CI job skip any changed file whose top-level class is declared abstract (detected by grepping abstract class <SimpleName> in the file - used content detection rather than an Abstract* name heuristic because some abstract bases in this repo don't follow that prefix (e.g. Web3IntegrationTest, CommonIntegrationTest).).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
