### PR TITLE
Do shallow fetch in copy stackgres cluster workflow

### DIFF
--- a/.github/workflows/copy-stackgres-cluster.yml
+++ b/.github/workflows/copy-stackgres-cluster.yml
@@ -185,7 +185,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-          fetch-depth: 0
 
       - name: Ensure jq is available
         run: jq --version || (sudo apt-get update && sudo apt-get install -y jq)


### PR DESCRIPTION
**Description**:

Do shallow fetch instead of full history

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

The workflow always run the script in `main` branch, fetching full history is a waste.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
