### PR TITLE
Sealed-secrets 'helm upgrade' command update in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a standard GKE cluster with at least Kubernetes 1.32.
 
 ```bash
 brew install kubeseal ksd yq
-helm upgrade -i --wait --create-namespace -n flux-system sealed-secrets oci://registry-1.docker.io/bitnamicharts/sealed-secrets --set keyrenewperiod=0s
+helm upgrade -i --wait=legacy --create-namespace -n flux-system sealed-secrets oci://registry-1.docker.io/bitnamicharts/sealed-secrets --set keyrenewperiod=0s
 ```
 
 ### FluxCD


### PR DESCRIPTION
**Description**:
- Added a `--wait` value to sealed-secrets controller `helm upgrade` command to avoid the wait timing out and failing every time, resulting in the need to re-run the upgrade command.
  - This change is relevant to Helm 4+ (current latest: v4.2.4)

**Related issue(s)**:
N/A

**Notes for reviewer**:
Helm upgrade command would fail and require an unnecessary rerun.
Adding `legacy` value to `--wait` fixes it.

**Checklist**
- [x] Verified during the sealed-secrets controller upgrade in all envs last week.
