### PR TITLE
Do shallow fetch in release-automation workflow

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           ref: main
           token: ${{ secrets.HEDERA_BOT_TOKEN }}
 
@@ -98,6 +97,7 @@ jobs:
             echo "CREATE_PR=true" >> $GITHUB_ENV
             echo "PR_TITLE=Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
           else
+            git fetch origin ${RELEASE_BRANCH}:${RELEASE_BRANCH}
             git checkout ${RELEASE_BRANCH}
           fi
 


### PR DESCRIPTION
**Description**:

Change release automation workflow to do shallow fetch.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Full history fetch was there because the workflow conditionally checks out the release branch if already exists. With the explicit `git fetch origin ${RELEASE_BRANCH}:${RELEASE_BRANCH}`, it's no longer needed.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
