### PR TITLE
Include access list in parser hash verification

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
@@ -120,10 +120,10 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
             } else {
                 storageKeys = new ArrayList<>(entryStorageKeys.size());
                 for (final var key : entryStorageKeys) {
-                    storageKeys.add(decodeHex(key, 64));
+                    storageKeys.add(decodeHex(key));
                 }
             }
-            encoded.add(List.of(decodeHex(entry.getAddress(), 40), storageKeys));
+            encoded.add(List.of(decodeHex(entry.getAddress()), storageKeys));
         }
         return encoded;
     }
@@ -134,13 +134,12 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
         return Integers.toBytesUnsigned(new BigInteger(ethereumTransaction.getValue()));
     }
 
-    private static byte[] decodeHex(String hex, int minLength) {
+    private static byte[] decodeHex(String hex) {
         final int start = hex.startsWith(HEX_PREFIX) ? HEX_PREFIX.length() : 0;
-        final int length = hex.length() - start;
-        if (length >= minLength && length % 2 == 0) {
-            return HexFormat.of().parseHex(hex, start, hex.length());
+        if ((hex.length() - start) % 2 != 0) {
+            return HexFormat.of().parseHex("0" + hex.substring(start));
         }
-        return HexFormat.of().parseHex(StringUtils.leftPad(hex.substring(start), Math.max(minLength, length + 1), '0'));
+        return HexFormat.of().parseHex(hex, start, hex.length());
     }
 
     private static byte[] getHash(byte[] rawBytes) {

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
@@ -76,7 +76,7 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
 
     protected static List<AccessList> parseAccessList(RLPItem rlpAccessList, String transactionTypeName) {
         if (!rlpAccessList.isList()) {
-            throw new InvalidEthereumBytesException(transactionTypeName, "Access list is not a list");
+            return List.of();
         }
 
         final var accessListEntries = rlpAccessList.asRLPList().elements();

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
@@ -23,8 +23,6 @@ import org.hiero.mirror.importer.exception.InvalidEthereumBytesException;
 import org.hiero.mirror.importer.repository.FileDataRepository;
 import org.hiero.mirror.importer.service.ContractBytecodeService;
 import org.hiero.mirror.importer.util.Utility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RequiredArgsConstructor
 abstract class AbstractEthereumTransactionParser implements EthereumTransactionParser {
@@ -33,7 +31,6 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
 
     private final ContractBytecodeService contractBytecodeService;
     private final FileDataRepository fileDataRepository;
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
     public final byte[] getHash(
@@ -50,11 +47,6 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
 
         try {
             var ethereumTransaction = decode(transactionBytes);
-            if (!CollectionUtils.isEmpty(ethereumTransaction.getAccessList())) {
-                log.warn("Re-encoding ethereum transaction at {} with access list is unsupported", consensusTimestamp);
-                return EMPTY_BYTE_ARRAY;
-            }
-
             callData = getCallData(callDataId, consensusTimestamp, useCurrentState);
             if (callData == null) {
                 Utility.handleRecoverableError(
@@ -114,10 +106,35 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
         return accessList;
     }
 
+    protected static List<List<Object>> encodeAccessList(List<AccessList> accessList) {
+        if (CollectionUtils.isEmpty(accessList)) {
+            return List.of();
+        }
+
+        final var encoded = new ArrayList<List<Object>>(accessList.size());
+        for (final var entry : accessList) {
+            final var storageKeys = CollectionUtils.isEmpty(entry.getStorageKeys())
+                    ? List.<byte[]>of()
+                    : entry.getStorageKeys().stream()
+                            .map(AbstractEthereumTransactionParser::decodeHex)
+                            .toList();
+            encoded.add(List.of(decodeHex(entry.getAddress()), storageKeys));
+        }
+        return encoded;
+    }
+
     protected static byte[] getValue(EthereumTransaction ethereumTransaction) {
         // Value (BigInteger 0) is stored as a 1-byte array [0] in EthereumTransaction, in the RPL encoded raw bytes,
         // it's an empty array, so re-encoding it to get the correct raw bytes for hashing
         return Integers.toBytesUnsigned(new BigInteger(ethereumTransaction.getValue()));
+    }
+
+    private static byte[] decodeHex(String hex) {
+        var stripped = hex.startsWith(HEX_PREFIX) ? hex.substring(HEX_PREFIX.length()) : hex;
+        if (stripped.length() % 2 != 0) {
+            stripped = "0" + stripped;
+        }
+        return HexFormat.of().parseHex(stripped);
     }
 
     private static byte[] getHash(byte[] rawBytes) {

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParser.java
@@ -113,12 +113,17 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
 
         final var encoded = new ArrayList<List<Object>>(accessList.size());
         for (final var entry : accessList) {
-            final var storageKeys = CollectionUtils.isEmpty(entry.getStorageKeys())
-                    ? List.<byte[]>of()
-                    : entry.getStorageKeys().stream()
-                            .map(AbstractEthereumTransactionParser::decodeHex)
-                            .toList();
-            encoded.add(List.of(decodeHex(entry.getAddress()), storageKeys));
+            final var entryStorageKeys = entry.getStorageKeys();
+            final List<byte[]> storageKeys;
+            if (CollectionUtils.isEmpty(entryStorageKeys)) {
+                storageKeys = List.of();
+            } else {
+                storageKeys = new ArrayList<>(entryStorageKeys.size());
+                for (final var key : entryStorageKeys) {
+                    storageKeys.add(decodeHex(key, 64));
+                }
+            }
+            encoded.add(List.of(decodeHex(entry.getAddress(), 40), storageKeys));
         }
         return encoded;
     }
@@ -129,12 +134,13 @@ abstract class AbstractEthereumTransactionParser implements EthereumTransactionP
         return Integers.toBytesUnsigned(new BigInteger(ethereumTransaction.getValue()));
     }
 
-    private static byte[] decodeHex(String hex) {
-        var stripped = hex.startsWith(HEX_PREFIX) ? hex.substring(HEX_PREFIX.length()) : hex;
-        if (stripped.length() % 2 != 0) {
-            stripped = "0" + stripped;
+    private static byte[] decodeHex(String hex, int minLength) {
+        final int start = hex.startsWith(HEX_PREFIX) ? HEX_PREFIX.length() : 0;
+        final int length = hex.length() - start;
+        if (length >= minLength && length % 2 == 0) {
+            return HexFormat.of().parseHex(hex, start, hex.length());
         }
-        return HexFormat.of().parseHex(stripped);
+        return HexFormat.of().parseHex(StringUtils.leftPad(hex.substring(start), Math.max(minLength, length + 1), '0'));
     }
 
     private static byte[] getHash(byte[] rawBytes) {

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParser.java
@@ -79,7 +79,7 @@ public final class Eip1559EthereumTransactionParser extends AbstractEthereumTran
                         ethereumTransaction.getToAddress(),
                         getValue(ethereumTransaction),
                         ethereumTransaction.getCallData(),
-                        List.of(/*accessList*/ ),
+                        encodeAccessList(ethereumTransaction.getAccessList()),
                         Integers.toBytes(ethereumTransaction.getRecoveryId()),
                         ethereumTransaction.getSignatureR(),
                         ethereumTransaction.getSignatureS()));

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParser.java
@@ -77,7 +77,7 @@ public final class Eip2930EthereumTransactionParser extends AbstractEthereumTran
                         ethereumTransaction.getToAddress(),
                         getValue(ethereumTransaction),
                         ethereumTransaction.getCallData(),
-                        List.of(/*accessList*/ ),
+                        encodeAccessList(ethereumTransaction.getAccessList()),
                         Integers.toBytes(ethereumTransaction.getRecoveryId()),
                         ethereumTransaction.getSignatureR(),
                         ethereumTransaction.getSignatureS()));

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParser.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParser.java
@@ -139,7 +139,7 @@ final class Eip7702EthereumTransactionParser extends AbstractEthereumTransaction
                         ethereumTransaction.getToAddress(),
                         getValue(ethereumTransaction),
                         ethereumTransaction.getCallData(),
-                        List.of(/*accessList*/ ),
+                        encodeAccessList(ethereumTransaction.getAccessList()),
                         authorizationList,
                         Integers.toBytes(ethereumTransaction.getRecoveryId()),
                         ethereumTransaction.getSignatureR(),

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
@@ -103,13 +103,21 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
 
     @ParameterizedTest
     @MethodSource("accessListTransactionTypes")
+    void parseAccessListEmptyString(String transactionType) {
+        final var accessListItem = RLPDecoder.RLP_STRICT.wrapItem(new byte[] {(byte) 0x80});
+
+        assertThat(AbstractEthereumTransactionParser.parseAccessList(accessListItem, transactionType))
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("accessListTransactionTypes")
     void parseAccessListNotList(String transactionType) {
         final var accessListItem =
                 RLPDecoder.RLP_STRICT.wrapItem(RLPEncoder.string(HexFormat.of().parseHex(ACCESS_LIST_ADDRESS_RAW)));
 
-        assertThatThrownBy(() -> AbstractEthereumTransactionParser.parseAccessList(accessListItem, transactionType))
-                .isInstanceOf(InvalidEthereumBytesException.class)
-                .hasMessage(decodeError(transactionType, "Access list is not a list"));
+        assertThat(AbstractEthereumTransactionParser.parseAccessList(accessListItem, transactionType))
+                .isEmpty();
     }
 
     @ParameterizedTest

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
@@ -63,6 +63,34 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
     }
 
     @ParameterizedTest
+    @MethodSource("accessListAddressesToPad")
+    void encodeAccessListPadsAddress(String address, String expectedHex) {
+        final var encoded =
+                AbstractEthereumTransactionParser.encodeAccessList(List.of(new AccessList(address, List.of())));
+
+        assertThat(encoded).singleElement().satisfies(entry -> {
+            assertThat((byte[]) entry.getFirst()).isEqualTo(HexFormat.of().parseHex(expectedHex));
+            assertThat(entry.get(1)).isEqualTo(List.of());
+        });
+    }
+
+    @Test
+    void encodeAccessListPadsAddressAndPreservesStorageKeys() {
+        final var encoded = AbstractEthereumTransactionParser.encodeAccessList(
+                List.of(new AccessList("0x1", List.of(ACCESS_LIST_STORAGE_KEY, SECOND_ACCESS_LIST_STORAGE_KEY))));
+
+        assertThat(encoded).singleElement().satisfies(entry -> {
+            assertThat((byte[]) entry.getFirst()).isEqualTo(HexFormat.of().parseHex(PADDED_ADDRESS.substring(2)));
+            assertThat((List<?>) entry.get(1))
+                    .satisfiesExactly(
+                            key -> assertThat((byte[]) key)
+                                    .isEqualTo(HexFormat.of().parseHex(ACCESS_LIST_STORAGE_KEY_RAW)),
+                            key -> assertThat((byte[]) key)
+                                    .isEqualTo(HexFormat.of().parseHex(SECOND_ACCESS_LIST_STORAGE_KEY_RAW)));
+        });
+    }
+
+    @ParameterizedTest
     @MethodSource("accessListTransactionTypes")
     void parseEmptyAccessList(String transactionType) {
         final var accessList = parseAccessList(List.of(), transactionType);
@@ -191,6 +219,22 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
 
     private static Stream<Arguments> accessListTransactionTypes() {
         return Stream.of(Arguments.of("EIP1559"), Arguments.of("EIP2930"), Arguments.of("EIP7702"));
+    }
+
+    private static Stream<Arguments> accessListAddressesToPad() {
+        final var one = PADDED_ADDRESS.substring(2);
+        final var abc = "0000000000000000000000000000000000000abc";
+        return Stream.of(
+                Arguments.of("0x1", one),
+                Arguments.of("0x01", one),
+                Arguments.of("1", one),
+                Arguments.of("01", one),
+                Arguments.of(PADDED_ADDRESS, one),
+                Arguments.of(one, one),
+                Arguments.of("0xabc", abc),
+                Arguments.of("abc", abc),
+                Arguments.of(ACCESS_LIST_ADDRESS, ACCESS_LIST_ADDRESS_RAW),
+                Arguments.of(ACCESS_LIST_ADDRESS_RAW, ACCESS_LIST_ADDRESS_RAW));
     }
 
     private static String decodeError(String transactionType, String detail) {

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
@@ -63,34 +63,6 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
     }
 
     @ParameterizedTest
-    @MethodSource("accessListAddressesToPad")
-    void encodeAccessListPadsAddress(String address, String expectedHex) {
-        final var encoded =
-                AbstractEthereumTransactionParser.encodeAccessList(List.of(new AccessList(address, List.of())));
-
-        assertThat(encoded).singleElement().satisfies(entry -> {
-            assertThat((byte[]) entry.getFirst()).isEqualTo(HexFormat.of().parseHex(expectedHex));
-            assertThat(entry.get(1)).isEqualTo(List.of());
-        });
-    }
-
-    @Test
-    void encodeAccessListPadsAddressAndPreservesStorageKeys() {
-        final var encoded = AbstractEthereumTransactionParser.encodeAccessList(
-                List.of(new AccessList("0x1", List.of(ACCESS_LIST_STORAGE_KEY, SECOND_ACCESS_LIST_STORAGE_KEY))));
-
-        assertThat(encoded).singleElement().satisfies(entry -> {
-            assertThat((byte[]) entry.getFirst()).isEqualTo(HexFormat.of().parseHex(PADDED_ADDRESS.substring(2)));
-            assertThat((List<?>) entry.get(1))
-                    .satisfiesExactly(
-                            key -> assertThat((byte[]) key)
-                                    .isEqualTo(HexFormat.of().parseHex(ACCESS_LIST_STORAGE_KEY_RAW)),
-                            key -> assertThat((byte[]) key)
-                                    .isEqualTo(HexFormat.of().parseHex(SECOND_ACCESS_LIST_STORAGE_KEY_RAW)));
-        });
-    }
-
-    @ParameterizedTest
     @MethodSource("accessListTransactionTypes")
     void parseEmptyAccessList(String transactionType) {
         final var accessList = parseAccessList(List.of(), transactionType);
@@ -219,22 +191,6 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
 
     private static Stream<Arguments> accessListTransactionTypes() {
         return Stream.of(Arguments.of("EIP1559"), Arguments.of("EIP2930"), Arguments.of("EIP7702"));
-    }
-
-    private static Stream<Arguments> accessListAddressesToPad() {
-        final var one = PADDED_ADDRESS.substring(2);
-        final var abc = "0000000000000000000000000000000000000abc";
-        return Stream.of(
-                Arguments.of("0x1", one),
-                Arguments.of("0x01", one),
-                Arguments.of("1", one),
-                Arguments.of("01", one),
-                Arguments.of(PADDED_ADDRESS, one),
-                Arguments.of(one, one),
-                Arguments.of("0xabc", abc),
-                Arguments.of("abc", abc),
-                Arguments.of(ACCESS_LIST_ADDRESS, ACCESS_LIST_ADDRESS_RAW),
-                Arguments.of(ACCESS_LIST_ADDRESS_RAW, ACCESS_LIST_ADDRESS_RAW));
     }
 
     private static String decodeError(String transactionType, String detail) {

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
@@ -12,12 +12,15 @@ import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransacti
 import com.esaulpaugh.headlong.rlp.RLPDecoder;
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.rlp.RLPItem;
+import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.hiero.mirror.common.domain.transaction.AccessList;
 import org.hiero.mirror.common.domain.transaction.EthereumTransaction;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.ImporterIntegrationTest;
 import org.hiero.mirror.importer.exception.InvalidEthereumBytesException;
 import org.junit.jupiter.api.Test;
@@ -153,6 +156,37 @@ abstract class AbstractEthereumTransactionParserTest extends ImporterIntegration
         assertThatThrownBy(() -> AbstractEthereumTransactionParser.parseAccessList(accessListItem, transactionType))
                 .isInstanceOf(InvalidEthereumBytesException.class)
                 .hasMessage(decodeError(transactionType, "Access list entry size was 3 but expected 2"));
+    }
+
+    protected void assertEncodeProducesOriginalHash(byte[] transactionBytes) {
+        final var parser = (AbstractEthereumTransactionParser) ethereumTransactionParser;
+        final var encoded = parser.encode(parser.decode(transactionBytes));
+        assertThat(encoded).isEqualTo(transactionBytes);
+        assertThat(new Keccak.Digest256().digest(encoded)).isEqualTo(new Keccak.Digest256().digest(transactionBytes));
+    }
+
+    protected void assertEmptyAccessListFormatsProduceSameHash(byte[] emptyListTx, byte[] emptyStringTx) {
+        final var parser = (AbstractEthereumTransactionParser) ethereumTransactionParser;
+        final var hashFromEmptyList = new Keccak.Digest256().digest(parser.encode(parser.decode(emptyListTx)));
+        final var hashFromEmptyString = new Keccak.Digest256().digest(parser.encode(parser.decode(emptyStringTx)));
+
+        assertThat(hashFromEmptyString).isEqualTo(hashFromEmptyList);
+        assertThat(hashFromEmptyList).isEqualTo(new Keccak.Digest256().digest(emptyListTx));
+    }
+
+    protected void assertGetHashWithOffloadedCallData(byte[] original, byte[] offloaded, String callDataHex) {
+        final var expected = new Keccak.Digest256().digest(original);
+        final var fileData = domainBuilder
+                .fileData()
+                .customize(f -> f.fileData(callDataHex.getBytes(StandardCharsets.UTF_8)))
+                .persist();
+        final var actual = ethereumTransactionParser.getHash(
+                DomainUtils.EMPTY_BYTE_ARRAY,
+                fileData.getEntityId(),
+                fileData.getConsensusTimestamp() + 1,
+                offloaded,
+                true);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private static Stream<Arguments> accessListTransactionTypes() {

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
@@ -6,12 +6,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hiero.mirror.common.domain.RecordItemBuilder.LONDON_RAW_TX;
 import static org.hiero.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
+import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED;
+import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.LONDON_RAW_TX_CALL_DATA_OFFLOADED;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.RAW_TX_TYPE_1;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.RAW_TX_TYPE_1_CALL_DATA;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.RAW_TX_TYPE_1_CALL_DATA_OFFLOADED;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.loadEthereumTransactions;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.populateFileData;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
@@ -167,19 +173,19 @@ final class CompositeEthereumTransactionParserTest extends AbstractEthereumTrans
     }
 
     @Test
-    void getHashCannotReencodeWithAccessList(CapturedOutput capturedOutput) {
-        // given
-        long consensusTimestamp = domainBuilder.timestamp();
-        String expectedMessage =
-                "Re-encoding ethereum transaction at %d with access list is unsupported".formatted(consensusTimestamp);
+    void getHashReencodesWithAccessList() {
+        assertGetHashWithOffloadedCallData(
+                EIP_2930_RAW_TX_WITH_ACCESS_LIST,
+                EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                RAW_TX_TYPE_1_CALL_DATA);
+    }
 
-        // when
-        var actual = ethereumTransactionParser.getHash(
-                EMPTY_BYTE_ARRAY, domainBuilder.entityId(), consensusTimestamp, EIP_2930_RAW_TX_WITH_ACCESS_LIST, true);
-
-        // then
-        softly.assertThat(actual).isEmpty();
-        softly.assertThat(capturedOutput.getAll()).contains(expectedMessage);
+    @ParameterizedTest
+    @MethodSource("emptyAccessListHashCases")
+    void getHashSameForEmptyListAndEmptyStringAccessList(
+            byte[] canonical, byte[] emptyListOffloaded, byte[] emptyStringOffloaded, String callDataHex) {
+        assertGetHashWithOffloadedCallData(canonical, emptyListOffloaded, callDataHex);
+        assertGetHashWithOffloadedCallData(canonical, emptyStringOffloaded, callDataHex);
     }
 
     @Test
@@ -242,6 +248,25 @@ final class CompositeEthereumTransactionParserTest extends AbstractEthereumTrans
     protected void validateEthereumTransaction(EthereumTransaction ethereumTransaction) {
         assertThat(ethereumTransaction).isNotNull().satisfies(t -> assertThat(t.getChainId())
                 .isNotEmpty());
+    }
+
+    private static Stream<Arguments> emptyAccessListHashCases() {
+        return Stream.of(
+                Arguments.of(
+                        RAW_TX_TYPE_1,
+                        RAW_TX_TYPE_1_CALL_DATA_OFFLOADED,
+                        withEmptyStringAccessList(RAW_TX_TYPE_1_CALL_DATA_OFFLOADED),
+                        RAW_TX_TYPE_1_CALL_DATA),
+                Arguments.of(
+                        LONDON_RAW_TX,
+                        LONDON_RAW_TX_CALL_DATA_OFFLOADED,
+                        withEmptyStringAccessList(LONDON_RAW_TX_CALL_DATA_OFFLOADED),
+                        RAW_TX_TYPE_1_CALL_DATA),
+                Arguments.of(
+                        EIP7702_RAW_TX_EMPTY_ACCESS_LIST,
+                        EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                        EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                        RAW_TX_TYPE_1_CALL_DATA));
     }
 
     private static Stream<Arguments> provideAllEthereumTransactions() {

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
@@ -8,7 +8,6 @@ import static org.hiero.mirror.common.domain.RecordItemBuilder.LONDON_RAW_TX;
 import static org.hiero.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
 import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_ACCESS_LIST;
 import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED;
-import static org.hiero.mirror.importer.parser.record.ethereum.Eip7702EthereumTransactionParserTest.EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.LONDON_RAW_TX_CALL_DATA_OFFLOADED;
@@ -265,7 +264,7 @@ final class CompositeEthereumTransactionParserTest extends AbstractEthereumTrans
                 Arguments.of(
                         EIP7702_RAW_TX_EMPTY_ACCESS_LIST,
                         EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED,
-                        EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                        withEmptyStringAccessList(EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED),
                         RAW_TX_TYPE_1_CALL_DATA));
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
@@ -10,6 +10,7 @@ import static org.hiero.mirror.importer.parser.record.ethereum.Eip2930EthereumTr
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_ADDRESS;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.LONDON_RAW_TX_WITH_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.util.Integers;
@@ -38,6 +39,12 @@ class Eip1559EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     @Test
     void decodeEmptyAccessList() {
         final var ethereumTransaction = ethereumTransactionParser.decode(LONDON_RAW_TX);
+        validateEthereumTransaction(ethereumTransaction, List.of());
+    }
+
+    @Test
+    void decodeEmptyStringAccessList() {
+        final var ethereumTransaction = ethereumTransactionParser.decode(withEmptyStringAccessList(LONDON_RAW_TX));
         validateEthereumTransaction(ethereumTransaction, List.of());
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
@@ -10,6 +10,8 @@ import static org.hiero.mirror.importer.parser.record.ethereum.Eip2930EthereumTr
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_ADDRESS;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.LONDON_RAW_TX_WITH_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.LONDON_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.RAW_TX_TYPE_1_CALL_DATA;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
@@ -46,6 +48,29 @@ class Eip1559EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     void decodeEmptyStringAccessList() {
         final var ethereumTransaction = ethereumTransactionParser.decode(withEmptyStringAccessList(LONDON_RAW_TX));
         validateEthereumTransaction(ethereumTransaction, List.of());
+    }
+
+    @Test
+    void encodePreservesHashWithAccessList() {
+        assertEncodeProducesOriginalHash(LONDON_RAW_TX_WITH_ACCESS_LIST);
+    }
+
+    @Test
+    void encodePreservesHashWithEmptyAccessList() {
+        assertEncodeProducesOriginalHash(LONDON_RAW_TX);
+    }
+
+    @Test
+    void emptyListAndEmptyStringAccessListProduceSameHash() {
+        assertEmptyAccessListFormatsProduceSameHash(LONDON_RAW_TX, withEmptyStringAccessList(LONDON_RAW_TX));
+    }
+
+    @Test
+    void getHashWithOffloadedCallDataAndAccessList() {
+        assertGetHashWithOffloadedCallData(
+                LONDON_RAW_TX_WITH_ACCESS_LIST,
+                LONDON_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                RAW_TX_TYPE_1_CALL_DATA);
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
@@ -9,6 +9,7 @@ import static org.hiero.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_ADDRESS;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.util.Integers;
@@ -41,6 +42,12 @@ class Eip2930EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     @Test
     void decodeEmptyAccessList() {
         final var ethereumTransaction = ethereumTransactionParser.decode(EIP_2930_RAW_TX);
+        validateEthereumTransaction(ethereumTransaction, List.of());
+    }
+
+    @Test
+    void decodeEmptyStringAccessList() {
+        final var ethereumTransaction = ethereumTransactionParser.decode(withEmptyStringAccessList(EIP_2930_RAW_TX));
         validateEthereumTransaction(ethereumTransaction, List.of());
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
@@ -9,6 +9,8 @@ import static org.hiero.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_ADDRESS;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.RAW_TX_TYPE_1_CALL_DATA;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
@@ -49,6 +51,29 @@ class Eip2930EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     void decodeEmptyStringAccessList() {
         final var ethereumTransaction = ethereumTransactionParser.decode(withEmptyStringAccessList(EIP_2930_RAW_TX));
         validateEthereumTransaction(ethereumTransaction, List.of());
+    }
+
+    @Test
+    void encodePreservesHashWithAccessList() {
+        assertEncodeProducesOriginalHash(EIP_2930_RAW_TX_WITH_ACCESS_LIST);
+    }
+
+    @Test
+    void encodePreservesHashWithEmptyAccessList() {
+        assertEncodeProducesOriginalHash(EIP_2930_RAW_TX);
+    }
+
+    @Test
+    void emptyListAndEmptyStringAccessListProduceSameHash() {
+        assertEmptyAccessListFormatsProduceSameHash(EIP_2930_RAW_TX, withEmptyStringAccessList(EIP_2930_RAW_TX));
+    }
+
+    @Test
+    void getHashWithOffloadedCallDataAndAccessList() {
+        assertGetHashWithOffloadedCallData(
+                EIP_2930_RAW_TX_WITH_ACCESS_LIST,
+                EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED,
+                RAW_TX_TYPE_1_CALL_DATA);
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
@@ -72,6 +72,13 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     }
 
     @Test
+    void decodeEmptyStringAccessList() {
+        final var ethereumTransaction =
+                ethereumTransactionParser.decode(encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST));
+        validateEthereumTransaction(ethereumTransaction, List.of(), true);
+    }
+
+    @Test
     void decodeWrongType() {
         var ethereumTransactionBytes = RLPEncoder.sequence(Integers.toBytes(2), new Object[] {});
 
@@ -324,7 +331,7 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
         }
     }
 
-    private static byte[] encodeEip7702Transaction(List<?> accessList, List<?> authorizationList) {
+    private static byte[] encodeEip7702Transaction(Object accessList, List<?> authorizationList) {
         return RLPEncoder.sequence(
                 Integers.toBytes(4),
                 List.of(

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
@@ -54,6 +54,14 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
             HexFormat.of().parseHex(SIGNATURE_S_HEX)));
 
     static final byte[] EIP7702_RAW_TX = encodeEip7702Transaction(DEFAULT_ACCESS_LIST, DEFAULT_AUTHORIZATION_LIST);
+    static final byte[] EIP7702_RAW_TX_EMPTY_ACCESS_LIST =
+            encodeEip7702Transaction(List.of(), DEFAULT_AUTHORIZATION_LIST);
+    static final byte[] EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST =
+            encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST);
+    static final byte[] EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED =
+            encodeEip7702Transaction(List.of(), DEFAULT_AUTHORIZATION_LIST, new byte[0]);
+    static final byte[] EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED =
+            encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST, new byte[0]);
 
     public Eip7702EthereumTransactionParserTest(Eip7702EthereumTransactionParser ethereumTransactionParser) {
         super(ethereumTransactionParser);
@@ -76,6 +84,30 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
         final var ethereumTransaction =
                 ethereumTransactionParser.decode(encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST));
         validateEthereumTransaction(ethereumTransaction, List.of(), true);
+    }
+
+    @Test
+    void encodePreservesHashWithAccessList() {
+        assertEncodeProducesOriginalHash(EIP7702_RAW_TX);
+    }
+
+    @Test
+    void encodePreservesHashWithEmptyAccessList() {
+        assertEncodeProducesOriginalHash(encodeEip7702Transaction(List.of(), DEFAULT_AUTHORIZATION_LIST));
+    }
+
+    @Test
+    void emptyListAndEmptyStringAccessListProduceSameHash() {
+        assertEmptyAccessListFormatsProduceSameHash(
+                EIP7702_RAW_TX_EMPTY_ACCESS_LIST, EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST);
+    }
+
+    @Test
+    void getHashWithOffloadedCallDataAndAccessList() {
+        assertGetHashWithOffloadedCallData(
+                EIP7702_RAW_TX,
+                encodeEip7702Transaction(DEFAULT_ACCESS_LIST, DEFAULT_AUTHORIZATION_LIST, new byte[0]),
+                CALL_DATA_HEX);
     }
 
     @Test
@@ -332,6 +364,10 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     }
 
     private static byte[] encodeEip7702Transaction(Object accessList, List<?> authorizationList) {
+        return encodeEip7702Transaction(accessList, authorizationList, Hex.decode(CALL_DATA_HEX));
+    }
+
+    private static byte[] encodeEip7702Transaction(Object accessList, List<?> authorizationList, byte[] callData) {
         return RLPEncoder.sequence(
                 Integers.toBytes(4),
                 List.of(
@@ -342,7 +378,7 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
                         Integers.toBytes(GAS_LIMIT),
                         Hex.decode(TO_ADDRESS_HEX),
                         Hex.decode(VALUE_HEX),
-                        Hex.decode(CALL_DATA_HEX),
+                        callData,
                         accessList,
                         authorizationList,
                         Integers.toBytes(1),

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/Eip7702EthereumTransactionParserTest.java
@@ -11,6 +11,7 @@ import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransacti
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_ADDRESS_RAW;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY;
 import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.ACCESS_LIST_STORAGE_KEY_RAW;
+import static org.hiero.mirror.importer.parser.record.ethereum.EthereumTransactionTestUtility.withEmptyStringAccessList;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.util.Integers;
@@ -56,12 +57,8 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     static final byte[] EIP7702_RAW_TX = encodeEip7702Transaction(DEFAULT_ACCESS_LIST, DEFAULT_AUTHORIZATION_LIST);
     static final byte[] EIP7702_RAW_TX_EMPTY_ACCESS_LIST =
             encodeEip7702Transaction(List.of(), DEFAULT_AUTHORIZATION_LIST);
-    static final byte[] EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST =
-            encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST);
     static final byte[] EIP7702_RAW_TX_EMPTY_ACCESS_LIST_CALL_DATA_OFFLOADED =
             encodeEip7702Transaction(List.of(), DEFAULT_AUTHORIZATION_LIST, new byte[0]);
-    static final byte[] EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST_CALL_DATA_OFFLOADED =
-            encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST, new byte[0]);
 
     public Eip7702EthereumTransactionParserTest(Eip7702EthereumTransactionParser ethereumTransactionParser) {
         super(ethereumTransactionParser);
@@ -82,7 +79,7 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     @Test
     void decodeEmptyStringAccessList() {
         final var ethereumTransaction =
-                ethereumTransactionParser.decode(encodeEip7702Transaction(new byte[0], DEFAULT_AUTHORIZATION_LIST));
+                ethereumTransactionParser.decode(withEmptyStringAccessList(EIP7702_RAW_TX_EMPTY_ACCESS_LIST));
         validateEthereumTransaction(ethereumTransaction, List.of(), true);
     }
 
@@ -99,7 +96,7 @@ class Eip7702EthereumTransactionParserTest extends AbstractEthereumTransactionPa
     @Test
     void emptyListAndEmptyStringAccessListProduceSameHash() {
         assertEmptyAccessListFormatsProduceSameHash(
-                EIP7702_RAW_TX_EMPTY_ACCESS_LIST, EIP7702_RAW_TX_EMPTY_STRING_ACCESS_LIST);
+                EIP7702_RAW_TX_EMPTY_ACCESS_LIST, withEmptyStringAccessList(EIP7702_RAW_TX_EMPTY_ACCESS_LIST));
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/EthereumTransactionTestUtility.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/EthereumTransactionTestUtility.java
@@ -4,6 +4,7 @@ package org.hiero.mirror.importer.parser.record.ethereum;
 
 import com.esaulpaugh.headlong.rlp.RLPDecoder;
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
+import com.esaulpaugh.headlong.rlp.RLPItem;
 import com.esaulpaugh.headlong.util.Integers;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -169,20 +170,39 @@ public class EthereumTransactionTestUtility {
     }
 
     /**
-     * Replaces the access list of a typed transaction (the field before y, r, s) with an empty RLP string.
+     * Replaces the access list with an empty RLP string. The access list is the first field after call data: index 7
+     * for EIP-2930, index 8 for EIP-1559 and EIP-7702.
      */
     public static byte[] withEmptyStringAccessList(byte[] transactionBytes) {
         final var decoder = RLPDecoder.RLP_STRICT.sequenceIterator(transactionBytes);
-        final var type = decoder.next().data();
+        final var type = decoder.next();
         final var items = decoder.next().asRLPList().elements();
+        final int accessListIndex = accessListIndex(type.asByte());
         final var rebuilt = new ArrayList<>(items.size());
         for (int i = 0; i < items.size(); i++) {
-            if (i == items.size() - 4) {
-                rebuilt.add(new byte[0]);
-            } else {
-                rebuilt.add(items.get(i).data());
-            }
+            rebuilt.add(i == accessListIndex ? new byte[0] : asEncodable(items.get(i)));
         }
-        return RLPEncoder.sequence(type, rebuilt);
+        return RLPEncoder.sequence(type.data(), rebuilt);
+    }
+
+    private static int accessListIndex(byte type) {
+        return switch (type) {
+            case Eip2930EthereumTransactionParser.EIP2930_TYPE_BYTE -> 7;
+            case Eip1559EthereumTransactionParser.EIP1559_TYPE_BYTE,
+                    Eip7702EthereumTransactionParser.EIP7702_TYPE_BYTE -> 8;
+            default -> throw new IllegalArgumentException("Unsupported ethereum transaction type: " + type);
+        };
+    }
+
+    private static Object asEncodable(RLPItem item) {
+        if (!item.isList()) {
+            return item.data();
+        }
+        final var elements = item.asRLPList().elements();
+        final var encoded = new ArrayList<>(elements.size());
+        for (final var element : elements) {
+            encoded.add(asEncodable(element));
+        }
+        return encoded;
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/EthereumTransactionTestUtility.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/ethereum/EthereumTransactionTestUtility.java
@@ -2,11 +2,13 @@
 
 package org.hiero.mirror.importer.parser.record.ethereum;
 
+import com.esaulpaugh.headlong.rlp.RLPDecoder;
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.util.Integers;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
 import lombok.SneakyThrows;
@@ -64,6 +66,10 @@ public class EthereumTransactionTestUtility {
     public static final String ACCESS_LIST_STORAGE_KEY_RAW =
             "0000000000000000000000000000000000000000000000000000000000000081";
 
+    private static final List<List<Object>> SAMPLE_ACCESS_LIST = List.of(List.of(
+            HexFormat.of().parseHex(ACCESS_LIST_ADDRESS_RAW),
+            List.of(HexFormat.of().parseHex(ACCESS_LIST_STORAGE_KEY_RAW))));
+
     public static final byte[] EIP_2930_RAW_TX_WITH_ACCESS_LIST = RLPEncoder.sequence(
             Integers.toBytes(1),
             List.of(
@@ -74,9 +80,22 @@ public class EthereumTransactionTestUtility {
                     HexFormat.of().parseHex("000000000000000000000000000000000000052d"),
                     HexFormat.of().parseHex("02540be400"),
                     HexFormat.of().parseHex("123456"),
-                    List.of(List.of(
-                            HexFormat.of().parseHex(ACCESS_LIST_ADDRESS_RAW),
-                            List.of(HexFormat.of().parseHex(ACCESS_LIST_STORAGE_KEY_RAW)))),
+                    SAMPLE_ACCESS_LIST,
+                    Integers.toBytes(1),
+                    HexFormat.of().parseHex("abb9e9c510716df2988cf626734ee50dcd9f41d30d638220712b5fe33fe4c816"),
+                    HexFormat.of().parseHex("249a72e1479b61e00d4f20308577bb63167d71b26138ee5229ca1cb3c49a2e53")));
+
+    public static final byte[] EIP_2930_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED = RLPEncoder.sequence(
+            Integers.toBytes(1),
+            List.of(
+                    HexFormat.of().parseHex("012a"),
+                    Integers.toBytes(5644),
+                    HexFormat.of().parseHex("a54f4c3c00"),
+                    Integers.toBytes(3_000_000),
+                    HexFormat.of().parseHex("000000000000000000000000000000000000052d"),
+                    HexFormat.of().parseHex("02540be400"),
+                    new byte[0],
+                    SAMPLE_ACCESS_LIST,
                     Integers.toBytes(1),
                     HexFormat.of().parseHex("abb9e9c510716df2988cf626734ee50dcd9f41d30d638220712b5fe33fe4c816"),
                     HexFormat.of().parseHex("249a72e1479b61e00d4f20308577bb63167d71b26138ee5229ca1cb3c49a2e53")));
@@ -92,9 +111,39 @@ public class EthereumTransactionTestUtility {
                     HexFormat.of().parseHex("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181"),
                     HexFormat.of().parseHex("0de0b6b3a7640000"),
                     HexFormat.of().parseHex("123456"),
-                    List.of(List.of(
-                            HexFormat.of().parseHex(ACCESS_LIST_ADDRESS_RAW),
-                            List.of(HexFormat.of().parseHex(ACCESS_LIST_STORAGE_KEY_RAW)))),
+                    SAMPLE_ACCESS_LIST,
+                    Integers.toBytes(1),
+                    HexFormat.of().parseHex("df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479"),
+                    HexFormat.of().parseHex("1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66")));
+
+    public static final byte[] LONDON_RAW_TX_WITH_ACCESS_LIST_CALL_DATA_OFFLOADED = RLPEncoder.sequence(
+            Integers.toBytes(2),
+            List.of(
+                    HexFormat.of().parseHex("012a"),
+                    Integers.toBytes(2),
+                    HexFormat.of().parseHex("2f"),
+                    HexFormat.of().parseHex("2f"),
+                    Integers.toBytes(98_304),
+                    HexFormat.of().parseHex("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181"),
+                    HexFormat.of().parseHex("0de0b6b3a7640000"),
+                    new byte[0],
+                    SAMPLE_ACCESS_LIST,
+                    Integers.toBytes(1),
+                    HexFormat.of().parseHex("df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479"),
+                    HexFormat.of().parseHex("1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66")));
+
+    public static final byte[] LONDON_RAW_TX_CALL_DATA_OFFLOADED = RLPEncoder.sequence(
+            Integers.toBytes(2),
+            List.of(
+                    HexFormat.of().parseHex("012a"),
+                    Integers.toBytes(2),
+                    HexFormat.of().parseHex("2f"),
+                    HexFormat.of().parseHex("2f"),
+                    Integers.toBytes(98_304),
+                    HexFormat.of().parseHex("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181"),
+                    HexFormat.of().parseHex("0de0b6b3a7640000"),
+                    new byte[0],
+                    List.of(),
                     Integers.toBytes(1),
                     HexFormat.of().parseHex("df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479"),
                     HexFormat.of().parseHex("1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66")));
@@ -117,5 +166,23 @@ public class EthereumTransactionTestUtility {
     public static void populateFileData(JdbcOperations jdbcOperations) {
         var file = ResourceUtils.getFile("classpath:data/ethereumTransaction/file_data.sql");
         jdbcOperations.update(FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Replaces the access list of a typed transaction (the field before y, r, s) with an empty RLP string.
+     */
+    public static byte[] withEmptyStringAccessList(byte[] transactionBytes) {
+        final var decoder = RLPDecoder.RLP_STRICT.sequenceIterator(transactionBytes);
+        final var type = decoder.next().data();
+        final var items = decoder.next().asRLPList().elements();
+        final var rebuilt = new ArrayList<>(items.size());
+        for (int i = 0; i < items.size(); i++) {
+            if (i == items.size() - 4) {
+                rebuilt.add(new byte[0]);
+            } else {
+                rebuilt.add(items.get(i).data());
+            }
+        }
+        return RLPEncoder.sequence(type, rebuilt);
     }
 }


### PR DESCRIPTION
**Description**:
Since the access lists will be available soon with Pectra release in consensus node, we add them in the parser encoding, so that the produced hashes will match. Added tests that verify the hash correctness,