### PR TITLE
ci: harden workflow permissions, validate gradle wrapper and pin base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
       - "/importer"
       - "/monitor"
       - "/pinger"
+      - "/rest"
       - "/rest-java"
       - "/rest/monitoring"
       - "/rosetta"
@@ -38,6 +39,11 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
     package-ecosystem: "docker"
     schedule:
@@ -73,16 +79,6 @@ updates:
         versions: [">=15.0.0"]
     open-pull-requests-limit: 10
     package-ecosystem: "npm"
-    schedule:
-      interval: "weekly"
-
-  - directory: "/rest"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 10
-    package-ecosystem: "docker"
     schedule:
       interval: "weekly"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,27 @@ updates:
     schedule:
       interval: "weekly"
 
+  - directories:
+      - "/graphql"
+      - "/grpc"
+      - "/importer"
+      - "/monitor"
+      - "/pinger"
+      - "/rest-java"
+      - "/rest/monitoring"
+      - "/rosetta"
+      - "/rosetta/container"
+      - "/test"
+      - "/web3"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+
   - directory: "/charts"
     groups:
       dependencies:

--- a/.github/workflows/copy-stackgres-cluster.yml
+++ b/.github/workflows/copy-stackgres-cluster.yml
@@ -150,15 +150,13 @@ env:
   LC_ALL: C.UTF-8
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   run-copy:
     name: Copy Citus from source to target
     runs-on: hiero-mirror-node-linux-medium
-    permissions:
-      contents: read
-      id-token: write
     timeout-minutes: 900 # 15 hours
     env:
       COLLECT_K6_REPORT: ${{ inputs.collect_k6_report }}

--- a/.github/workflows/copy-stackgres-cluster.yml
+++ b/.github/workflows/copy-stackgres-cluster.yml
@@ -150,13 +150,15 @@ env:
   LC_ALL: C.UTF-8
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   run-copy:
     name: Copy Citus from source to target
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 900 # 15 hours
     env:
       COLLECT_K6_REPORT: ${{ inputs.collect_k6_report }}

--- a/.github/workflows/deploy-preprod.yaml
+++ b/.github/workflows/deploy-preprod.yaml
@@ -15,7 +15,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 defaults:
   run:
@@ -31,6 +31,8 @@ jobs:
       ENVIRONMENT: ${{ github.event.inputs.environment }}
       VERSION: ${{ github.event.inputs.version }}
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,8 +8,7 @@ on:
       - HelmRelease/mirror.*
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 defaults:
   run:
@@ -22,6 +21,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.client_payload.severity == 'info'
     steps:
       - name: Harden Runner

--- a/.github/workflows/gh-pages-sync.yaml
+++ b/.github/workflows/gh-pages-sync.yaml
@@ -14,12 +14,14 @@ env:
   LC_ALL: C.UTF-8
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
     name: Sync Pages
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Gradle Wrapper Validation"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validate Gradle Wrapper
+    runs-on: hiero-mirror-node-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -10,8 +10,7 @@ on:
         required: true
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 defaults:
   run:
@@ -24,6 +23,9 @@ jobs:
   release:
     name: Release
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
+      issues: write
     outputs:
       create_pr: ${{ env.CREATE_PR }}
       next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
@@ -145,6 +147,8 @@ jobs:
   create_pr:
     name: Create PR
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
     needs: release
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -8,7 +8,7 @@ on:
       - "main"
 
 permissions:
-  contents: write
+  contents: read
 
 defaults:
   run:
@@ -115,6 +115,8 @@ jobs:
   deploy:
     needs: publish
     runs-on: hiero-mirror-node-linux-medium
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8083
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8083/actuator/health/liveness"]

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8083
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8083/actuator/health/liveness"]

--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8081/actuator/health/liveness"]

--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8081/actuator/health/liveness"]

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8080/actuator/health/liveness"]
 WORKDIR /app

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8080/actuator/health/liveness"]
 WORKDIR /app

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8082/actuator/health/liveness"]

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8082/actuator/health/liveness"]

--- a/pinger/Dockerfile
+++ b/pinger/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # Builder (multi-arch)
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine3.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine3.24@sha256:28d89ee9cc0ff9fec75c82ca201e6bf7fdf9a679d4b7b24dfa04f2bb766bb468 AS builder
 
 WORKDIR /src
 

--- a/rest-java/Dockerfile
+++ b/rest-java/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8084
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8084/actuator/health/liveness"]

--- a/rest-java/Dockerfile
+++ b/rest-java/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8084
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8084/actuator/health/liveness"]

--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de AS builder
+FROM node:24.20.0-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0 AS builder
 WORKDIR /dist
 
 RUN apt-get update && \
@@ -19,7 +19,7 @@ RUN npm run build && \
         -type d \( -name tests -o -name __tests__ \) \
     \) -exec rm -rf {} + 2>/dev/null || true
 
-FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de
+FROM node:24.20.0-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0
 LABEL maintainer="mirrornode@hedera.com"
 
 ENV NODE_ENV=production

--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.19.0-trixie-slim AS builder
+FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de AS builder
 WORKDIR /dist
 
 RUN apt-get update && \
@@ -19,7 +19,7 @@ RUN npm run build && \
         -type d \( -name tests -o -name __tests__ \) \
     \) -exec rm -rf {} + 2>/dev/null || true
 
-FROM node:24.19.0-trixie-slim
+FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de
 LABEL maintainer="mirrornode@hedera.com"
 
 ENV NODE_ENV=production

--- a/rest/monitoring/Dockerfile
+++ b/rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.19.0-trixie-slim
+FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/rest/monitoring/Dockerfile
+++ b/rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.19.0-trixie-slim@sha256:ab3eebe934147fee049b5eb83c570f68c849a13c930bdfa482de99fcdfa3b3de
+FROM node:24.20.0-trixie-slim@sha256:50c3b2f6988dfc307b86e5301d69611af31f4789bdf232863b07d3b02fe55ae0
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/rosetta/Dockerfile
+++ b/rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.7-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.7-trixie@sha256:e6e8ff4b72b128bb673613645c5ac415e4f537b2390e77a86ffc40622ab56da8 AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=development
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X main.Version=${VERSION}" -o rosetta
 
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness

--- a/rosetta/Dockerfile
+++ b/rosetta/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X main.Version=${VERSION}" -o rosetta
 
-FROM debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
+FROM debian:trixie-20260824-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness

--- a/rosetta/app/tools/hex_test.go
+++ b/rosetta/app/tools/hex_test.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,18 @@ func TestRemovesPrefixCorrectly(t *testing.T) {
 		// then:
 		assert.Equal(t, expectedData[i].result, result)
 	}
+}
+
+func FuzzSafeHexPrefix(f *testing.F) {
+	for _, seed := range []string{"", "0x", "0x0x", "0x123", "0X123", "123", " ", "0x "} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		withPrefix := SafeAddHexPrefix(value)
+
+		assert.True(t, strings.HasPrefix(withPrefix, HexPrefix))
+		assert.Equal(t, withPrefix, SafeAddHexPrefix(withPrefix))
+		assert.Equal(t, SafeRemoveHexPrefix(value), SafeRemoveHexPrefix(withPrefix))
+	})
 }

--- a/rosetta/app/tools/safecast_test.go
+++ b/rosetta/app/tools/safecast_test.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +81,23 @@ func TestCastToUint64(t *testing.T) {
 func TestCastToUint64OutOfRange(t *testing.T) {
 	_, err := CastToUint64(-1)
 	assert.Error(t, err)
+}
+
+func FuzzCastRoundTrip(f *testing.F) {
+	for _, seed := range []uint64{0, 1, math.MaxInt64, math.MaxInt64 + 1, math.MaxUint64} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, value uint64) {
+		casted, err := CastToInt64(value)
+		if value > math.MaxInt64 {
+			assert.Error(t, err)
+			return
+		}
+
+		assert.NoError(t, err)
+		roundTrip, err := CastToUint64(casted)
+		assert.NoError(t, err)
+		assert.Equal(t, value, roundTrip)
+	})
 }

--- a/rosetta/container/Dockerfile
+++ b/rosetta/container/Dockerfile
@@ -2,7 +2,7 @@
 # Importer, Rosetta and PostgreSQL into one image
 # and run the services using supervisord
 
-FROM ubuntu:noble AS builder
+FROM ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS builder
 ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y --no-install-recommends && apt-get install -y gcc git openjdk-25-jdk-headless wget
@@ -28,7 +28,7 @@ RUN mkdir importer rosetta scripts \
 # --------------------------- Runner Container --------------------------- #
 # ######################################################################## #
 
-FROM ubuntu:noble AS runner
+FROM ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS runner
 
 # ---------------------- Install Deps & PostgreSQL ------------------------ #
 # Add the PostgreSQL PGP key to verify their Debian packages.

--- a/rosetta/container/Dockerfile
+++ b/rosetta/container/Dockerfile
@@ -2,7 +2,7 @@
 # Importer, Rosetta and PostgreSQL into one image
 # and run the services using supervisord
 
-FROM ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS builder
+FROM ubuntu:noble-20260810@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS builder
 ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y --no-install-recommends && apt-get install -y gcc git openjdk-25-jdk-headless wget
@@ -28,7 +28,7 @@ RUN mkdir importer rosetta scripts \
 # --------------------------- Runner Container --------------------------- #
 # ######################################################################## #
 
-FROM ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS runner
+FROM ubuntu:noble-20260810@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS runner
 
 # ---------------------- Install Deps & PostgreSQL ------------------------ #
 # Add the PostgreSQL PGP key to verify their Debian packages.

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 WORKDIR /app

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 WORKDIR /app

--- a/web3/Dockerfile
+++ b/web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute AS builder
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute
+FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview -Djava.io.tmpdir=/tmp/web3"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8545/actuator/health/liveness"]

--- a/web3/Dockerfile
+++ b/web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007 AS builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=tools -jar *.jar extract --layers --launcher --destination extracted
 
-FROM eclipse-temurin:25-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
+FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a764d5ab4e83f4e90baec3b3dcda14071007
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview -Djava.io.tmpdir=/tmp/web3"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=5s CMD ["java", "-cp", "/app/healthcheck.jar", "org.hiero.mirror.common.healthcheck.HealthCheckClient", "http://localhost:8545/actuator/health/liveness"]


### PR DESCRIPTION
**Description**:

Improve the repository's [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/hiero-ledger/hiero-mirror-node) results (currently 7.0, with Token-Permissions at 0) without changing what any workflow is actually allowed to do. Every job keeps the scopes it uses today; the only difference is that write scopes are now granted per job instead of to every job in the workflow.

* Declare read-only top-level `permissions` in every workflow and move write scopes to the jobs that use them
* Add a Gradle wrapper validation workflow
* Pin all Docker Hub base images by digest and let Dependabot keep the digests current
* Add native Go fuzz tests for the rosetta `tools` helpers

**Changes by Scorecard check**

*Token-Permissions*
* `deploy.yaml`, `deploy-preprod.yaml`, `gh-pages-sync.yaml`, `release-automation.yml`, `release-integration.yml`: top-level block is now `contents: read`; the previous `contents: write` / `pull-requests: write` / `issues: write` scopes are set on the jobs that used them (`deploy`, `sync`, `release`, `create_pr`, `deploy`). The `create_pr` job in release-automation only gets `contents: write` since it does not touch issues or milestones.
* `copy-stackgres-cluster.yml`: `id-token: write` moved from the top level to the `run-copy` job.

*Binary-Artifacts*
* New `gradle-wrapper-validation.yml` using `gradle/actions/wrapper-validation` (same pinned SHA as the existing `setup-gradle` usages). Scorecard only exempts `gradle-wrapper.jar` when this explicit validation action runs successfully on the default branch; the implicit check done by `setup-gradle` does not count.

*Pinned-Dependencies*
* 21 `FROM` lines across 12 Dockerfiles now reference `image:tag@sha256:<digest>` (multi-arch index digests, verified with `docker buildx imagetools inspect`). Tags are kept alongside the digests for readability.
* `.github/dependabot.yml`: one new `docker` entry covering the Dockerfile directories that were not yet watched, so the digests get bumped weekly like `/rest` already does.

*Fuzzing*
* `FuzzSafeHexPrefix` and `FuzzCastRoundTrip` in `rosetta/app/tools`, property-style tests of the pure hex prefix and safe cast helpers with seed corpora. They run as normal tests under `go test` and can be fuzzed with `go test ./app/tools/ -run '^$' -fuzz '^FuzzSafeHexPrefix$'`.

| Check | Before | After (local `scorecard --local`) |
| --- | --- | --- |
| Token-Permissions | 0 | 10 |
| Fuzzing | 0 | 10 |
| Pinned-Dependencies | 7 | 9 |
| Binary-Artifacts | 9 | 9 locally; 10 once the wrapper validation workflow has run on `main` |
| Dangerous-Workflow | 10 | 10 |
| SAST | 5 | 5 (unchanged, see below) |

**Intentionally not changed**
* SAST / CodeQL: this repository already has CodeQL default setup enabled, and GitHub rejects analyses from a workflow-based (advanced) CodeQL configuration while default setup is on (`advanced configurations cannot be processed when the default setup is enabled`). Scorecard only credits default setup through the check runs it leaves on merged PRs, so no workflow is added here.
* `charts/marketplace/gcp/Dockerfile`: `gcr.io/cloud-marketplace-tools/k8s/deployer_helm` has no tag and requires GCP credentials to resolve a digest.
* `npm install -g snyk-to-html @wcj/html-to-markdown-cli` (security.yml) and `npm install -g @hiero-ledger/solo@...` (wrb-differential.yaml): global tool installs with no lockfile, so `npm ci` does not apply.
* `bash <(curl -Ls https://coverage.codacy.com/get.sh)` in gradle.yml: Codacy does not publish a checksum for the script.
* Job-level write scopes flagged as `Warn` by Scorecard (release-ghcr `packages: write`, release-production `contents: write`, and the ones moved here) are not penalized when the top level is read-only and are all required.

**Related issue(s)**:

N/A

**Notes for reviewer**:

* `actionlint` reports the same pre-existing shellcheck/runner-label notes as `main`; nothing new.
* `cd rosetta && go test ./app/tools/` passes, and both fuzzers ran for 10s (>1M executions each) with no findings.
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` produced the "After" column above.
* The `deploy`/`release` workflows cannot be exercised from a PR; the job-level blocks are a 1:1 copy of the scopes those jobs had before.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
