### PR TITLE
Fix acceptance test log file path in k6 action

### DIFF
--- a/.github/actions/k6/action.yml
+++ b/.github/actions/k6/action.yml
@@ -8,8 +8,8 @@ runs:
     - name: Parse acceptance tests logs and set k6 environment variables
       shell: bash
       run: |
-        set -ex
-        LOG_FILE="./output_log.txt"
+        set -euxo pipefail
+        LOG_FILE="./logs/acceptance-tests/output.log"
 
         declare -A k6Map
         k6Map["PARENT"]="DEFAULT_CONTRACT_ADDRESS"


### PR DESCRIPTION
**Description**:

This PR fixes the regression in k6 test action:

- Fix acceptance test log file path
- Make the step fail on any command failure

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

It's still hardcoded, less ideal, can improve later.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
