### PR TITLE
Harden protobuf parsing

### DIFF
--- a/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
+++ b/common/src/main/java/org/hiero/mirror/common/domain/transaction/RecordItem.java
@@ -3,9 +3,9 @@
 package org.hiero.mirror.common.domain.transaction;
 
 import static lombok.AccessLevel.PRIVATE;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -436,20 +436,17 @@ public class RecordItem implements StreamItem {
         @SuppressWarnings("deprecation")
         private void parseTransaction() {
             if (transactionBody == null || signatureMap == null) {
-                try {
-                    if (!transaction.getSignedTransactionBytes().equals(ByteString.EMPTY)) {
-                        var signedTransaction = SignedTransaction.parseFrom(transaction.getSignedTransactionBytes());
-                        this.transactionBody = TransactionBody.parseFrom(signedTransaction.getBodyBytes());
-                        this.signatureMap = signedTransaction.getSigMap();
-                    } else if (!transaction.getBodyBytes().equals(ByteString.EMPTY)) {
-                        this.transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
-                        this.signatureMap = transaction.getSigMap();
-                    } else if (transaction.hasBody()) {
-                        this.transactionBody = transaction.getBody();
-                        this.signatureMap = transaction.getSigMap();
-                    }
-                } catch (InvalidProtocolBufferException e) {
-                    throw new ProtobufException(BAD_TRANSACTION_BODY_BYTES_MESSAGE, e);
+                if (!transaction.getSignedTransactionBytes().equals(ByteString.EMPTY)) {
+                    final var signedTransactionBytes = transaction.getSignedTransactionBytes();
+                    final var signedTransaction = parseProtobuf(signedTransactionBytes, SignedTransaction::parseFrom);
+                    this.transactionBody = parseProtobuf(signedTransaction.getBodyBytes(), TransactionBody::parseFrom);
+                    this.signatureMap = signedTransaction.getSigMap();
+                } else if (!transaction.getBodyBytes().equals(ByteString.EMPTY)) {
+                    this.transactionBody = parseProtobuf(transaction.getBodyBytes(), TransactionBody::parseFrom);
+                    this.signatureMap = transaction.getSigMap();
+                } else if (transaction.hasBody()) {
+                    this.transactionBody = transaction.getBody();
+                    this.signatureMap = transaction.getSigMap();
                 }
             }
 

--- a/common/src/main/java/org/hiero/mirror/common/util/DomainUtils.java
+++ b/common/src/main/java/org/hiero/mirror/common/util/DomainUtils.java
@@ -8,6 +8,7 @@ import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteOutput;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Internal;
 import com.google.protobuf.UnsafeByteOperations;
 import com.hedera.services.stream.proto.HashObject;
@@ -18,6 +19,7 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -37,6 +39,7 @@ import org.hiero.mirror.common.domain.transaction.ContractSlotKey;
 import org.hiero.mirror.common.exception.InvalidEntityException;
 import org.hiero.mirror.common.exception.ProtobufException;
 import org.jspecify.annotations.Nullable;
+import org.springframework.util.function.ThrowingFunction;
 
 @CustomLog
 @UtilityClass
@@ -48,6 +51,11 @@ public class DomainUtils {
     public static final long NANOS_PER_SECOND = 1_000_000_000L;
     public static final String RECOVERABLE_ERROR = "Recoverable error. ";
     public static final long TINYBARS_IN_ONE_HBAR = 100_000_000L;
+
+    // These should match the default values in PBJ and CN so MN doesn't reject protobuf that CN accepts.
+    public static final int MAX_DEPTH = 128;
+    public static final int MAX_SIZE_FILE = 32 * 1024 * 1024;
+    public static final int MAX_SIZE_ITEM = 2 * 1024 * 1024;
 
     private static final long MAX_SYSTEM_ENTITY_NUM = 999;
     private static final byte[] MIRROR_PREFIX = new byte[12];
@@ -99,7 +107,7 @@ public class DomainUtils {
                 return null;
             }
 
-            final var key = Key.parseFrom(protobufKey);
+            final var key = parseProtobuf(protobufKey, Key::parseFrom);
             byte[] primitiveKey = getPublicKey(key, 1);
             return bytesToHex(primitiveKey);
         } catch (Exception e) {
@@ -321,6 +329,46 @@ public class DomainUtils {
         }
 
         return new ContractSlotKey(slotKey.slotId(), DomainUtils.fromBytes(normalizedBytes));
+    }
+
+    /**
+     * Parses protobuf-encoded data with hardened limits on nesting depth and total size.
+     *
+     * @param protobufBytes the encoded data; must be a {@code byte[]}, {@link ByteString}, {@link InputStream},
+     *                      or {@code null}
+     * @param parser        the parsing function to apply to the configured stream, usually a method reference such as
+     *                      {@code MyMessage::parseFrom}
+     * @param <T>           the type of the parsed message
+     * @return the parsed protobuf message
+     */
+    public static <T> T parseProtobuf(Object protobufBytes, ThrowingFunction<CodedInputStream, T> parser) {
+        return parseProtobuf(protobufBytes, parser, MAX_SIZE_ITEM);
+    }
+
+    /**
+     * Parses protobuf-encoded data with hardened limits on nesting depth and total size.
+     *
+     * @param protobufBytes the encoded data; must be a {@code byte[]}, {@link ByteString}, {@link InputStream},
+     *                      or {@code null}
+     * @param parser        the parsing function to apply to the configured stream, usually a method reference such as
+     *                      {@code MyMessage::parseFrom}
+     * @param maxSize       the maximum number of bytes to parse before throwing an error
+     * @param <T>           the type of the parsed message
+     * @return the parsed protobuf message
+     */
+    public static <T> T parseProtobuf(Object protobufBytes, ThrowingFunction<CodedInputStream, T> parser, int maxSize) {
+        final var codedInputStream =
+                switch (protobufBytes) {
+                    case null -> ByteString.EMPTY.newCodedInput();
+                    case byte[] bytes -> CodedInputStream.newInstance(bytes);
+                    case ByteString bytes -> bytes.newCodedInput();
+                    case InputStream inputStream -> CodedInputStream.newInstance(inputStream);
+                    default -> throw new IllegalStateException("Unexpected type: " + protobufBytes.getClass());
+                };
+
+        codedInputStream.setRecursionLimit(MAX_DEPTH);
+        codedInputStream.setSizeLimit(maxSize);
+        return parser.apply(codedInputStream, ProtobufException::new);
     }
 
     public static byte[] trim(final byte[] data) {

--- a/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
+++ b/common/src/test/java/org/hiero/mirror/common/util/DomainUtilsTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.google.protobuf.Internal;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.UnsafeByteOperations;
 import com.hedera.services.stream.proto.HashObject;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -23,9 +24,12 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
+import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
@@ -36,6 +40,7 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.transaction.ContractSlotId;
 import org.hiero.mirror.common.domain.transaction.ContractSlotKey;
 import org.hiero.mirror.common.exception.InvalidEntityException;
+import org.hiero.mirror.common.exception.ProtobufException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,6 +73,8 @@ final class DomainUtilsTest {
             + "8ecadacc328cb02594a2a5e9e46602010e2430203010001";
     private static final String EMPTY_EVM_ADDRESS = "0000000000000000000000000000000000000000";
     private static final String MAX_LONG_EVM_ADDRESS = "0000000000000000000000000000003FFFFFFFFF";
+    private static final Timestamp TIMESTAMP =
+            Timestamp.newBuilder().setSeconds(1234567890L).setNanos(42).build();
 
     private static Stream<Arguments> paddingByteProvider() {
         return Stream.of(
@@ -311,6 +318,100 @@ final class DomainUtilsTest {
         var hookSlotKey = new ContractSlotKey(slotId, ByteString.fromHex(input));
         var expected = new ContractSlotKey(slotId, ByteString.fromHex(trimmed));
         assertThat(DomainUtils.normalize(hookSlotKey)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"byte[]", "ByteString", "InputStream"})
+    void parseProtobufSupportedTypes(String type) {
+        // given
+        final var bytes = TIMESTAMP.toByteArray();
+        final var input =
+                switch (type) {
+                    case "byte[]" -> bytes;
+                    case "ByteString" -> ByteString.copyFrom(bytes);
+                    case "InputStream" -> new ByteArrayInputStream(bytes);
+                    default -> throw new IllegalArgumentException(type);
+                };
+
+        // when
+        final var actual = DomainUtils.parseProtobuf(input, Timestamp::parseFrom);
+
+        // then
+        assertThat(actual).isEqualTo(TIMESTAMP);
+    }
+
+    @Test
+    void parseProtobufNull() {
+        // when
+        final var actual = DomainUtils.parseProtobuf(null, Timestamp::parseFrom);
+
+        // then
+        assertThat(actual).isEqualTo(Timestamp.getDefaultInstance());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"String", "ByteBuffer", "Integer", "List"})
+    void parseProtobufUnsupportedType(String type) {
+        // given
+        final var input =
+                switch (type) {
+                    case "String" -> "not protobuf";
+                    case "ByteBuffer" -> ByteBuffer.allocate(8);
+                    case "Integer" -> 42;
+                    case "List" -> List.of();
+                    default -> throw new IllegalArgumentException(type);
+                };
+
+        // when, then
+        assertThatThrownBy(() -> DomainUtils.parseProtobuf(input, Timestamp::parseFrom))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Unexpected type:")
+                .hasMessageContaining(input.getClass().getName());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ffffff", "08", "1a05"})
+    void parseProtobufMalformed(String hex) {
+        // given
+        final var malformed = HexFormat.of().parseHex(hex);
+
+        // when, then
+        assertThatThrownBy(() -> DomainUtils.parseProtobuf(malformed, Timestamp::parseFrom))
+                .isInstanceOf(ProtobufException.class)
+                .hasCauseInstanceOf(InvalidProtocolBufferException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "2, true",
+        "0, false",
+        "-1, false",
+    })
+    void parseProtobufRecursionLimit(int offsetFromLimit, boolean expectFailure) {
+        // given
+        final var nested = nest(DomainUtils.MAX_DEPTH + offsetFromLimit);
+
+        // when, then
+        if (!expectFailure) {
+            final var actual = DomainUtils.parseProtobuf(nested, Key::parseFrom);
+            assertThat(actual).isNotNull();
+        } else {
+            assertThatThrownBy(() -> DomainUtils.parseProtobuf(nested, Key::parseFrom))
+                    .isInstanceOf(ProtobufException.class)
+                    .hasCauseInstanceOf(InvalidProtocolBufferException.class);
+        }
+    }
+
+    @Test
+    void parseProtobufPropagatesParserException() {
+        // given
+        final var cause = new IllegalArgumentException("boom");
+
+        // when, then
+        assertThatThrownBy(() -> DomainUtils.parseProtobuf(new byte[0], stream -> {
+                    throw cause;
+                }))
+                .isSameAs(cause);
     }
 
     @Test
@@ -599,5 +700,13 @@ final class DomainUtilsTest {
         } else {
             assertThat(result.getNum()).isEqualTo(expectedNum);
         }
+    }
+
+    private static byte[] nest(int depth) {
+        var key = Key.newBuilder().setEd25519(ByteString.fromHex(ED25519_KEY)).build();
+        for (int i = 0; i < depth / 2; i++) {
+            key = Key.newBuilder().setKeyList(KeyList.newBuilder().addKeys(key)).build();
+        }
+        return key.toByteArray();
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -2,6 +2,7 @@
 
 package org.hiero.mirror.importer.addressbook;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 import static org.hiero.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
 import static org.hiero.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 
@@ -219,7 +220,7 @@ public class AddressBookServiceImpl implements AddressBookService {
                 .fileId(fileData.getEntityId());
 
         try {
-            var nodeAddressBook = NodeAddressBook.parseFrom(fileData.getFileData());
+            final var nodeAddressBook = parseProtobuf(fileData.getFileData(), NodeAddressBook::parseFrom);
 
             if (nodeAddressBook != null && nodeAddressBook.getNodeAddressCount() > 0) {
                 addressBookBuilder.nodeCount(nodeAddressBook.getNodeAddressCount());

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockFileSource.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/BlockFileSource.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.downloader.block;
 
+import static org.hiero.mirror.common.util.DomainUtils.MAX_SIZE_FILE;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 import static org.hiero.mirror.importer.downloader.block.scheduler.Scheduler.EARLIEST_AVAILABLE_BLOCK_NUMBER;
 
 import com.hedera.hapi.block.stream.protoc.Block;
@@ -104,7 +106,7 @@ final class BlockFileSource extends AbstractBlockSource {
 
     private BlockStream getBlockStream(final StreamFileData blockFileData) throws IOException {
         try (final var inputStream = blockFileData.getInputStream()) {
-            final var block = Block.parseFrom(inputStream);
+            final var block = parseProtobuf(inputStream, Block::parseFrom, MAX_SIZE_FILE);
             final byte[] bytes = blockFileData.getBytes();
             return new BlockStream(
                     block.getItemsList(),

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/NetworkLedgerLoader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/tss/NetworkLedgerLoader.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.downloader.block.tss;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.hedera.hapi.node.tss.legacy.LedgerIdPublicationTransactionBody;
 import jakarta.inject.Named;
 import java.io.IOException;
@@ -11,6 +13,7 @@ import java.util.Set;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.common.domain.tss.Ledger;
+import org.hiero.mirror.common.exception.ProtobufException;
 import org.hiero.mirror.importer.ImporterProperties;
 import org.hiero.mirror.importer.ImporterProperties.HederaNetwork;
 import org.hiero.mirror.importer.downloader.block.BlockProperties;
@@ -47,8 +50,8 @@ final class NetworkLedgerLoader {
     private Ledger loadFromPath(final Path path) {
         final LedgerIdPublicationTransactionBody body;
         try (var in = Files.newInputStream(path)) {
-            body = LedgerIdPublicationTransactionBody.parseFrom(in);
-        } catch (IOException e) {
+            body = parseProtobuf(in, LedgerIdPublicationTransactionBody::parseFrom);
+        } catch (IOException | ProtobufException e) {
             throw new IllegalStateException("Failed to parse initialLedgerIdPublication file: " + path, e);
         }
         log.info("Loaded initial ledger from {}", path);
@@ -71,8 +74,8 @@ final class NetworkLedgerLoader {
 
         final LedgerIdPublicationTransactionBody body;
         try (var in = resource.getInputStream()) {
-            body = LedgerIdPublicationTransactionBody.parseFrom(in);
-        } catch (IOException e) {
+            body = parseProtobuf(in, LedgerIdPublicationTransactionBody::parseFrom);
+        } catch (IOException | ProtobufException e) {
             throw new IllegalStateException("Failed to parse bundled network ledger: " + location, e);
         }
         log.info("Loaded initial ledger from {}", location);

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/ContractResultMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/ContractResultMigration.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.migration;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.google.common.base.Stopwatch;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -84,7 +86,7 @@ public class ContractResultMigration extends AbstractJavaMigration {
                 return false;
             }
 
-            ContractFunctionResult contractFunctionResult = ContractFunctionResult.parseFrom(functionResult);
+            final var contractFunctionResult = parseProtobuf(functionResult, ContractFunctionResult::parseFrom);
             Long[] createdContractIds = new Long[contractFunctionResult.getCreatedContractIDsCount()];
 
             for (int i = 0; i < createdContractIds.length; ++i) {

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/ErrataMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/ErrataMigration.java
@@ -2,6 +2,7 @@
 
 package org.hiero.mirror.importer.migration;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 import static org.hiero.mirror.importer.reader.record.RecordFileReader.MAX_TRANSACTION_LENGTH;
 
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -231,8 +232,8 @@ final class ErrataMigration extends RepeatableMigration implements BalanceStream
             try (var in = new ValidatedDataInputStream(resource.getInputStream(), name)) {
                 byte[] recordBytes = in.readLengthAndBytes(1, MAX_TRANSACTION_LENGTH, false, "record");
                 byte[] transactionBytes = in.readLengthAndBytes(1, MAX_TRANSACTION_LENGTH, false, "transaction");
-                var transactionRecord = TransactionRecord.parseFrom(recordBytes);
-                var transaction = Transaction.parseFrom(transactionBytes);
+                final var transactionRecord = parseProtobuf(recordBytes, TransactionRecord::parseFrom);
+                final var transaction = parseProtobuf(transactionBytes, Transaction::parseFrom);
                 var recordItem = RecordItem.builder()
                         .transactionRecord(transactionRecord)
                         .transaction(transaction)

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/FixNodeTransactionsMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/FixNodeTransactionsMigration.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.migration;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import io.hypersistence.utils.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
 import jakarta.inject.Named;
@@ -127,8 +129,9 @@ public class FixNodeTransactionsMigration extends ConfigurableJavaMigration {
 
     @SneakyThrows
     private RecordItem toRecordItem(NodeTransaction transaction) {
-        var protoTransaction = com.hederahashgraph.api.proto.java.Transaction.parseFrom(transaction.transactionBytes());
-        var protoRecord = TransactionRecord.parseFrom(transaction.transactionRecordBytes());
+        final var protoTransaction =
+                parseProtobuf(transaction.transactionBytes, com.hederahashgraph.api.proto.java.Transaction::parseFrom);
+        final var protoRecord = parseProtobuf(transaction.transactionRecordBytes(), TransactionRecord::parseFrom);
         return RecordItem.builder()
                 .transaction(protoTransaction)
                 .transactionRecord(protoRecord)

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/HistoricalAccountInfoMigration.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.migration;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.google.common.base.Stopwatch;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import jakarta.inject.Named;
@@ -160,7 +162,7 @@ final class HistoricalAccountInfoMigration extends RepeatableMigration {
         try {
             if (StringUtils.isNotBlank(line)) {
                 byte[] data = Base64.decodeBase64(line);
-                return AccountInfo.parseFrom(data);
+                return parseProtobuf(data, AccountInfo::parseFrom);
             }
         } catch (Exception e) {
             log.error("Unable to parse AccountInfo from line: {}", line, e);

--- a/importer/src/main/java/org/hiero/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -2,6 +2,8 @@
 
 package org.hiero.mirror.importer.migration;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.hederahashgraph.api.proto.java.Key;
 import jakarta.inject.Named;
@@ -259,7 +261,7 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
      */
     private boolean isAuthorizedByContractKey(ApprovalTransfer transfer, List<String> migrationErrors) {
         try {
-            var parsedKey = Key.parseFrom(transfer.key);
+            final var parsedKey = parseProtobuf(transfer.key, Key::parseFrom);
             // If the threshold is greater than one ignore it
             if (!parsedKey.hasThresholdKey() || parsedKey.getThresholdKey().getThreshold() > 1) {
                 // Update the isApproval value to true

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -2,10 +2,12 @@
 
 package org.hiero.mirror.importer.reader.balance;
 
+import static org.hiero.mirror.common.util.DomainUtils.MAX_SIZE_FILE;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.hedera.services.stream.proto.AllAccountBalances;
 import com.hedera.services.stream.proto.SingleAccountBalances;
 import jakarta.inject.Named;
-import java.io.IOException;
 import java.util.List;
 import lombok.CustomLog;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -16,7 +18,6 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.domain.StreamFileData;
 import org.hiero.mirror.importer.exception.InvalidStreamFileException;
-import org.hiero.mirror.importer.exception.StreamFileReaderException;
 
 @CustomLog
 @Named
@@ -32,30 +33,26 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
 
     @Override
     public AccountBalanceFile read(StreamFileData streamFileData) {
-        try {
-            var bytes = streamFileData.getDecompressedBytes();
-            var allAccountBalances = AllAccountBalances.parseFrom(bytes);
+        final var bytes = streamFileData.getDecompressedBytes();
+        final var allAccountBalances = parseProtobuf(bytes, AllAccountBalances::parseFrom, MAX_SIZE_FILE);
 
-            if (!allAccountBalances.hasConsensusTimestamp()) {
-                throw new InvalidStreamFileException("Missing required consensusTimestamp field");
-            }
-
-            long consensusTimestamp = DomainUtils.timestampInNanosMax(allAccountBalances.getConsensusTimestamp());
-            var items = allAccountBalances.getAllAccountsList().stream()
-                    .map(ab -> toAccountBalance(consensusTimestamp, ab))
-                    .toList();
-
-            AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
-            accountBalanceFile.setBytes(streamFileData.getBytes());
-            accountBalanceFile.setConsensusTimestamp(consensusTimestamp);
-            accountBalanceFile.setFileHash(DigestUtils.sha384Hex(bytes));
-            accountBalanceFile.setItems(items);
-            accountBalanceFile.setLoadStart(streamFileData.getStreamFilename().getTimestamp());
-            accountBalanceFile.setName(streamFileData.getFilename());
-            return accountBalanceFile;
-        } catch (IOException e) {
-            throw new StreamFileReaderException(e);
+        if (!allAccountBalances.hasConsensusTimestamp()) {
+            throw new InvalidStreamFileException("Missing required consensusTimestamp field");
         }
+
+        final long consensusTimestamp = DomainUtils.timestampInNanosMax(allAccountBalances.getConsensusTimestamp());
+        final var items = allAccountBalances.getAllAccountsList().stream()
+                .map(ab -> toAccountBalance(consensusTimestamp, ab))
+                .toList();
+
+        final var accountBalanceFile = new AccountBalanceFile();
+        accountBalanceFile.setBytes(streamFileData.getBytes());
+        accountBalanceFile.setConsensusTimestamp(consensusTimestamp);
+        accountBalanceFile.setFileHash(DigestUtils.sha384Hex(bytes));
+        accountBalanceFile.setItems(items);
+        accountBalanceFile.setLoadStart(streamFileData.getStreamFilename().getTimestamp());
+        accountBalanceFile.setName(streamFileData.getFilename());
+        return accountBalanceFile;
     }
 
     private AccountBalance toAccountBalance(long consensusTimestamp, SingleAccountBalances balances) {

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
@@ -2,10 +2,11 @@
 
 package org.hiero.mirror.importer.reader.balance.line;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import com.google.common.base.Splitter;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.TokenBalances;
-import com.hederahashgraph.api.proto.java.TokenID;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,6 +16,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.hiero.mirror.common.domain.balance.AccountBalance;
 import org.hiero.mirror.common.domain.balance.TokenBalance;
 import org.hiero.mirror.common.domain.entity.EntityId;
+import org.hiero.mirror.common.exception.ProtobufException;
 import org.hiero.mirror.importer.exception.InvalidDatasetException;
 
 @Named
@@ -78,17 +80,21 @@ public class AccountBalanceLineParserV2 implements AccountBalanceLineParser {
     private List<TokenBalance> parseTokenBalanceList(
             String tokenBalancesProtoString, long consensusTimestamp, EntityId accountId)
             throws InvalidProtocolBufferException {
-        List<com.hederahashgraph.api.proto.java.TokenBalance> tokenBalanceProtoList = TokenBalances.parseFrom(
-                        Base64.decodeBase64(tokenBalancesProtoString))
-                .getTokenBalancesList();
-        List<TokenBalance> tokenBalances = new ArrayList<>();
-        for (com.hederahashgraph.api.proto.java.TokenBalance tokenBalanceProto : tokenBalanceProtoList) {
-            TokenID tokenId = tokenBalanceProto.getTokenId();
-            TokenBalance tokenBalance = new TokenBalance(
-                    tokenBalanceProto.getBalance(),
-                    new TokenBalance.Id(consensusTimestamp, accountId, EntityId.of(tokenId)));
-            tokenBalances.add(tokenBalance);
+        try {
+            final var bytes = Base64.decodeBase64(tokenBalancesProtoString);
+            final var tokenBalanceProto = parseProtobuf(bytes, TokenBalances::parseFrom);
+            final var tokenBalanceProtoList = tokenBalanceProto.getTokenBalancesList();
+            final var tokenBalances = new ArrayList<TokenBalance>(tokenBalanceProtoList.size());
+
+            for (final var tokenBalance : tokenBalanceProtoList) {
+                final var tokenId = EntityId.of(tokenBalance.getTokenId());
+                final var id = new TokenBalance.Id(consensusTimestamp, accountId, tokenId);
+                tokenBalances.add(new TokenBalance(tokenBalance.getBalance(), id));
+            }
+
+            return tokenBalances;
+        } catch (ProtobufException e) {
+            throw new InvalidDatasetException(e);
         }
-        return tokenBalances;
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderImpl.java
@@ -15,9 +15,9 @@ import static com.hedera.hapi.block.stream.protoc.BlockItem.ItemCase.TRANSACTION
 import static com.hedera.hapi.block.stream.protoc.BlockItem.ItemCase.TRANSACTION_RESULT;
 import static org.hiero.mirror.common.domain.transaction.RecordFile.GENESIS_BLOCK_NUMBER;
 import static org.hiero.mirror.common.util.DomainUtils.bytesToHex;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 import static org.hiero.mirror.common.util.DomainUtils.toBytes;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hapi.block.stream.output.protoc.StateChanges;
 import com.hedera.hapi.block.stream.output.protoc.TransactionOutput;
 import com.hedera.hapi.block.stream.output.protoc.TransactionOutput.TransactionCase;
@@ -185,67 +185,63 @@ public final class BlockStreamReaderImpl implements BlockStreamReader {
     private void readSignedTransactions(final ReaderContext context) {
         BlockItem protoBlockItem;
         SignedTransactionInfo signedTransactionInfo;
-        try {
-            while ((signedTransactionInfo = context.getSignedTransaction()) != null) {
-                final var signedTransaction = SignedTransaction.parseFrom(signedTransactionInfo.signedTransaction());
-                final var transactionBody = TransactionBody.parseFrom(signedTransaction.getBodyBytes());
-                final var transactionResultProtoBlockItem = context.readBlockItemFor(TRANSACTION_RESULT);
-                if (transactionResultProtoBlockItem == null) {
-                    if (signedTransactionInfo.userTransactionInBatch()) {
-                        // #12313 - when a user transaction in an atomic batch fails, any subsequent user transaction
-                        // in the same batch will not execute thus won't have a TransactionResult block item
-                        context.resetBatchTransaction();
-                    }
 
-                    // System transactions won't have transactionResult either, continue to next block item
-                    continue;
+        while ((signedTransactionInfo = context.getSignedTransaction()) != null) {
+            final var signedTransaction =
+                    parseProtobuf(signedTransactionInfo.signedTransaction(), SignedTransaction::parseFrom);
+            final var transactionBody = parseProtobuf(signedTransaction.getBodyBytes(), TransactionBody::parseFrom);
+            final var transactionResultProtoBlockItem = context.readBlockItemFor(TRANSACTION_RESULT);
+            if (transactionResultProtoBlockItem == null) {
+                if (signedTransactionInfo.userTransactionInBatch()) {
+                    // #12313 - when a user transaction in an atomic batch fails, any subsequent user transaction
+                    // in the same batch will not execute thus won't have a TransactionResult block item
+                    context.resetBatchTransaction();
                 }
 
-                final var transactionOutputs = new EnumMap<TransactionCase, TransactionOutput>(TransactionCase.class);
-                while ((protoBlockItem = context.readBlockItemFor(TRANSACTION_OUTPUT)) != null) {
-                    final var transactionOutput = protoBlockItem.getTransactionOutput();
-                    transactionOutputs.put(transactionOutput.getTransactionCase(), transactionOutput);
-                }
-
-                final var traceDataList = new ArrayList<TraceData>();
-                while ((protoBlockItem = context.readBlockItemFor(TRACE_DATA)) != null) {
-                    traceDataList.add(protoBlockItem.getTraceData());
-                }
-
-                final var stateChangesList = new ArrayList<StateChanges>();
-                final var transactionResult = transactionResultProtoBlockItem.getTransactionResult();
-                while ((protoBlockItem = context.readBlockItemFor(STATE_CHANGES)) != null) {
-                    final var stateChanges = protoBlockItem.getStateChanges();
-                    if (!Objects.equals(
-                            transactionResult.getConsensusTimestamp(), stateChanges.getConsensusTimestamp())) {
-                        break;
-                    }
-
-                    stateChangesList.add(stateChanges);
-                }
-
-                final var blockTransaction = BlockTransaction.builder()
-                        .previous(context.getLastBlockTransaction())
-                        .signedTransaction(signedTransaction)
-                        .signedTransactionBytes(signedTransactionInfo.signedTransaction())
-                        .stateChanges(Collections.unmodifiableList(stateChangesList))
-                        .traceData(Collections.unmodifiableList(traceDataList))
-                        .transactionBody(transactionBody)
-                        .transactionResult(transactionResult)
-                        .transactionOutputs(Collections.unmodifiableMap(transactionOutputs))
-                        .build();
-                context.setLastBlockTransaction(blockTransaction, signedTransactionInfo.userTransactionInBatch());
-
-                final var blockFileBuilder = context.getBlockFile();
-                blockFileBuilder.item(blockTransaction);
-                context.getConsensusTimestampTracker().track(blockTransaction.getConsensusTimestamp());
-                if (blockTransaction.getTransactionBody().hasLedgerIdPublication() && blockTransaction.isSuccessful()) {
-                    blockFileBuilder.lastLedgerIdPublicationTransaction(blockTransaction);
-                }
+                // System transactions won't have transactionResult either, continue to next block item
+                continue;
             }
-        } catch (InvalidProtocolBufferException e) {
-            throw new InvalidStreamFileException(
-                    "Failed to deserialize Transaction from block " + context.getFilename(), e);
+
+            final var transactionOutputs = new EnumMap<TransactionCase, TransactionOutput>(TransactionCase.class);
+            while ((protoBlockItem = context.readBlockItemFor(TRANSACTION_OUTPUT)) != null) {
+                final var transactionOutput = protoBlockItem.getTransactionOutput();
+                transactionOutputs.put(transactionOutput.getTransactionCase(), transactionOutput);
+            }
+
+            final var traceDataList = new ArrayList<TraceData>();
+            while ((protoBlockItem = context.readBlockItemFor(TRACE_DATA)) != null) {
+                traceDataList.add(protoBlockItem.getTraceData());
+            }
+
+            final var stateChangesList = new ArrayList<StateChanges>();
+            final var transactionResult = transactionResultProtoBlockItem.getTransactionResult();
+            while ((protoBlockItem = context.readBlockItemFor(STATE_CHANGES)) != null) {
+                final var stateChanges = protoBlockItem.getStateChanges();
+                if (!Objects.equals(transactionResult.getConsensusTimestamp(), stateChanges.getConsensusTimestamp())) {
+                    break;
+                }
+
+                stateChangesList.add(stateChanges);
+            }
+
+            final var blockTransaction = BlockTransaction.builder()
+                    .previous(context.getLastBlockTransaction())
+                    .signedTransaction(signedTransaction)
+                    .signedTransactionBytes(signedTransactionInfo.signedTransaction())
+                    .stateChanges(Collections.unmodifiableList(stateChangesList))
+                    .traceData(Collections.unmodifiableList(traceDataList))
+                    .transactionBody(transactionBody)
+                    .transactionResult(transactionResult)
+                    .transactionOutputs(Collections.unmodifiableMap(transactionOutputs))
+                    .build();
+            context.setLastBlockTransaction(blockTransaction, signedTransactionInfo.userTransactionInBatch());
+
+            final var blockFileBuilder = context.getBlockFile();
+            blockFileBuilder.item(blockTransaction);
+            context.getConsensusTimestampTracker().track(blockTransaction.getConsensusTimestamp());
+            if (blockTransaction.getTransactionBody().hasLedgerIdPublication() && blockTransaction.isSuccessful()) {
+                blockFileBuilder.lastLedgerIdPublicationTransaction(blockTransaction);
+            }
         }
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.importer.reader.record;
 
 import static org.hiero.mirror.common.util.DomainUtils.createSha384Digest;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
@@ -108,9 +109,9 @@ public abstract class AbstractPreV5RecordFileReader implements RecordFileReader 
             RecordItem recordItem = RecordItem.builder()
                     .hapiVersion(recordFile.getHapiVersion())
                     .previous(lastRecordItem)
-                    .transactionRecord(TransactionRecord.parseFrom(recordBytes))
+                    .transactionRecord(parseProtobuf(recordBytes, TransactionRecord::parseFrom))
                     .transactionIndex(count)
-                    .transaction(Transaction.parseFrom(transactionBytes))
+                    .transaction(parseProtobuf(transactionBytes, Transaction::parseFrom))
                     .build();
             items.add(recordItem);
 

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -3,7 +3,9 @@
 package org.hiero.mirror.importer.reader.record;
 
 import static java.lang.String.format;
+import static org.hiero.mirror.common.util.DomainUtils.MAX_SIZE_FILE;
 import static org.hiero.mirror.common.util.DomainUtils.createSha384Digest;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 
 import com.hedera.services.stream.proto.HashAlgorithm;
 import com.hedera.services.stream.proto.RecordStreamFile;
@@ -215,7 +217,7 @@ public final class ProtoRecordFileReader implements RecordFileReader {
                         format("Expected file %s with version %d, got %d.", filename, VERSION, version));
             }
 
-            return RecordStreamFile.parseFrom(dataInputStream);
+            return parseProtobuf(dataInputStream, RecordStreamFile::parseFrom, MAX_SIZE_FILE);
         }
     }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/RecordFileReaderImplV5.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/RecordFileReaderImplV5.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.importer.reader.record;
 
 import static org.hiero.mirror.common.util.DomainUtils.createSha384Digest;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 
 import com.google.common.primitives.Longs;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -102,9 +103,9 @@ public class RecordFileReaderImplV5 implements RecordFileReader {
             var recordItem = RecordItem.builder()
                     .hapiVersion(recordFile.getHapiVersion())
                     .previous(lastRecordItem)
-                    .transactionRecord(TransactionRecord.parseFrom(recordStreamObject.recordBytes))
+                    .transactionRecord(parseProtobuf(recordStreamObject.recordBytes, TransactionRecord::parseFrom))
                     .transactionIndex(count)
-                    .transaction(Transaction.parseFrom(recordStreamObject.transactionBytes))
+                    .transaction(parseProtobuf(recordStreamObject.transactionBytes, Transaction::parseFrom))
                     .build();
 
             items.add(recordItem);

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/record/sidecar/SidecarFileReaderImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/record/sidecar/SidecarFileReaderImpl.java
@@ -2,6 +2,9 @@
 
 package org.hiero.mirror.importer.reader.record.sidecar;
 
+import static org.hiero.mirror.common.util.DomainUtils.MAX_SIZE_FILE;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
+
 import jakarta.inject.Named;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -17,7 +20,8 @@ public class SidecarFileReaderImpl implements SidecarFileReader {
         try (var digestInputStream = new DigestInputStream(
                 streamFileData.getInputStream(),
                 MessageDigest.getInstance(sidecarFile.getHashAlgorithm().getName()))) {
-            var protoSidecarFile = com.hedera.services.stream.proto.SidecarFile.parseFrom(digestInputStream);
+            final var protoSidecarFile = parseProtobuf(
+                    digestInputStream, com.hedera.services.stream.proto.SidecarFile::parseFrom, MAX_SIZE_FILE);
             var bytes = streamFileData.getBytes();
             sidecarFile.setActualHash(digestInputStream.getMessageDigest().digest());
             sidecarFile.setBytes(bytes);

--- a/importer/src/main/java/org/hiero/mirror/importer/reader/signature/ProtoSignatureFileReader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/reader/signature/ProtoSignatureFileReader.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.importer.reader.signature;
 
 import static java.lang.String.format;
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 
 import com.hedera.services.stream.proto.SignatureFile;
 import jakarta.inject.Named;
@@ -53,7 +54,7 @@ public class ProtoSignatureFileReader implements SignatureFileReader {
                 throw new InvalidStreamFileException(message);
             }
 
-            var signatureFile = SignatureFile.parseFrom(dataInputStream);
+            final var signatureFile = parseProtobuf(dataInputStream, SignatureFile::parseFrom);
             if (!signatureFile.hasFileSignature()) {
                 throw new InvalidStreamFileException(format("The file %s does not have a file signature", filename));
             }

--- a/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/util/Utility.java
@@ -2,6 +2,7 @@
 
 package org.hiero.mirror.importer.util;
 
+import static org.hiero.mirror.common.util.DomainUtils.parseProtobuf;
 import static org.hiero.mirror.common.util.SignatureUtils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
 
 import com.google.common.base.CaseFormat;
@@ -64,7 +65,7 @@ public class Utility {
 
         byte[] evmAddress = null;
         try {
-            var key = Key.parseFrom(alias);
+            var key = parseProtobuf(alias, Key::parseFrom);
             if (key.getKeyCase() == Key.KeyCase.ECDSA_SECP256K1
                     && key.getECDSASecp256K1().size() == ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
                 byte[] rawCompressedKey = DomainUtils.toBytes(key.getECDSASecp256K1());

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/block/BlockStreamReaderTest.java
@@ -49,6 +49,7 @@ import org.hiero.mirror.common.domain.StreamType;
 import org.hiero.mirror.common.domain.transaction.BlockFile;
 import org.hiero.mirror.common.domain.transaction.BlockTransaction;
 import org.hiero.mirror.common.domain.transaction.RecordFile;
+import org.hiero.mirror.common.exception.ProtobufException;
 import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.TestUtils;
 import org.hiero.mirror.importer.domain.StreamFileData;
@@ -806,9 +807,7 @@ public final class BlockStreamReaderTest {
                 .addItems(blockProof())
                 .build();
         var blockStream = createBlockStream(block, null, BlockFile.getFilename(1, true));
-        assertThatThrownBy(() -> reader.read(blockStream))
-                .isInstanceOf(InvalidStreamFileException.class)
-                .hasMessageContaining("Failed to deserialize Transaction");
+        assertThatThrownBy(() -> reader.read(blockStream)).isInstanceOf(ProtobufException.class);
         verifyNoInteractions(initialStateReader);
     }
 
@@ -830,9 +829,7 @@ public final class BlockStreamReaderTest {
                 .addItems(blockProof())
                 .build();
         var blockStream = createBlockStream(block, null, BlockFile.getFilename(1, true));
-        assertThatThrownBy(() -> reader.read(blockStream))
-                .isInstanceOf(InvalidStreamFileException.class)
-                .hasMessageContaining("Failed to deserialize Transaction");
+        assertThatThrownBy(() -> reader.read(blockStream)).isInstanceOf(ProtobufException.class);
         verifyNoInteractions(initialStateReader);
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
@@ -5,10 +5,10 @@ package org.hiero.mirror.importer.reader.record.sidecar;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.hiero.mirror.common.domain.DomainBuilder;
 import org.hiero.mirror.common.domain.transaction.SidecarFile;
+import org.hiero.mirror.common.exception.ProtobufException;
 import org.hiero.mirror.importer.TestRecordFiles;
 import org.hiero.mirror.importer.TestUtils;
 import org.hiero.mirror.importer.domain.StreamFileData;
@@ -74,6 +74,6 @@ class SidecarFileReaderImplTest {
         var sidecar = domainBuilder.sidecarFile().get();
         assertThatThrownBy(() -> sidecarFileReader.read(sidecar, streamFileData))
                 .isInstanceOf(InvalidStreamFileException.class)
-                .hasCauseInstanceOf(InvalidProtocolBufferException.class);
+                .hasCauseInstanceOf(ProtobufException.class);
     }
 }


### PR DESCRIPTION
**Description**:

Harden protobuf parsing by:
* Limit max depth to 128 to match consensus node behavior
* Limit max protobuf size to 2 MiB for individual items
* Limit max protobuf size to 32 MiB for the whole file

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
