### PR TITLE
Synchronize ledger resolution in TssVerifierImpl

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierImpl.java
@@ -24,8 +24,6 @@ import org.jspecify.annotations.Nullable;
 final class TssVerifierImpl implements TssVerifier {
 
     private static final Ledger EMPTY = new Ledger();
-
-    private final Object lock = new Object();
     private final AtomicReference<Optional<Ledger>> ledger = new AtomicReference<>(Optional.empty());
     private final LedgerRepository ledgerRepository;
 
@@ -33,28 +31,20 @@ final class TssVerifierImpl implements TssVerifier {
     private volatile @Nullable Ledger ledgerOnChain;
 
     @Override
-    public void setLedger(final Ledger ledger, final boolean fromConfig) {
-        synchronized (lock) {
-            if (fromConfig) {
-                ledgerConfig = ledger;
-            } else {
-                ledgerOnChain = ledger;
-            }
-
-            this.ledger.set(Optional.empty());
+    public synchronized void setLedger(final Ledger ledger, final boolean fromConfig) {
+        if (fromConfig) {
+            ledgerConfig = ledger;
+        } else {
+            ledgerOnChain = ledger;
         }
+
+        this.ledger.set(Optional.empty());
     }
 
     @Override
-    public void verify(final long blockNumber, final byte[] message, final byte[] signature) {
-        final byte[] ledgerId;
-        final boolean verified;
-        synchronized (lock) {
-            ledgerId = getLedger().getLedgerId();
-            verified = TSS.verifyTSS(ledgerId, signature, message);
-        }
-
-        if (!verified) {
+    public synchronized void verify(final long blockNumber, final byte[] message, final byte[] signature) {
+        final var ledgerId = getLedger().getLedgerId();
+        if (!TSS.verifyTSS(ledgerId, signature, message)) {
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Failed to verify TSS signature for block {}: ledgerId={}, message={}, signature={}",

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierImpl.java
@@ -25,6 +25,7 @@ final class TssVerifierImpl implements TssVerifier {
 
     private static final Ledger EMPTY = new Ledger();
 
+    private final Object lock = new Object();
     private final AtomicReference<Optional<Ledger>> ledger = new AtomicReference<>(Optional.empty());
     private final LedgerRepository ledgerRepository;
 
@@ -33,20 +34,27 @@ final class TssVerifierImpl implements TssVerifier {
 
     @Override
     public void setLedger(final Ledger ledger, final boolean fromConfig) {
-        if (fromConfig) {
-            ledgerConfig = ledger;
-        } else {
-            ledgerOnChain = ledger;
-        }
+        synchronized (lock) {
+            if (fromConfig) {
+                ledgerConfig = ledger;
+            } else {
+                ledgerOnChain = ledger;
+            }
 
-        // Clear the atomic reference to reload the ledger
-        this.ledger.set(Optional.empty());
+            this.ledger.set(Optional.empty());
+        }
     }
 
     @Override
     public void verify(final long blockNumber, final byte[] message, final byte[] signature) {
-        final var ledgerId = getLedger().getLedgerId();
-        if (!TSS.verifyTSS(ledgerId, signature, message)) {
+        final byte[] ledgerId;
+        final boolean verified;
+        synchronized (lock) {
+            ledgerId = getLedger().getLedgerId();
+            verified = TSS.verifyTSS(ledgerId, signature, message);
+        }
+
+        if (!verified) {
             if (log.isDebugEnabled()) {
                 log.debug(
                         "Failed to verify TSS signature for block {}: ledgerId={}, message={}, signature={}",
@@ -71,7 +79,7 @@ final class TssVerifierImpl implements TssVerifier {
                                 return l;
                             })
                             .or(() -> Optional.of(EMPTY));
-                    ledger.compareAndSet(Optional.empty(), resolved);
+                    ledger.set(resolved);
                     return resolved;
                 })
                 .filter(l -> l != EMPTY)

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/tss/TssVerifierTest.java
@@ -51,6 +51,36 @@ final class TssVerifierTest {
     }
 
     @Test
+    void concurrentGetLedgerCallsOnLedgerSetOnce() throws Exception {
+        // given
+        when(ledgerRepository.findTopByOrderByConsensusTimestampDesc()).thenAnswer(invocation -> {
+            Thread.sleep(50); // widen the race window
+            return Optional.of(TEST_ARTIFACT.toLedger());
+        });
+
+        // when
+        final var pool = java.util.concurrent.Executors.newFixedThreadPool(2);
+        final var latch = new java.util.concurrent.CountDownLatch(2);
+        final Runnable task = () -> {
+            latch.countDown();
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            tssVerifier.verify(0, TEST_ARTIFACT.message, TEST_ARTIFACT.signatureWithWraps);
+        };
+        final var f1 = pool.submit(task);
+        final var f2 = pool.submit(task);
+        f1.get();
+        f2.get();
+        pool.shutdown();
+
+        // then
+        verify(ledgerRepository, times(1)).findTopByOrderByConsensusTimestampDesc();
+    }
+
+    @Test
     void verifyWhenThrow() {
         // given
         when(ledgerRepository.findTopByOrderByConsensusTimestampDesc())


### PR DESCRIPTION
**Description**:

Guard ledger resolution and TSS verification with a single lock to avoid redundant work under concurrent access.

  * Synchronize `setLedger()` and the ledger-resolution/verification path in `verify()` under one lock in `TssVerifierImpl`                                                              
  * Add a test covering concurrent calls into ledger resolution

**Related issue(s)**:

Fixes #MN-69

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
