### PR TITLE
Sanitize log message content and optimize code

### DIFF
--- a/rest/__tests__/logger.test.js
+++ b/rest/__tests__/logger.test.js
@@ -73,6 +73,23 @@ describe('Logger', () => {
       testLogger.info('hello world');
       expect(getOutput()).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z INFO 1234 hello world\n/);
     });
+
+    test('collapses CR/LF in message to prevent log forging', () => {
+      testLogger.info('legit\r\n2026-01-01T00:00:00Z INFO forged entry');
+      const output = getOutput();
+      // The only newline is the record terminator; the injected CR/LF is neutralized to a single line
+      expect(output.match(/\n/g)).toHaveLength(1);
+      expect(output).toMatch(/INFO 1234 legit 2026-01-01T00:00:00Z INFO forged entry\n/);
+    });
+
+    test('preserves multi-line err.stack', () => {
+      const err = new Error('boom');
+      err.stack = 'Error: boom\n    at foo\n    at bar';
+      testLogger.error('failure', err);
+      const output = getOutput();
+      expect(output).toMatch(/ERROR 1234 failure\n/);
+      expect(output).toContain('\n    at foo\n    at bar');
+    });
   });
 
   describe('log levels', () => {

--- a/rest/__tests__/requestHandler.test.js
+++ b/rest/__tests__/requestHandler.test.js
@@ -48,4 +48,30 @@ describe('qs tests', () => {
     const val = requestQueryParser('order=ASC&ORder=ASC');
     expect(val.order).toStrictEqual(['asc', 'asc']);
   });
+
+  // A case-variant of a prototype-member name (e.g. `Constructor`) survives qs's exact-case stripping, then the
+  // parser lowercases it to `constructor`. Both the dedup check and the canonicalization-map lookup must treat it
+  // as a plain key: neither merge against the inherited Object function (type-confused [<fn>, value] array) nor
+  // canonicalize via Object('x') (a boxed String). The stored value must be a plain primitive string.
+  // Read via getOwnPropertyDescriptor to avoid the special `.constructor` accessor.
+  const getOwnPropertyValue = (obj, key) => Object.getOwnPropertyDescriptor(obj, key)?.value;
+
+  test('requestQueryParser stores case-variant prototype key as a plain string', () => {
+    const val = requestQueryParser('Constructor=abc');
+    const stored = getOwnPropertyValue(val, 'constructor');
+    expect(typeof stored).toBe('string');
+    expect(stored).toBe('abc');
+  });
+
+  test('requestQueryParser merges repeated case-variant prototype keys as strings', () => {
+    const stored = getOwnPropertyValue(requestQueryParser('Constructor=a&CONSTRUCTOR=b'), 'constructor');
+    expect(stored).toStrictEqual(['a', 'b']);
+    stored.forEach((v) => expect(typeof v).toBe('string'));
+  });
+
+  test('requestQueryParser keeps normal params alongside a case-variant prototype key', () => {
+    const val = requestQueryParser('Constructor=x&limit=5');
+    expect(val.limit).toStrictEqual('5');
+    expect(getOwnPropertyValue(val, 'constructor')).toBe('x');
+  });
 });

--- a/rest/logger.js
+++ b/rest/logger.js
@@ -66,7 +66,10 @@ class Logger {
     const levelName = Level.toString(level);
     const requestId = httpContext.get(constants.requestIdLabel) || 'Startup';
     const stack = err?.stack ? `\n${err.stack}` : '';
-    const text = `${time} ${levelName} ${requestId} ${msg}${stack}\n`;
+    // Collapse CR/LF in the caller-supplied message to avoid splitting log
+    // records (CWE-117). The server-generated fields and err.stack are left intact.
+    const sanitizedMsg = String(msg).replace(/[\r\n]+/g, ' ');
+    const text = `${time} ${levelName} ${requestId} ${sanitizedMsg}${stack}\n`;
     this.#write(text);
   }
 

--- a/rest/middleware/requestHandler.js
+++ b/rest/middleware/requestHandler.js
@@ -57,7 +57,7 @@ const requestQueryParser = (queryString) => {
   for (const [key, value] of Object.entries(parsedQueryString)) {
     const lowerKey = key.toLowerCase();
     const canonicalValue = canonicalizeValue(lowerKey, value);
-    if (lowerKey in caseInsensitiveQueryString) {
+    if (Object.hasOwn(caseInsensitiveQueryString, lowerKey)) {
       // handle repeated values, merge into an array
       caseInsensitiveQueryString[lowerKey] = merge(caseInsensitiveQueryString[lowerKey], canonicalValue);
     } else {
@@ -69,7 +69,7 @@ const requestQueryParser = (queryString) => {
 };
 
 const canonicalizeValue = (key, value) => {
-  const canonicalizationFunc = queryCanonicalizationMap[key];
+  const canonicalizationFunc = Object.hasOwn(queryCanonicalizationMap, key) ? queryCanonicalizationMap[key] : undefined;
   if (canonicalizationFunc === undefined) {
     return value;
   }

--- a/web3/src/main/java/org/hiero/mirror/web3/service/RecordFileServiceImpl.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/RecordFileServiceImpl.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.web3.service;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.web3.repository.RecordFileRepository;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RecordFileServiceImpl implements RecordFileService {
 
+    private static final Pattern BLOCK_HASH_PATTERN = Pattern.compile("[0-9a-f]{64}|[0-9a-f]{96}");
+
     private final RecordFileRepository recordFileRepository;
 
     @Override
@@ -22,7 +25,11 @@ public class RecordFileServiceImpl implements RecordFileService {
         } else if (block == BlockType.LATEST) {
             return recordFileRepository.findLatest();
         } else if (block.isHash()) {
-            return recordFileRepository.findByHash(block.name());
+            final var hash = block.name();
+            if (!BLOCK_HASH_PATTERN.matcher(hash).matches()) {
+                throw new IllegalArgumentException("Invalid block hash: " + hash);
+            }
+            return recordFileRepository.findByHash(hash);
         }
 
         return recordFileRepository.findByIndex(block.number());

--- a/web3/src/main/java/org/hiero/mirror/web3/service/RecordFileServiceImpl.java
+++ b/web3/src/main/java/org/hiero/mirror/web3/service/RecordFileServiceImpl.java
@@ -3,7 +3,6 @@
 package org.hiero.mirror.web3.service;
 
 import java.util.Optional;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
 import org.hiero.mirror.web3.repository.RecordFileRepository;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RecordFileServiceImpl implements RecordFileService {
 
-    private static final Pattern BLOCK_HASH_PATTERN = Pattern.compile("[0-9a-f]{64}|[0-9a-f]{96}");
-
     private final RecordFileRepository recordFileRepository;
 
     @Override
@@ -25,11 +22,8 @@ public class RecordFileServiceImpl implements RecordFileService {
         } else if (block == BlockType.LATEST) {
             return recordFileRepository.findLatest();
         } else if (block.isHash()) {
-            final var hash = block.name();
-            if (!BLOCK_HASH_PATTERN.matcher(hash).matches()) {
-                throw new IllegalArgumentException("Invalid block hash: " + hash);
-            }
-            return recordFileRepository.findByHash(hash);
+            // The block.name() format is already validated by BlockType.of()
+            return recordFileRepository.findByHash(block.name());
         }
 
         return recordFileRepository.findByIndex(block.number());

--- a/web3/src/test/java/org/hiero/mirror/web3/service/RecordFileServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/RecordFileServiceTest.java
@@ -2,13 +2,17 @@
 
 package org.hiero.mirror.web3.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.web3.Web3IntegrationTest;
 import org.hiero.mirror.web3.validation.HexValidator;
 import org.hiero.mirror.web3.viewmodel.BlockType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @RequiredArgsConstructor
 class RecordFileServiceTest extends Web3IntegrationTest {
@@ -86,5 +90,27 @@ class RecordFileServiceTest extends Web3IntegrationTest {
         final var differentHash = HexValidator.HEX_PREFIX + "a".repeat(96);
         final var blockType = BlockType.of(differentHash);
         assertThat(recordFileService.findByBlockType(blockType)).isEmpty();
+    }
+
+    // BlockType's public constructor does not validate its name, so a hash-type BlockType could hold a real-looking
+    // hash that carries a SQL LIKE metacharacter or is a short/partial prefix. The service must reject such values
+    // before they reach findByHash. The cases below take a valid 96-hex hash and inject the malicious element.
+    static Stream<String> invalidBlockHashes() {
+        final var hash = "0123456789abcdef".repeat(6); // realistic 96-char lowercase hex
+        return Stream.of(
+                hash.substring(0, 95) + "%", // full-length hash with a trailing wildcard
+                hash.substring(0, 48) + "_" + hash.substring(49), // underscore wildcard mid-hash
+                hash.substring(0, 40), // realistic short/partial hash prefix
+                hash.toUpperCase(), // valid hex but uppercase (record_file.hash is stored lowercase)
+                HexValidator.HEX_PREFIX + hash, // 0x-prefixed: block.name() is bare hex, so the 0x form is invalid
+                HexValidator.HEX_PREFIX + hash.substring(0, 64)); // 0x-prefixed 64-hex, also bare-hex only
+    }
+
+    @MethodSource("invalidBlockHashes")
+    @ParameterizedTest
+    void testFindByBlockTypeRejectsInvalidHash(String name) {
+        final var blockType = new BlockType(name, BlockType.BLOCK_HASH_SENTINEL);
+        assertThatThrownBy(() -> recordFileService.findByBlockType(blockType))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/RecordFileServiceTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/RecordFileServiceTest.java
@@ -2,17 +2,13 @@
 
 package org.hiero.mirror.web3.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.web3.Web3IntegrationTest;
 import org.hiero.mirror.web3.validation.HexValidator;
 import org.hiero.mirror.web3.viewmodel.BlockType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @RequiredArgsConstructor
 class RecordFileServiceTest extends Web3IntegrationTest {
@@ -90,27 +86,5 @@ class RecordFileServiceTest extends Web3IntegrationTest {
         final var differentHash = HexValidator.HEX_PREFIX + "a".repeat(96);
         final var blockType = BlockType.of(differentHash);
         assertThat(recordFileService.findByBlockType(blockType)).isEmpty();
-    }
-
-    // BlockType's public constructor does not validate its name, so a hash-type BlockType could hold a real-looking
-    // hash that carries a SQL LIKE metacharacter or is a short/partial prefix. The service must reject such values
-    // before they reach findByHash. The cases below take a valid 96-hex hash and inject the malicious element.
-    static Stream<String> invalidBlockHashes() {
-        final var hash = "0123456789abcdef".repeat(6); // realistic 96-char lowercase hex
-        return Stream.of(
-                hash.substring(0, 95) + "%", // full-length hash with a trailing wildcard
-                hash.substring(0, 48) + "_" + hash.substring(49), // underscore wildcard mid-hash
-                hash.substring(0, 40), // realistic short/partial hash prefix
-                hash.toUpperCase(), // valid hex but uppercase (record_file.hash is stored lowercase)
-                HexValidator.HEX_PREFIX + hash, // 0x-prefixed: block.name() is bare hex, so the 0x form is invalid
-                HexValidator.HEX_PREFIX + hash.substring(0, 64)); // 0x-prefixed 64-hex, also bare-hex only
-    }
-
-    @MethodSource("invalidBlockHashes")
-    @ParameterizedTest
-    void testFindByBlockTypeRejectsInvalidHash(String name) {
-        final var blockType = new BlockType(name, BlockType.BLOCK_HASH_SENTINEL);
-        assertThatThrownBy(() -> recordFileService.findByBlockType(blockType))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/viewmodel/BlockTypeTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/viewmodel/BlockTypeTest.java
@@ -109,4 +109,32 @@ class BlockTypeTest {
     void invalidNoTrim(String value) {
         assertThatThrownBy(() -> BlockType.of(value)).isInstanceOf(IllegalArgumentException.class);
     }
+
+    // RecordFileRepository.findByHash binds the value into "where r.hash like concat(:hash, '%')". These confirm
+    // BlockType rejects any value carrying a SQL LIKE metacharacter (% or _), so a wildcard can never reach that
+    // query (the pattern only accepts [0-9a-f]).
+    static Stream<String> likeMetacharacterHashes() {
+        return Stream.of(
+                "%",
+                "_",
+                HEX_PREFIX + "a".repeat(63) + "%", // 64 chars, wildcard in place of a hex digit
+                HEX_PREFIX + "a".repeat(63) + "_",
+                HEX_PREFIX + "a".repeat(95) + "%", // 96 chars with a wildcard
+                HEX_PREFIX + "%",
+                HEX_PREFIX + "ab%cd");
+    }
+
+    @MethodSource("likeMetacharacterHashes")
+    @ParameterizedTest
+    void rejectsLikeMetacharacters(String value) {
+        assertThatThrownBy(() -> BlockType.of(value)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // A short hex string is parsed as a block NUMBER (isHash() == false), so it is routed to findByIndex and can
+    // never reach findByHash as a short/partial-hash prefix for enumeration.
+    @ValueSource(strings = {HEX_PREFIX + "ab", HEX_PREFIX + "1", HEX_PREFIX + "deadbeef"})
+    @ParameterizedTest
+    void shortHexIsBlockNumberNotHash(String value) {
+        assertThat(BlockType.of(value).isHash()).isFalse();
+    }
 }


### PR DESCRIPTION
**Description**:
 - Collapse CR/LF in the caller-supplied message to avoid splitting log records.
 - Avoid wildcard injection in findByHash query.
 - Avoid prototype-chain-confusion / prototype-pollution-adjacent anti-pattern (CWE-1321 family): treating a normal object as a dictionary and letting attacker-controlled keys reach into Object.prototype. Even though the code assigns to own keys (so it's not full prototype pollution), using in let inherited members masquerade as present entries. Object.hasOwn is the recommended defensive fix.

**Related issue(s)**:

Fixes #
MN-63
MN-64
MN-71

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
