### PR TITLE
Bump jackson, log4j2, and netty versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,12 +22,13 @@ extra.apply {
     set("grpc-java.version", "1.83.1") // Temporary until next Spring Boot
     set("httpclient5.version", "5.6.2") // Temporary until next Spring Boot
     set("httpcore5.version", "5.4.3") // Temporary until next Spring Boot
-    set("jackson-bom.version", "3.1.5") // Temporary until next Spring Boot
-    set("jackson-2-bom.version", "2.22.1") // Temporary until next Spring Boot
+    set("jackson-bom.version", "3.2.2") // Temporary until next Spring Boot
+    set("jackson-2-bom.version", "2.22.2") // Temporary until next Spring Boot
     set("jooq.version", "3.21.7") // Must match buildSrc/build.gradle.kts
+    set("log4j2.version", "2.25.5") // Temporary until next Spring Boot
     set("logback.version", "1.5.36") // Temporary until next Spring Boot
     set("mapStructVersion", "1.6.3")
-    set("netty.version", "4.2.16.Final") // Temporary until next Spring Boot
+    set("netty.version", "4.2.17.Final") // Temporary until next Spring Boot
     set("nodeJsVersion", "24.18.1")
     set("postgresql.version", "42.7.13") // Temporary until next Spring Boot
     set("tomcat.version", "11.0.23") // Temporary until next Spring Boot

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,10 +8,10 @@ dependencies {
     // Temporary until all plugins upgrade
     constraints {
         add("implementation", "com.fasterxml.jackson.core:jackson-databind") {
-            version { require("2.22.1") }
+            version { require("2.22.2") }
         }
         add("implementation", "tools.jackson.core:jackson-databind") {
-            version { require("3.2.1") }
+            version { require("3.2.2") }
         }
     }
 


### PR DESCRIPTION
**Description**:

* Bump Jackson from `3.1.5` to `3.2.2`
* Bump Jackson 2 from `2.22.1` to `2.22.2`
* Bump Log4j2 from `2.25.1` to `2.25.2`
* Bump Netty from `4.2.16.Final` to `4.2.17.Final`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
