### PR TITLE
Add a highly compressed zstd payload over grpc test

### DIFF
--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/BlockNodeTest.java
@@ -435,6 +435,24 @@ final class BlockNodeTest extends BlockNodeTestBase {
     }
 
     @Test
+    void streamResponseExceedsMaxStreamResponseSize() {
+        // given a malicious block node which replies with a zstd bomb of 32 GB once decompressed. gRPC enforces the max
+        // inbound message size against both the compressed and the decompressed bytes, so the response is rejected
+        // mid-decompression, long before 32GB is materialized.
+        final var maxStreamResponseSize = DataSize.ofMegabytes(1);
+        streamProperties.setMaxStreamResponseSize(maxStreamResponseSize);
+        blockNodeSimulator = new BlockNodeSimulator()
+                .withBlocks(new BlockGenerator(0).next(1))
+                .withHttpChannel()
+                .withZstdBomb(DataSize.ofGigabytes(32))
+                .start();
+        node = httpBlockNode(blockNodeSimulator);
+
+        // when, then
+        assertThatThrownBy(() -> node.streamBlocks(0, null, IGNORE, TIMEOUT)).isInstanceOf(BlockStreamException.class);
+    }
+
+    @Test
     void streamTooManyBlockItems(Resources resources) {
         // given
         streamProperties.setMaxBlockItems(2);

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/simulator/BlockNodeSimulator.java
@@ -14,6 +14,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Duration;
@@ -38,6 +39,7 @@ import org.hiero.block.api.protoc.SubscribeStreamRequest;
 import org.hiero.block.api.protoc.SubscribeStreamResponse;
 import org.hiero.mirror.importer.downloader.block.BlockNodeProperties;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.unit.DataSize;
 
 public final class BlockNodeSimulator implements AutoCloseable {
 
@@ -52,6 +54,11 @@ public final class BlockNodeSimulator implements AutoCloseable {
             return new ZstdOutputStream(os);
         }
     };
+
+    // A protobuf message made of repeated skippable varint fields (field number 1000, wire type 0, value 0). An
+    // all-zero payload wouldn't do since the parser rejects the zero tag after the first few bytes, before the
+    // decompressed size limit is reached.
+    private static final byte[] ZSTD_BOMB_PATTERN = {(byte) 0xc0, 0x3e, 0x00};
 
     private List<BlockGenerator.BlockRecord> blocks = Collections.emptyList();
     private int chunksPerBlock = 1;
@@ -72,6 +79,7 @@ public final class BlockNodeSimulator implements AutoCloseable {
     private Server server;
     private boolean started;
     private boolean zstdCompression;
+    private byte[] zstdBomb;
 
     @Override
     @SneakyThrows
@@ -115,7 +123,7 @@ public final class BlockNodeSimulator implements AutoCloseable {
 
         if (zstdCompression) {
             final var compressorRegistry = CompressorRegistry.newEmptyInstance();
-            compressorRegistry.register(ZSTD_COMPRESSOR);
+            compressorRegistry.register(zstdBomb == null ? ZSTD_COMPRESSOR : zstdBombCompressor(zstdBomb));
             serverBuilder.compressorRegistry(compressorRegistry);
         }
 
@@ -200,9 +208,69 @@ public final class BlockNodeSimulator implements AutoCloseable {
         return this;
     }
 
+    public BlockNodeSimulator withZstdBomb(final DataSize decompressedSize) {
+        zstdBomb = zstdBomb(decompressedSize.toBytes());
+        zstdCompression = true;
+        return this;
+    }
+
     public BlockNodeSimulator withZstdCompression(final boolean compressed) {
         this.zstdCompression = compressed;
         return this;
+    }
+
+    @SneakyThrows
+    private static byte[] zstdBomb(final long decompressedSize) {
+        final byte[] chunk = new byte[3 * 1024 * 1024];
+        for (int i = 0; i < chunk.length; i += ZSTD_BOMB_PATTERN.length) {
+            System.arraycopy(ZSTD_BOMB_PATTERN, 0, chunk, i, ZSTD_BOMB_PATTERN.length);
+        }
+
+        // zstd frames concatenate, so compress the chunk once and repeat the frame as many times as needed instead of
+        // compressing the whole payload
+        final var frame = new ByteArrayOutputStream();
+        try (final var zstd = new ZstdOutputStream(frame)) {
+            zstd.write(chunk);
+        }
+
+        final byte[] frameBytes = frame.toByteArray();
+        final int frames = (int) Math.ceilDiv(decompressedSize, chunk.length);
+        final var bomb = new ByteArrayOutputStream(frameBytes.length * frames);
+        for (int i = 0; i < frames; i++) {
+            bomb.write(frameBytes);
+        }
+
+        return bomb.toByteArray();
+    }
+
+    private static Compressor zstdBombCompressor(final byte[] bomb) {
+        return new Compressor() {
+            @Override
+            public String getMessageEncoding() {
+                return "zstd";
+            }
+
+            @Override
+            public OutputStream compress(final OutputStream os) {
+                return new OutputStream() {
+                    @Override
+                    public void write(final int b) {
+                        // discard the real message
+                    }
+
+                    @Override
+                    public void write(final byte[] b, final int off, final int len) {
+                        // discard the real message
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        os.write(bomb);
+                        os.flush();
+                    }
+                };
+            }
+        };
     }
 
     private static void validateArg(boolean condition, String message) {


### PR DESCRIPTION
**Description**:

This PR adds a test case to prove highly compressed zstd payload over grpc gets rejected properly.

**Related issue(s)**:

Fixes #MN-75

**Notes for reviewer**:

The PR doesn't fix issues since the report is wrong. Instead, a test case is added to show that a highly compressed zstd bomb payload is not a threat.

When zstd compression is negotiated and turned on by the peers, given a zstd bomb of very large size, due to the stack working in a pull mode, that is, the zstd codec will only decompress the amount of data (likely 64KB decompressed) pulled / read by the downstream reader, there's no chance the codec will decompress the data and hold tens of GB memory.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
