### PR TITLE
Fix tests under non-zero shard and realm

### DIFF
--- a/importer/src/test/java/org/hiero/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -468,7 +468,7 @@ final class EntityStakeRepositoryTest extends ImporterIntegrationTest {
     void createEntityStateStartWithChunking() {
         // given: two entities whose IDs are in different chunks
         final int chunkSize = 400;
-        final long accountId = 100L;
+        final long accountId = domainBuilder.entityNum(100L).getId();
         stakingProperties.setChunkSize(chunkSize);
 
         final long epochDay = 1000L;
@@ -512,7 +512,7 @@ final class EntityStakeRepositoryTest extends ImporterIntegrationTest {
         // given: two chunks separated by a measurable delay
         final var chunkDelay = Duration.ofMillis(50);
         final int chunkSize = 400;
-        final long accountId = 100L;
+        final long accountId = domainBuilder.entityNum(100L).getId();
         stakingProperties.setChunkSize(chunkSize);
         stakingProperties.setChunkDelay(chunkDelay);
 
@@ -1028,7 +1028,7 @@ final class EntityStakeRepositoryTest extends ImporterIntegrationTest {
         // forfeitedStakingPeriod is the first period the account has earned staking reward, so the stake period start
         // is forfeitedStakingPeriod - 1
         var account = domainBuilder
-                .entity(stakingRewardAccountId + domainBuilder.id(), entityLowerTimestamp + 1)
+                .entity(domainBuilder.id(), entityLowerTimestamp + 1)
                 .customize(e -> e.stakedNodeId(forfeitedStakingPeriod - 1))
                 .persist();
         // To make it underflow (pending reward becomes negative after forfeiting), the reward rate needs to be large
@@ -1156,7 +1156,7 @@ final class EntityStakeRepositoryTest extends ImporterIntegrationTest {
                 .entity(stakingRewardAccountId, entityLowerTimestamp)
                 .persist();
         final var account = domainBuilder
-                .entity(stakingRewardAccountId + domainBuilder.id(), entityLowerTimestamp + 1)
+                .entity(domainBuilder.id(), entityLowerTimestamp + 1)
                 .customize(e -> e.stakedNodeId(forfeitedStakingPeriod - 1))
                 .persist();
         domainBuilder


### PR DESCRIPTION
**Description**:
The malformed id came from the test constructing an account as stakingRewardAccountId + domainBuilder.id() — literally summing two already-encoded entity ids, which produces an id that corresponds to no valid shard/realm/num. Nothing in production ever does that, so the issue is only in tests.

**Related issue(s)**:

Fixes #14206 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
