### PR TITLE
Exclude transaction_index=null from contract results endpoint (0.161)

### DIFF
--- a/rest/__tests__/specs/contracts/results/duplicate-transaction-excluded.json
+++ b/rest/__tests__/specs/contracts/results/duplicate-transaction-excluded.json
@@ -1,0 +1,147 @@
+{
+  "description": "Contract results list excludes DUPLICATE_TRANSACTION contract call transactions",
+  "setup": {
+    "features": {
+      "fakeTime": 187700
+    },
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 5000,
+        "sender_id": 6001,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "187654000123490",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "DUPLICATE_TRANSACTION",
+        "function_parameters": [7, 7],
+        "function_result": null,
+        "gas_consumed": null,
+        "gas_limit": 987654,
+        "gas_used": null,
+        "payer_account_id": 5000,
+        "sender_id": null,
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": null,
+        "transaction_nonce": 0,
+        "transaction_result": "11"
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 187654000123455,
+        "consensus_end": 187654000123500,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ],
+    "ethereumtransactions": [
+      {
+        "consensus_timestamp": "187654000123456",
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "chain_id": "0x012a",
+        "max_fee_per_gas": "0xCF38224400",
+        "max_priority_fee_per_gas": "0x76BE5E6C00",
+        "payer_account_id": 5000,
+        "signature_r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+        "signature_s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+        "recovery_id": 1,
+        "nonce": 5,
+        "value": ["0x2E90EDD000"],
+        "access_list": [
+          {
+            "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+            "storage_keys": [
+              "0x0000000000000000000000000000000000000000000000000000000000000081"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "urls": ["/api/v1/contracts/results"],
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [
+      {
+        "access_list": [
+          {
+            "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+            "storage_keys": [
+              "0x0000000000000000000000000000000000000000000000000000000000000081"
+            ]
+          }
+        ],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 20,
+        "authorization_list": [],
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x0101",
+        "call_result": "0x0202",
+        "chain_id": "0x12a",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001771",
+        "function_parameters": "0x0303",
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_price": "0x4a817c80",
+        "gas_used": 987,
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": "0x59",
+        "max_priority_fee_per_gas": "0x33",
+        "nonce": 5,
+        "r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+        "result": "SUCCESS",
+        "s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+        "status": "0x1",
+        "timestamp": "187654.000123456",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 1,
+        "type": 2,
+        "v": 1
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/synthetic-log-duplicate-excluded.json
+++ b/rest/__tests__/specs/contracts/results/synthetic-log-duplicate-excluded.json
@@ -1,0 +1,105 @@
+{
+  "description": "Contract results list does not duplicate a real contract_result with a synthetic contract log at the same timestamp",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[187654000123000,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 5000,
+        "sender_id": 5000,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "root_contract_id": 5001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "synthetic": true,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 187654000123000,
+        "consensus_end": 187654000123500,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ]
+  },
+  "url": "/api/v1/contracts/results",
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [
+      {
+        "access_list": [],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 20,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x0101",
+        "call_result": "0x0202",
+        "chain_id": "0x128",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x0303",
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_price": null,
+        "gas_used": 987,
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123456",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 1,
+        "type": 0,
+        "v": null
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/synthetic-log-false-excluded.json
+++ b/rest/__tests__/specs/contracts/results/synthetic-log-false-excluded.json
@@ -1,0 +1,35 @@
+{
+  "description": "Contract results list excludes an orphaned EVM contract log explicitly marked synthetic=false with no matching contract_result",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[187654000123000,)"
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "root_contract_id": 5001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "synthetic": false,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0
+      }
+    ]
+  },
+  "url": "/api/v1/contracts/results",
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/synthetic-log-mixed-with-real-result.json
+++ b/rest/__tests__/specs/contracts/results/synthetic-log-mixed-with-real-result.json
@@ -1,0 +1,147 @@
+{
+  "description": "Contract results list orders a real contract_result and a synthetic-only contract log together by timestamp",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[187654000123000,)"
+      },
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "6001",
+        "key": [1, 1, 1],
+        "num": "6001",
+        "timestamp_range": "[187654000123000,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 5000,
+        "sender_id": 5000,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123490",
+        "contract_id": 6001,
+        "root_contract_id": 6001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "synthetic": true,
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 187654000123000,
+        "consensus_end": 187654000123500,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ]
+  },
+  "url": "/api/v1/contracts/results?order=asc",
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [
+      {
+        "access_list": [],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 20,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x0101",
+        "call_result": "0x0202",
+        "chain_id": "0x128",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x0303",
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_price": null,
+        "gas_used": 987,
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123456",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 1,
+        "type": 0,
+        "v": null
+      },
+      {
+        "access_list": [],
+        "address": "0x1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "amount": null,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x",
+        "call_result": "0x",
+        "chain_id": "0x128",
+        "contract_id": "0.0.6001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x",
+        "gas_consumed": null,
+        "gas_limit": 0,
+        "gas_price": null,
+        "gas_used": null,
+        "hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123490",
+        "to": "0x0000000000000000000000000000000000001771",
+        "transaction_index": 1,
+        "type": 0,
+        "v": null
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/synthetic-log-null-excluded.json
+++ b/rest/__tests__/specs/contracts/results/synthetic-log-null-excluded.json
@@ -1,0 +1,34 @@
+{
+  "description": "Contract results list excludes an old-style contract log with synthetic left null",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[187654000123000,)"
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "root_contract_id": 5001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0
+      }
+    ]
+  },
+  "url": "/api/v1/contracts/results",
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/synthetic-nft-transfer.json
+++ b/rest/__tests__/specs/contracts/results/synthetic-nft-transfer.json
@@ -1,0 +1,89 @@
+{
+  "description": "Contract results list includes a synthetic NFT transfer contract log with no matching contract_result",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "187654000123000",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[187654000123000,)"
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "root_contract_id": 5001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "synthetic": true,
+        "topic0": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+        "topic1": "0x",
+        "topic2": "0x0000000000000000000000000000000000001389",
+        "topic3": "0x0000000000000000000000000000000000000001",
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 187654000123000,
+        "consensus_end": 187654000123500,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ]
+  },
+  "url": "/api/v1/contracts/results",
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [
+      {
+        "access_list": [],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": null,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x",
+        "call_result": "0x",
+        "chain_id": "0x128",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x",
+        "gas_consumed": null,
+        "gas_limit": 0,
+        "gas_price": null,
+        "gas_used": null,
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123456",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 0,
+        "type": 0,
+        "v": null
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/controllers/contractController.js
+++ b/rest/controllers/contractController.js
@@ -74,6 +74,9 @@ const contractCreateType = Number(TransactionType.getProtoId('CONTRACTCREATEINST
 const ethereumTransactionType = Number(TransactionType.getProtoId('ETHEREUMTRANSACTION'));
 const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
 const wrongNonceTransactionResult = TransactionResult.getProtoId('WRONG_NONCE');
+const nonEvmTransactionResultsCondition = `${ContractResult.getFullName(
+  ContractResult.TRANSACTION_RESULT
+)} not in (${wrongNonceTransactionResult}, ${duplicateTransactionResult})`;
 
 /**
  * Extracts the sql where clause, params, order and limit values to be used from the provided contract query
@@ -881,9 +884,7 @@ class ContractController extends BaseController {
       return;
     }
 
-    conditions.push(
-      `${ContractResult.getFullName(ContractResult.TRANSACTION_RESULT)} <> ${wrongNonceTransactionResult}`
-    );
+    conditions.push(nonEvmTransactionResultsCondition);
 
     const rows = await ContractService.getContractResultsByIdAndFilters(conditions, params, order, limit);
     if (rows.length === 0) {
@@ -1102,9 +1103,7 @@ class ContractController extends BaseController {
       return;
     }
 
-    conditions.push(
-      `${ContractResult.getFullName(ContractResult.TRANSACTION_RESULT)} <> ${wrongNonceTransactionResult}`
-    );
+    conditions.push(nonEvmTransactionResultsCondition);
 
     const rows = await ContractService.getContractResultsByIdAndFilters(
       conditions,


### PR DESCRIPTION
**Description**:

Cherry pick of #14103 to release/0.161:

The filtering of contract results is now enhanced to exclude results with transaction_index that is equal to null.

**Related issue(s)**:

Fixes #14070

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
