### PR TITLE
Add limits to state overrides

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/StreamSourceProperties.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/StreamSourceProperties.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.time.Duration;
 import lombok.Data;
+import lombok.ToString.Exclude;
 import org.hibernate.validator.constraints.time.DurationMin;
 
 @Data
@@ -47,9 +48,11 @@ public class StreamSourceProperties {
     @Data
     public static class SourceCredentials {
 
+        @Exclude
         @NotBlank
         private String accessKey;
 
+        @Exclude
         @NotBlank
         private String secretKey;
     }

--- a/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
@@ -117,9 +117,13 @@ public class Utility {
     }
 
     public static void archiveFile(String filename, byte[] contents, Path destinationRoot) {
-        Path destination = destinationRoot.resolve(filename);
+        final var destination = destinationRoot.resolve(filename).normalize();
 
         try {
+            if (!destination.startsWith(destinationRoot.normalize())) {
+                throw new IllegalArgumentException(
+                        "Destination file " + destination + " does not start with " + destinationRoot);
+            }
             destination.getParent().toFile().mkdirs();
             Files.write(destination, contents, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
             log.trace("Archived file to {}", destination);

--- a/importer/src/test/java/org/hiero/mirror/importer/TestUtils.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/TestUtils.java
@@ -57,8 +57,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @UtilityClass
 public class TestUtils {
 
-    public static final int S3_PROXY_PORT = 8001;
-
     private static final byte[] HEX_PREFIX_BYTES = new byte[] {'0', 'x'};
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -178,8 +176,9 @@ public class TestUtils {
         final var blobStore = new FilesystemNio2BlobStore(path.toAbsolutePath().toString());
         final var s3Proxy = S3Proxy.builder()
                 .blobStore(blobStore)
-                .endpoint(URI.create("http://localhost:" + S3_PROXY_PORT))
+                .endpoint(URI.create("http://localhost:0")) // Use a random port
                 .ignoreUnknownHeaders(true)
+                .metricsEnabled(false)
                 .build();
         s3Proxy.start();
 

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -3,7 +3,6 @@
 package org.hiero.mirror.importer.downloader;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hiero.mirror.importer.TestUtils.S3_PROXY_PORT;
 import static org.hiero.mirror.importer.domain.StreamFilename.FileType.DATA;
 import static org.hiero.mirror.importer.domain.StreamFilename.FileType.SIGNATURE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -232,31 +231,32 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     protected void beforeEach() {
         loadAddressBook("testnet");
         initProperties();
+
+        s3Proxy = TestUtils.startS3Proxy(s3Path);
+        commonDownloaderProperties.setEndpointOverride("http://localhost:" + s3Proxy.getPort());
         s3AsyncClient = S3AsyncClient.builder()
                 .credentialsProvider(AnonymousCredentialsProvider.create())
                 .endpointOverride(URI.create(commonDownloaderProperties.getEndpointOverride()))
                 .forcePathStyle(true)
                 .region(Region.of(commonDownloaderProperties.getRegion()))
                 .build();
-
         signatureFileReader = new CompositeSignatureFileReader(
                 new SignatureFileReaderV2(), new SignatureFileReaderV5(), new ProtoSignatureFileReader());
         var consensusValidator = new ConsensusValidatorImpl(commonDownloaderProperties);
         nodeSignatureVerifier = new NodeSignatureVerifier(consensusValidator);
         downloader = getDownloader();
         streamType = downloaderProperties.getStreamType();
-
         fileCopier = FileCopier.create(TestUtils.getResource("data").toPath(), s3Path)
                 .from(getTestDataDir())
                 .to(commonDownloaderProperties.getBucketName(), streamType.getPath());
-
-        s3Proxy = TestUtils.startS3Proxy(s3Path);
     }
 
     @AfterEach
     @SneakyThrows
     void after() {
-        s3Proxy.stop();
+        if (s3Proxy != null) {
+            s3Proxy.stop();
+        }
     }
 
     @Test
@@ -642,7 +642,6 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
 
         commonDownloaderProperties = new CommonDownloaderProperties(importerProperties);
-        commonDownloaderProperties.setEndpointOverride("http://localhost:" + S3_PROXY_PORT);
         // tests (except for "testPartialCollection" test) expect every Streamfile to be present
         commonDownloaderProperties.setDownloadRatio(BigDecimal.ONE);
 

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockFileSourceTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockFileSourceTest.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.from;
-import static org.hiero.mirror.importer.TestUtils.S3_PROXY_PORT;
 import static org.hiero.mirror.importer.TestUtils.findAllMatches;
 import static org.hiero.mirror.importer.TestUtils.generateRandomByteArray;
 import static org.hiero.mirror.importer.TestUtils.zstd;
@@ -126,9 +125,9 @@ final class BlockFileSourceTest {
         meterRegistry = new SimpleMeterRegistry();
 
         s3Proxy = TestUtils.startS3Proxy(dataPath);
-        var s3AsyncClient = S3AsyncClient.builder()
+        final var s3AsyncClient = S3AsyncClient.builder()
                 .credentialsProvider(AnonymousCredentialsProvider.create())
-                .endpointOverride(URI.create("http://localhost:" + S3_PROXY_PORT))
+                .endpointOverride(URI.create("http://localhost:" + s3Proxy.getPort()))
                 .forcePathStyle(true)
                 .region(Region.of(commonDownloaderProperties.getRegion()))
                 .build();

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
@@ -2,7 +2,6 @@
 
 package org.hiero.mirror.importer.downloader.provider;
 
-import static org.hiero.mirror.importer.TestUtils.S3_PROXY_PORT;
 import static org.hiero.mirror.importer.downloader.provider.S3StreamFileProvider.SEPARATOR;
 import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR;
 
@@ -17,7 +16,7 @@ import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
-class S3StreamFileProviderTest extends AbstractStreamFileProviderTest {
+final class S3StreamFileProviderTest extends AbstractStreamFileProviderTest {
 
     private S3Proxy s3Proxy;
 
@@ -30,15 +29,15 @@ class S3StreamFileProviderTest extends AbstractStreamFileProviderTest {
     @Override
     void setup() {
         super.setup();
-        var s3AsyncClient = S3AsyncClient.builder()
+        s3Proxy = TestUtils.startS3Proxy(dataPath);
+        final var s3AsyncClient = S3AsyncClient.builder()
                 .asyncConfiguration(b -> b.advancedOption(FUTURE_COMPLETION_EXECUTOR, ForkJoinPool.commonPool()))
                 .credentialsProvider(AnonymousCredentialsProvider.create())
-                .endpointOverride(URI.create("http://localhost:" + S3_PROXY_PORT))
+                .endpointOverride(URI.create("http://localhost:" + s3Proxy.getPort()))
                 .forcePathStyle(true)
                 .region(Region.of(properties.getRegion()))
                 .build();
         streamFileProvider = new S3StreamFileProvider(blockProperties, properties, s3AsyncClient);
-        s3Proxy = TestUtils.startS3Proxy(dataPath);
         blockStreamTargetRootPath = blockProperties.getBucketName();
         targetRootPath = properties.getBucketName();
     }

--- a/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/controller/ContractController.java
@@ -7,7 +7,6 @@ import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType
 import static org.hiero.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static org.hiero.mirror.web3.validation.HexValidator.HEX_PREFIX;
 
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,7 @@ class ContractController {
     private final ThrottleManager throttleManager;
 
     @PostMapping(value = "/call")
-    ContractCallResponse call(@RequestBody @Valid ContractCallRequest request, HttpServletResponse response) {
+    ContractCallResponse call(@RequestBody @Valid ContractCallRequest request) {
         validateContractMaxGasLimit(request);
         final var params = constructServiceParameters(request);
 

--- a/web3/src/main/java/org/hiero/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/viewmodel/ContractCallRequest.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -50,6 +51,7 @@ public class ContractCallRequest {
 
     @JsonProperty("state_overrides")
     @NotNull
+    @Size(max = 10)
     private List<@Valid StateOverride> stateOverrides = List.of();
 
     @PositiveOrZero

--- a/web3/src/main/java/org/hiero/mirror/web3/viewmodel/StateOverride.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/viewmodel/StateOverride.java
@@ -25,6 +25,7 @@ import org.springframework.validation.annotation.Validated;
 public class StateOverride {
 
     private static final int DECIMAL_MAX_LENGTH = 16;
+    public static final int CODE_MAX_LENGTH = 24576 * 2;
 
     /** EVM address (40 hex characters, optional {@code 0x} prefix) of the account to override. */
     @NotNull
@@ -36,7 +37,7 @@ public class StateOverride {
     private String balance;
 
     /** Hex-encoded runtime bytecode override. */
-    @Hex
+    @Hex(maxLength = CODE_MAX_LENGTH)
     private String code;
 
     /** Hex-encoded Ethereum nonce override. */

--- a/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/controller/ContractControllerTest.java
@@ -29,9 +29,10 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.annotation.Resource;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.StringContains;
 import org.hiero.mirror.web3.Web3Properties;
@@ -110,6 +111,7 @@ final class ContractControllerTest {
 
     @BeforeEach
     void setUp() {
+        web3Properties.setEnableStateOverrides(true);
         throttleManager.throttle(any(ContractCallRequest.class));
     }
 
@@ -124,19 +126,6 @@ final class ContractControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convert(request)));
-    }
-
-    @SneakyThrows
-    private ResultActions contractCall(ContractCallRequest request, final Map<String, String> headers) {
-        final var requestBuilder = post(CALL_URI)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(convert(request));
-
-        // Add headers dynamically
-        headers.forEach(requestBuilder::header);
-
-        return mockMvc.perform(requestBuilder);
     }
 
     @ParameterizedTest
@@ -609,15 +598,39 @@ final class ContractControllerTest {
     // ── State override tests ──────────────────────────────────────────────────
 
     @Test
+    void callWithStateOverrideDisabled() throws Exception {
+        web3Properties.setEnableStateOverrides(false);
+        final var override = new StateOverride();
+        override.setAddress("0x00000000000000000000000000000000000004e4");
+        override.setCode("0x6080604052");
+        final var request = request();
+        request.setStateOverrides(List.of(override));
+        contractCall(request).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void callWithMaxStateOverrides() throws Exception {
+        final var overrides = new ArrayList<StateOverride>();
+        for (int i = 0; i < 11; i++) {
+            final var override = new StateOverride();
+            override.setAddress("0x00000000000000000000000000000000000004e4");
+            overrides.add(override);
+        }
+        final var request = request();
+        request.setStateOverrides(overrides);
+        contractCall(request)
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(new StringContains("stateOverrides field size must be between 0 and 10")));
+    }
+
+    @Test
     void callWithStateOverrideBalance() throws Exception {
         final var override = new StateOverride();
         override.setAddress("0x00000000000000000000000000000000000004e2");
         override.setBalance("0xde0b6b3a7640000"); // 1 HBAR in tinybars hex
         final var request = request();
         request.setStateOverrides(List.of(override));
-
-        contractCall(request)
-                .andExpect(web3Properties.isEnableStateOverrides() ? status().isOk() : status().isBadRequest());
+        contractCall(request).andExpect(status().isOk());
     }
 
     @Test
@@ -627,9 +640,7 @@ final class ContractControllerTest {
         override.setNonce("0x2a");
         final var request = request();
         request.setStateOverrides(List.of(override));
-
-        contractCall(request)
-                .andExpect(web3Properties.isEnableStateOverrides() ? status().isOk() : status().isBadRequest());
+        contractCall(request).andExpect(status().isOk());
     }
 
     @Test
@@ -639,9 +650,19 @@ final class ContractControllerTest {
         override.setCode("0x6080604052");
         final var request = request();
         request.setStateOverrides(List.of(override));
+        contractCall(request).andExpect(status().isOk());
+    }
 
+    @Test
+    void callWithStateOverrideCodeExceedsMax() throws Exception {
+        final var override = new StateOverride();
+        override.setAddress("0x00000000000000000000000000000000000004e4");
+        override.setCode("0x" + RandomStringUtils.secure().next(StateOverride.CODE_MAX_LENGTH + 1, "0123456789abcdef"));
+        final var request = request();
+        request.setStateOverrides(List.of(override));
         contractCall(request)
-                .andExpect(web3Properties.isEnableStateOverrides() ? status().isOk() : status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(new StringContains("code field invalid hexadecimal string")));
     }
 
     @Test
@@ -654,9 +675,7 @@ final class ContractControllerTest {
         override.setStateDiff(List.of(entry));
         final var request = request();
         request.setStateOverrides(List.of(override));
-
-        contractCall(request)
-                .andExpect(web3Properties.isEnableStateOverrides() ? status().isOk() : status().isBadRequest());
+        contractCall(request).andExpect(status().isOk());
     }
 
     @Test
@@ -669,9 +688,7 @@ final class ContractControllerTest {
         override.setState(List.of(entry));
         final var request = request();
         request.setStateOverrides(List.of(override));
-
-        contractCall(request)
-                .andExpect(web3Properties.isEnableStateOverrides() ? status().isOk() : status().isBadRequest());
+        contractCall(request).andExpect(status().isOk());
     }
 
     @Test
@@ -707,8 +724,6 @@ final class ContractControllerTest {
 
     @Test
     void callWithStateOverrideUpperCaseAddressPrefix() throws Exception {
-        web3Properties.setEnableStateOverrides(true);
-
         final var override = new StateOverride();
         override.setAddress("0X00000000000000000000000000000000000004e4");
         override.setBalance("0x1");


### PR DESCRIPTION
**Description**:

* Exclude stream source credentials from `toString()`
* Limit state overrides to 10 entries
* Limit state override contract code to 24 KiB
* Normalize and validate stream archive path
* Use a random port for s3 server during tests

**Related issue(s)**:

MN-83
MN-93
MN-113

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
