### PR TITLE
Exclude `transaction_index=null` from contract results endpoints (0.161)

### DIFF
--- a/rest/__tests__/specs/contracts/results/null-transaction-index-excluded.json
+++ b/rest/__tests__/specs/contracts/results/null-transaction-index-excluded.json
@@ -1,0 +1,181 @@
+{
+  "description": "Contract results list excludes rows with a null transaction_index, including synthetic logs, and keeps a zero index",
+  "setup": {
+    "features": {
+      "fakeTime": 187700
+    },
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "187654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 5000,
+        "sender_id": 5000,
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1,
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "187654000123490",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_consumed": 111,
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 5000,
+        "sender_id": 5000,
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": null,
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 40,
+        "bloom": [3, 3],
+        "call_result": [4, 4],
+        "consensus_timestamp": "187654000123500",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "",
+        "function_parameters": [5, 5],
+        "function_result": [6, 6],
+        "gas_consumed": 200,
+        "gas_limit": 111111,
+        "gas_used": 80,
+        "payer_account_id": 5000,
+        "sender_id": 5000,
+        "transaction_hash": "0x401202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0,
+        "transaction_nonce": 0
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "187654000123510",
+        "contract_id": 5001,
+        "root_contract_id": 5001,
+        "index": 0,
+        "payer_account_id": 5000,
+        "synthetic": true,
+        "transaction_hash": "0xaa5602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": null
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 187654000123000,
+        "consensus_end": 187654000123600,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ]
+  },
+  "urls": ["/api/v1/contracts/results"],
+  "responseStatus": 200,
+  "responseJson": {
+    "results": [
+      {
+        "access_list": [],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 40,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x0303",
+        "call_result": "0x0404",
+        "chain_id": "0x128",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x0505",
+        "gas_consumed": 200,
+        "gas_limit": 111111,
+        "gas_price": null,
+        "gas_used": 80,
+        "hash": "0x401202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123500",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 0,
+        "type": 0,
+        "v": null
+      },
+      {
+        "access_list": [],
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 20,
+        "block_gas_used": 400000,
+        "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "block_number": 10,
+        "bloom": "0x0101",
+        "call_result": "0x0202",
+        "chain_id": "0x128",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "failed_initcode": null,
+        "from": "0x0000000000000000000000000000000000001388",
+        "function_parameters": "0x0303",
+        "gas_consumed": 987,
+        "gas_limit": 1234556,
+        "gas_price": null,
+        "gas_used": 987,
+        "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "max_fee_per_gas": null,
+        "max_priority_fee_per_gas": null,
+        "nonce": null,
+        "r": null,
+        "result": "SUCCESS",
+        "s": null,
+        "status": "0x1",
+        "timestamp": "187654.000123456",
+        "to": "0x0000000000000000000000000000000000001389",
+        "transaction_index": 1,
+        "type": 0,
+        "v": null
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/rest/__tests__/specs/contracts/results/wrong-nonce-excluded.json
+++ b/rest/__tests__/specs/contracts/results/wrong-nonce-excluded.json
@@ -49,6 +49,7 @@
         "payer_account_id": 5000,
         "sender_id": null,
         "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": null,
         "transaction_nonce": 0,
         "transaction_result": "312"
       }

--- a/rest/__tests__/specs/contracts/{id}/results/null-transaction-index-excluded.json
+++ b/rest/__tests__/specs/contracts/{id}/results/null-transaction-index-excluded.json
@@ -1,5 +1,5 @@
 {
-  "description": "Contract results for a specific contract excludes WRONG_NONCE ethereum transactions",
+  "description": "Contract results for a specific contract excludes rows with a null transaction_index and keeps a zero index",
   "setup": {
     "contracts": [
       {
@@ -19,6 +19,8 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "gas_used": 100,
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1,
         "transaction_nonce": 0
       },
       {
@@ -28,9 +30,20 @@
         "consensus_timestamp": "187654000123490",
         "contract_id": 5001,
         "gas_used": 0,
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
         "transaction_index": null,
-        "transaction_nonce": 0,
-        "transaction_result": "312"
+        "transaction_nonce": 0
+      },
+      {
+        "amount": 40,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "187654000123500",
+        "contract_id": 5001,
+        "gas_used": 50,
+        "transaction_hash": "0x401202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 0,
+        "transaction_nonce": 0
       }
     ]
   },
@@ -41,6 +54,23 @@
   "responseStatus": 200,
   "responseJson": {
     "results": [
+      {
+        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "amount": 40,
+        "bloom": "0x0505",
+        "call_result": "0x0606",
+        "contract_id": "0.0.5001",
+        "created_contract_ids": [],
+        "error_message": null,
+        "from": "0x0000000000000000000000000000000000000065",
+        "function_parameters": "0x010102020303",
+        "gas_consumed": null,
+        "gas_limit": 1000,
+        "gas_used": 50,
+        "hash": "0x401202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "timestamp": "187654.000123500",
+        "to": "0x0000000000000000000000000000000000001389"
+      },
       {
         "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
         "amount": 20,
@@ -54,7 +84,7 @@
         "gas_consumed": null,
         "gas_limit": 1000,
         "gas_used": 100,
-        "hash": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
         "timestamp": "187654.000123456",
         "to": "0x0000000000000000000000000000000000001389"
       }

--- a/rest/controllers/contractController.js
+++ b/rest/controllers/contractController.js
@@ -77,6 +77,7 @@ const wrongNonceTransactionResult = TransactionResult.getProtoId('WRONG_NONCE');
 const nonEvmTransactionResultsCondition = `${ContractResult.getFullName(
   ContractResult.TRANSACTION_RESULT
 )} not in (${wrongNonceTransactionResult}, ${duplicateTransactionResult})`;
+const nonNullTransactionIndexCondition = `${ContractResult.getFullName(ContractResult.TRANSACTION_INDEX)} is not null`;
 
 /**
  * Extracts the sql where clause, params, order and limit values to be used from the provided contract query
@@ -885,6 +886,7 @@ class ContractController extends BaseController {
     }
 
     conditions.push(nonEvmTransactionResultsCondition);
+    conditions.push(nonNullTransactionIndexCondition);
 
     const rows = await ContractService.getContractResultsByIdAndFilters(conditions, params, order, limit);
     if (rows.length === 0) {
@@ -1104,6 +1106,7 @@ class ContractController extends BaseController {
     }
 
     conditions.push(nonEvmTransactionResultsCondition);
+    conditions.push(nonNullTransactionIndexCondition);
 
     const rows = await ContractService.getContractResultsByIdAndFilters(
       conditions,


### PR DESCRIPTION
**Description**:

This PR excludes all contract results from the REST endpoints that have a wrong transaction index equal to null. A migration will be added soon that recalculates these indexes.

**Related issue(s)**:

Fixes #14070

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
