### PR TITLE
Improve importer parsing

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -161,18 +161,19 @@ public class AddressBookServiceImpl implements AddressBookService {
             nodeStakeTimestamp.compareAndSet(0L, nodeStake.getConsensusTimestamp());
         });
 
+        long nodeCountAddressBook = addressBook.getNodeCount() != null ? addressBook.getNodeCount() : 0L;
         long nodeCount = (consensusMode == ConsensusMode.STAKE_IN_ADDRESS_BOOK || nodeStakes.isEmpty())
-                ? addressBook.getNodeCount()
+                ? nodeCountAddressBook
                 : nodeStakes.size();
 
         // if only including address book nodes in stake count, warn if any nodes are excluded
         if (consensusMode == ConsensusMode.STAKE_IN_ADDRESS_BOOK
-                && addressBook.getNodeCount() != nodeStakes.size()
+                && nodeCountAddressBook != nodeStakes.size()
                 && !nodeStakes.isEmpty()) {
             log.warn(
                     "Using address book {} with {} nodes and node stake {} with {} nodes",
                     addressBook.getStartConsensusTimestamp(),
-                    addressBook.getNodeCount(),
+                    nodeCountAddressBook,
                     nodeStakeTimestamp.get(),
                     nodeStakes.size());
         }
@@ -234,7 +235,15 @@ public class AddressBookServiceImpl implements AddressBookService {
             return null;
         }
 
-        return addressBookBuilder.build();
+        final var addressBook = addressBookBuilder.build();
+
+        // Don't replace a valid address book with an invalid one that has no entries
+        if (CollectionUtils.isEmpty(addressBook.getEntries())) {
+            DomainUtils.logRecoverableError("No valid entries in address book {}", addressBook);
+            return null;
+        }
+
+        return addressBook;
     }
 
     private long getAddressBookStartConsensusTimestamp(FileData fileData) {

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/ParserContext.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/ParserContext.java
@@ -92,6 +92,17 @@ public class ParserContext {
         domainContext.clear();
     }
 
+    public <T> void replace(Object key, T value) {
+        final var domainContext = getDomainContext(value);
+        final var previous = domainContext.getState().put(key, value);
+
+        if (previous != null) {
+            domainContext.getInserts().remove(previous);
+        }
+
+        domainContext.getInserts().add(value);
+    }
+
     public Collection<Long> getEvmAddressLookupIds() {
         return Collections.unmodifiableSet(evmAddressLookupIds);
     }

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -274,7 +274,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
     @Override
     public void onNodeStake(NodeStake nodeStake) {
-        context.add(nodeStake);
+        context.replace(nodeStake.getId(), nodeStake);
     }
 
     @Override

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractNodeTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractNodeTransactionHandler.java
@@ -57,10 +57,7 @@ public abstract class AbstractNodeTransactionHandler extends AbstractTransaction
                     e.getMessage());
         }
 
-        return ServiceEndpoint.builder()
-                .domainName(proto.getDomainName())
-                .ipAddressV4(ipAddress)
-                .port(proto.getPort())
-                .build();
+        final var domainName = DomainUtils.sanitize(proto.getDomainName());
+        return new ServiceEndpoint(domainName, ipAddress, proto.getPort());
     }
 }

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractRegisteredNodeTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/AbstractRegisteredNodeTransactionHandler.java
@@ -77,7 +77,7 @@ abstract class AbstractRegisteredNodeTransactionHandler extends AbstractTransact
                     }
                 }
             }
-            case DOMAIN_NAME -> builder.domainName(proto.getDomainName());
+            case DOMAIN_NAME -> builder.domainName(DomainUtils.sanitize(proto.getDomainName()));
             default -> Utility.handleRecoverableError("Invalid addressCase: {}", proto.getAddressCase());
         }
 

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandler.java
@@ -3,6 +3,7 @@
 package org.hiero.mirror.importer.parser.record.transactionhandler;
 
 import static java.time.ZoneOffset.UTC;
+import static org.hiero.mirror.common.util.DomainUtils.logRecoverableError;
 
 import jakarta.inject.Named;
 import java.time.Instant;
@@ -18,7 +19,7 @@ import org.hiero.mirror.importer.parser.record.entity.EntityListener;
 
 @Named
 @RequiredArgsConstructor
-class FreezeTransactionHandler extends AbstractTransactionHandler {
+final class FreezeTransactionHandler extends AbstractTransactionHandler {
 
     private final EntityListener entityListener;
 
@@ -39,35 +40,56 @@ class FreezeTransactionHandler extends AbstractTransactionHandler {
             return;
         }
 
-        long startTime;
+        long consensusTimeStamp = recordItem.getConsensusTimestamp();
+        long startTime = 0L;
         Long endTime = null;
-        var body = recordItem.getTransactionBody().getFreeze();
-        var fileId = body.hasUpdateFile() ? EntityId.of(body.getUpdateFile()) : null;
+        final var body = recordItem.getTransactionBody().getFreeze();
 
         if (body.hasStartTime()) {
             startTime = DomainUtils.timestampInNanosMax(body.getStartTime());
         } else {
-            var consensusTime = Instant.ofEpochSecond(0L, recordItem.getConsensusTimestamp());
-            var startOfDay = LocalDate.ofInstant(consensusTime, UTC).atStartOfDay();
+            final var consensusTime = Instant.ofEpochSecond(0L, consensusTimeStamp);
+            final var startOfDay = LocalDate.ofInstant(consensusTime, UTC).atStartOfDay();
 
-            var startDateTime = startOfDay.withHour(body.getStartHour()).withMinute(body.getStartMin());
-            startTime = DomainUtils.convertToNanosMax(startDateTime.toInstant(UTC));
+            int startHour = body.getStartHour();
+            int startMinute = body.getStartMin();
+            int endHour = body.getEndHour();
+            int endMinute = body.getEndMin();
 
-            var endDateTime = startOfDay.withHour(body.getEndHour()).withMinute(body.getEndMin());
-
-            // The freeze starts in one day, but ends in another
-            if (body.getStartHour() > body.getEndHour()) {
-                endDateTime = endDateTime.plusDays(1);
+            if (startHour >= 0 && startHour <= 23 && startMinute >= 0 && startMinute <= 59) {
+                final var startDateTime = startOfDay.withHour(startHour).withMinute(startMinute);
+                startTime = DomainUtils.convertToNanosMax(startDateTime.toInstant(UTC));
+            } else {
+                logRecoverableError(
+                        "Freeze transaction {} contains an invalid start time {}:{}",
+                        consensusTimeStamp,
+                        startHour,
+                        startMinute);
             }
 
-            endTime = DomainUtils.convertToNanosMax(endDateTime.toInstant(UTC));
+            if (endHour >= 0 && endHour <= 23 && endMinute >= 0 && endMinute <= 59) {
+                var endDateTime = startOfDay.withHour(endHour).withMinute(endMinute);
+
+                // The freeze starts in one day, but ends in another
+                if (startTime > 0 && startHour > endHour) {
+                    endDateTime = endDateTime.plusDays(1);
+                }
+
+                endTime = DomainUtils.convertToNanosMax(endDateTime.toInstant(UTC));
+            } else {
+                logRecoverableError(
+                        "Freeze transaction {} contains an invalid end time {}:{}",
+                        consensusTimeStamp,
+                        endHour,
+                        endMinute);
+            }
         }
 
-        var networkFreeze = new NetworkFreeze();
-        networkFreeze.setConsensusTimestamp(recordItem.getConsensusTimestamp());
+        final var networkFreeze = new NetworkFreeze();
+        networkFreeze.setConsensusTimestamp(consensusTimeStamp);
         networkFreeze.setEndTime(endTime);
         networkFreeze.setFileHash(DomainUtils.toBytes(body.getFileHash()));
-        networkFreeze.setFileId(fileId);
+        networkFreeze.setFileId(transaction.getEntityId());
         networkFreeze.setPayerAccountId(recordItem.getPayerAccountId());
         networkFreeze.setStartTime(startTime);
         networkFreeze.setType(body.getFreezeTypeValue());

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandler.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandler.java
@@ -2,7 +2,10 @@
 
 package org.hiero.mirror.importer.parser.record.transactionhandler;
 
+import static org.hiero.mirror.common.util.DomainUtils.logRecoverableError;
+
 import jakarta.inject.Named;
+import java.util.HashSet;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.hiero.mirror.common.domain.addressbook.NetworkStake;
@@ -48,7 +51,7 @@ class NodeStakeUpdateTransactionHandler extends AbstractTransactionHandler {
                 .map(nodeStake -> nodeStake.getStakeRewarded() + nodeStake.getStakeNotRewarded())
                 .reduce(0L, Long::sum);
 
-        NetworkStake networkStake = new NetworkStake();
+        final var networkStake = new NetworkStake();
         networkStake.setConsensusTimestamp(consensusTimestamp);
         networkStake.setEpochDay(epochDay);
         networkStake.setMaxStakeRewarded(transactionBody.getMaxStakeRewarded());
@@ -74,25 +77,33 @@ class NodeStakeUpdateTransactionHandler extends AbstractTransactionHandler {
 
         entityListener.onNetworkStake(networkStake);
 
-        var nodeStakesProtos = transactionBody.getNodeStakeList();
+        final var nodeStakesProtos = transactionBody.getNodeStakeList();
         if (nodeStakesProtos.isEmpty()) {
-            log.warn("NodeStakeUpdateTransaction has empty node stake list");
+            logRecoverableError("NodeStakeUpdate {} has an empty node stake list", consensusTimestamp);
             return;
         }
 
+        final var nodeIds = new HashSet<Long>(nodeStakesProtos.size());
+
         for (var nodeStakeProto : nodeStakesProtos) {
-            var nodeStake = new NodeStake();
+            long nodeId = nodeStakeProto.getNodeId();
+            final var nodeStake = new NodeStake();
             nodeStake.setConsensusTimestamp(consensusTimestamp);
             nodeStake.setEpochDay(epochDay);
             nodeStake.setMaxStake(nodeStakeProto.getMaxStake());
             nodeStake.setMinStake(nodeStakeProto.getMinStake());
-            nodeStake.setNodeId(nodeStakeProto.getNodeId());
+            nodeStake.setNodeId(nodeId);
             nodeStake.setRewardRate(nodeStakeProto.getRewardRate());
             nodeStake.setStake(nodeStakeProto.getStake());
             nodeStake.setStakeNotRewarded(nodeStakeProto.getStakeNotRewarded());
             nodeStake.setStakeRewarded(nodeStakeProto.getStakeRewarded());
             nodeStake.setStakingPeriod(stakingPeriod);
             entityListener.onNodeStake(nodeStake);
+
+            // Duplicate collapsing is done in EntityListener so we don't loop twice here
+            if (!nodeIds.add(nodeId)) {
+                logRecoverableError("NodeStakeUpdate {} contains a duplicate node ID {}", consensusTimestamp, nodeId);
+            }
         }
 
         applicationEventPublisher.publishEvent(new NodeStakeUpdatedEvent(this));

--- a/importer/src/test/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -218,6 +218,26 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
     }
 
     @Test
+    @Transactional
+    void updateFileWithNoNodes() {
+        long consensusTimeStamp = domainBuilder.timestamp();
+        final var nodeAddressBook = NodeAddressBook.newBuilder().build();
+        update(nodeAddressBook.toByteArray(), consensusTimeStamp, true);
+        assertThat(addressBookRepository.findById(consensusTimeStamp + 1)).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void updateFileWithNoValidEntry() {
+        long consensusTimeStamp = domainBuilder.timestamp();
+        final var nodeAddressBook = NodeAddressBook.newBuilder()
+                .addNodeAddress(NodeAddress.newBuilder())
+                .build();
+        update(nodeAddressBook.toByteArray(), consensusTimeStamp, true);
+        assertThat(addressBookRepository.findById(consensusTimeStamp + 1)).isEmpty();
+    }
+
+    @Test
     void appendFileWithoutFileCreateOrUpdate() {
         byte[] addressBookBytes = UPDATED.toByteArray();
         int index = addressBookBytes.length / 2;
@@ -1021,6 +1041,14 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
         // when, then
         assertThat(addressBookService.getNode(4L)).isNull();
+    }
+
+    @Test
+    void getNodesEmpty() {
+        domainBuilder.addressBook().customize(ab -> ab.nodeCount(null)).persist();
+        assertThatThrownBy(() -> addressBookService.getNodes())
+                .isInstanceOf(InvalidDatasetException.class)
+                .hasMessage("Unable to find a valid address book");
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/ParserContextTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/ParserContextTest.java
@@ -87,6 +87,22 @@ class ParserContextTest {
     }
 
     @Test
+    void replace() {
+        final var entity1 = domainBuilder.entity().get();
+        final var entity2 =
+                domainBuilder.entity().customize(e -> e.id(entity1.getId())).get();
+
+        parserContext.replace(entity1.getId(), entity1);
+        assertThat(parserContext.get(Entity.class, entity1.getId())).isEqualTo(entity1);
+        assertThat(parserContext.get(Entity.class)).isEqualTo(List.of(entity1));
+
+        parserContext.replace(entity2.getId(), entity2);
+        assertThat(parserContext.get(Entity.class, entity1.getId())).isEqualTo(entity2);
+        assertThat(parserContext.get(Entity.class, entity2.getId())).isEqualTo(entity2);
+        assertThat(parserContext.get(Entity.class)).isEqualTo(List.of(entity2));
+    }
+
+    @Test
     void addTransient() {
         assertThatThrownBy(() -> parserContext.addTransient(null)).isInstanceOf(NullPointerException.class);
         var domain = domainBuilder.entity().get();

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -2261,6 +2261,25 @@ final class SqlEntityListenerTest extends ImporterIntegrationTest {
     }
 
     @Test
+    void onNodeStakeDuplicate() {
+        // given
+        var nodeStake1 = domainBuilder.nodeStake().get();
+        var nodeStake2 = domainBuilder
+                .nodeStake()
+                .customize(n ->
+                        n.consensusTimestamp(nodeStake1.getConsensusTimestamp()).nodeId(nodeStake1.getNodeId()))
+                .get();
+
+        // when
+        sqlEntityListener.onNodeStake(nodeStake1);
+        sqlEntityListener.onNodeStake(nodeStake2);
+        completeFileAndCommit();
+
+        // then
+        assertThat(nodeStakeRepository.findAll()).containsExactlyInAnyOrder(nodeStake2);
+    }
+
+    @Test
     void onPrng() {
         var prng = domainBuilder.prng().get();
         var prng2 = domainBuilder

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandlerTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
-class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
+final class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
 
     @Captor
     protected ArgumentCaptor<NetworkFreeze> networkFreezeCaptor;
@@ -46,9 +46,11 @@ class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Test
     void updateTransaction() {
         // Given
-        var recordItem = recordItemBuilder.freeze().build();
-        var transaction = domainBuilder.transaction().get();
-        var freeze = recordItem.getTransactionBody().getFreeze();
+        final var recordItem = recordItemBuilder.freeze().build();
+        final var freeze = recordItem.getTransactionBody().getFreeze();
+        final var entityId = EntityId.of(freeze.getUpdateFile());
+        final var transaction =
+                domainBuilder.transaction().customize(t -> t.entityId(entityId)).get();
 
         // When
         transactionHandler.updateTransaction(transaction, recordItem);
@@ -63,7 +65,7 @@ class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
                 .returns(recordItem.getConsensusTimestamp(), NetworkFreeze::getConsensusTimestamp)
                 .returns(null, NetworkFreeze::getEndTime)
                 .returns(DomainUtils.toBytes(freeze.getFileHash()), NetworkFreeze::getFileHash)
-                .returns(EntityId.of(freeze.getUpdateFile()), NetworkFreeze::getFileId)
+                .returns(entityId, NetworkFreeze::getFileId)
                 .returns(recordItem.getPayerAccountId(), NetworkFreeze::getPayerAccountId)
                 .returns(DomainUtils.timestampInNanosMax(freeze.getStartTime()), NetworkFreeze::getStartTime)
                 .returns(freeze.getFreezeTypeValue(), NetworkFreeze::getType);
@@ -86,7 +88,8 @@ class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
                         .setEndMin(4))
                 .record(r -> r.setConsensusTimestamp(Timestamp.newBuilder().setSeconds(consensusTime)))
                 .build();
-        var transaction = domainBuilder.transaction().get();
+        final var transaction =
+                domainBuilder.transaction().customize(t -> t.entityId(null)).get();
 
         // When
         transactionHandler.updateTransaction(transaction, recordItem);
@@ -109,10 +112,40 @@ class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
 
     @SuppressWarnings("deprecation")
     @Test
+    void updateTransactionTimeOutOfRange() {
+        // Given
+        final var recordItem = recordItemBuilder
+                .freeze()
+                .transactionBody(b -> b.clearFileHash()
+                        .clearFreezeType()
+                        .clearStartTime()
+                        .clearUpdateFile()
+                        .setStartHour(-1)
+                        .setStartMin(-1)
+                        .setEndHour(24)
+                        .setEndMin(60))
+                .build();
+        final var transaction =
+                domainBuilder.transaction().customize(t -> t.entityId(null)).get();
+
+        // When
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // Then
+        verify(entityListener).onNetworkFreeze(networkFreezeCaptor.capture());
+        assertThat(networkFreezeCaptor.getAllValues())
+                .hasSize(1)
+                .first()
+                .returns(null, NetworkFreeze::getEndTime)
+                .returns(0L, NetworkFreeze::getStartTime);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
     void updateTransactionDeprecatedStartAfterEnd() {
         // Given
-        var consensusTime = 1690848000L;
-        var recordItem = recordItemBuilder
+        final var consensusTime = 1690848000L;
+        final var recordItem = recordItemBuilder
                 .freeze()
                 .transactionBody(b -> b.clearFileHash()
                         .clearFreezeType()
@@ -124,7 +157,8 @@ class FreezeTransactionHandlerTest extends AbstractTransactionHandlerTest {
                         .setEndMin(4))
                 .record(r -> r.setConsensusTimestamp(Timestamp.newBuilder().setSeconds(consensusTime)))
                 .build();
-        var transaction = domainBuilder.transaction().get();
+        final var transaction =
+                domainBuilder.transaction().customize(t -> t.entityId(null)).get();
 
         // When
         transactionHandler.updateTransaction(transaction, recordItem);

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeCreateTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeCreateTransactionHandlerTest.java
@@ -15,6 +15,7 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.domain.node.Node;
 import org.hiero.mirror.common.domain.node.ServiceEndpoint;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.junit.jupiter.api.Test;
 
 class NodeCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
@@ -111,6 +112,29 @@ class NodeCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
         verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
                 .isNotNull()
                 .returns(new ServiceEndpoint("", "", endpoint.getPort()), Node::getGrpcProxyEndpoint)));
+    }
+
+    @Test
+    void nodeCreateInvalidDomainName() {
+        // given
+        final var domainName = "hedera.com" + DomainUtils.NULL_CHARACTER;
+        final var recordItem = recordItemBuilder
+                .nodeCreate()
+                .transactionBody(b -> b.getGrpcProxyEndpointBuilder().setDomainName(domainName))
+                .build();
+        final var transaction = domainBuilder.transaction().get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
+                .isNotNull()
+                .extracting(Node::getGrpcProxyEndpoint)
+                .extracting(ServiceEndpoint::domainName)
+                .asString()
+                .startsWith("hedera.com")
+                .doesNotContain(String.valueOf(DomainUtils.NULL_CHARACTER))));
     }
 
     @Test

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandlerTest.java
@@ -20,6 +20,7 @@ import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.domain.node.Node;
 import org.hiero.mirror.common.domain.node.ServiceEndpoint;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -209,5 +210,28 @@ final class NodeUpdateTransactionHandlerTest extends AbstractTransactionHandlerT
                 .returns(recordItem.getConsensusTimestamp(), Node::getTimestampLower)
                 .returns(false, Node::isDeleted)
                 .returns(null, Node::getGrpcProxyEndpoint)));
+    }
+
+    @Test
+    void nodeUpdateInvalidDomainName() {
+        // given
+        final var domainName = "hedera.com" + DomainUtils.NULL_CHARACTER;
+        final var recordItem = recordItemBuilder
+                .nodeUpdate()
+                .transactionBody(b -> b.getGrpcProxyEndpointBuilder().setDomainName(domainName))
+                .build();
+        final var transaction = domainBuilder.transaction().get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
+                .isNotNull()
+                .extracting(Node::getGrpcProxyEndpoint)
+                .extracting(ServiceEndpoint::domainName)
+                .asString()
+                .startsWith("hedera.com")
+                .doesNotContain(String.valueOf(DomainUtils.NULL_CHARACTER))));
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeCreateTransactionHandlerTest.java
@@ -22,6 +22,7 @@ import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.domain.node.RegisteredNode;
 import org.hiero.mirror.common.domain.node.RegisteredServiceEndpoint;
 import org.hiero.mirror.common.domain.transaction.TransactionType;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.parser.record.RegisteredNodeChangedEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -153,5 +154,34 @@ final class RegisteredNodeCreateTransactionHandlerTest extends AbstractTransacti
         verifyNoInteractions(applicationEventPublisher);
         assertThat(recordItem.getEntityTransactions())
                 .containsExactlyInAnyOrderEntriesOf(getExpectedEntityTransactions(recordItem, transaction));
+    }
+
+    @Test
+    void updateTransactionInvalidDomainName() {
+        // given
+        final var domainName = "hedera.com" + DomainUtils.NULL_CHARACTER;
+        final var recordItem = recordItemBuilder
+                .registeredNodeCreate()
+                .transactionBody(b -> b.getServiceEndpointBuilder(0).setDomainName(domainName))
+                .build();
+        final long consensusTimestamp = recordItem.getConsensusTimestamp();
+        final var transaction = domainBuilder
+                .transaction()
+                .customize(t -> t.consensusTimestamp(consensusTimestamp).entityId(EntityId.EMPTY))
+                .get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        verify(entityListener, times(1)).onRegisteredNode(assertArg(registeredNode -> assertThat(registeredNode)
+                .extracting(RegisteredNode::getServiceEndpoints)
+                .asInstanceOf(InstanceOfAssertFactories.list(RegisteredServiceEndpoint.class))
+                .first()
+                .extracting(RegisteredServiceEndpoint::getDomainName)
+                .asString()
+                .startsWith("hedera.com")
+                .doesNotContain(String.valueOf(DomainUtils.NULL_CHARACTER))));
+        verify(applicationEventPublisher, times(1)).publishEvent(any(RegisteredNodeChangedEvent.class));
     }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeUpdateTransactionHandlerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/transactionhandler/RegisteredNodeUpdateTransactionHandlerTest.java
@@ -22,6 +22,7 @@ import org.hiero.mirror.common.domain.entity.EntityType;
 import org.hiero.mirror.common.domain.node.RegisteredNode;
 import org.hiero.mirror.common.domain.node.RegisteredServiceEndpoint;
 import org.hiero.mirror.common.domain.transaction.TransactionType;
+import org.hiero.mirror.common.util.DomainUtils;
 import org.hiero.mirror.importer.parser.record.RegisteredNodeChangedEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -136,5 +137,34 @@ final class RegisteredNodeUpdateTransactionHandlerTest extends AbstractTransacti
         verify(applicationEventPublisher, never()).publishEvent(any(RegisteredNodeChangedEvent.class));
         assertThat(recordItem.getEntityTransactions())
                 .containsExactlyInAnyOrderEntriesOf(getExpectedEntityTransactions(recordItem, transaction));
+    }
+
+    @Test
+    void updateTransactionInvalidDomainName() {
+        // given
+        final var domainName = "hedera.com" + DomainUtils.NULL_CHARACTER;
+        final var recordItem = recordItemBuilder
+                .registeredNodeUpdate()
+                .transactionBody(b -> b.getServiceEndpointBuilder(0).setDomainName(domainName))
+                .build();
+        final long consensusTimestamp = recordItem.getConsensusTimestamp();
+        final var transaction = domainBuilder
+                .transaction()
+                .customize(t -> t.consensusTimestamp(consensusTimestamp).entityId(EntityId.EMPTY))
+                .get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        verify(entityListener, times(1)).onRegisteredNode(assertArg(registeredNode -> assertThat(registeredNode)
+                .extracting(RegisteredNode::getServiceEndpoints)
+                .asInstanceOf(InstanceOfAssertFactories.list(RegisteredServiceEndpoint.class))
+                .first()
+                .extracting(RegisteredServiceEndpoint::getDomainName)
+                .asString()
+                .startsWith("hedera.com")
+                .doesNotContain(String.valueOf(DomainUtils.NULL_CHARACTER))));
+        verify(applicationEventPublisher, times(1)).publishEvent(any(RegisteredNodeChangedEvent.class));
     }
 }

--- a/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/web3/src/test/java/org/hiero/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -263,8 +263,9 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
         assertThatThrownBy(functionCall::send)
                 .isInstanceOf(MirrorEvmTransactionException.class)
                 .satisfies(ex -> {
-                    MirrorEvmTransactionException exception = (MirrorEvmTransactionException) ex;
-                    assertEquals("Failed to associate tokens", exception.getDetail());
+                    if (ex instanceof MirrorEvmTransactionException exception) {
+                        assertEquals("Failed to associate tokens", exception.getDetail());
+                    }
                 });
 
         verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
@@ -305,8 +306,9 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
             assertThatThrownBy(functionCall::send)
                     .isInstanceOf(MirrorEvmTransactionException.class)
                     .satisfies(ex -> {
-                        MirrorEvmTransactionException exception = (MirrorEvmTransactionException) ex;
-                        assertEquals("Failed to associate tokens", exception.getDetail());
+                        if (ex instanceof MirrorEvmTransactionException exception) {
+                            assertEquals("Failed to associate tokens", exception.getDetail());
+                        }
                     });
 
             verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
@@ -391,8 +393,9 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
         assertThatThrownBy(functionCall::send)
                 .isInstanceOf(MirrorEvmTransactionException.class)
                 .satisfies(ex -> {
-                    MirrorEvmTransactionException exception = (MirrorEvmTransactionException) ex;
-                    assertEquals(expectedErrorMessage, exception.getDetail());
+                    if (ex instanceof MirrorEvmTransactionException exception) {
+                        assertEquals(expectedErrorMessage, exception.getDetail());
+                    }
                 });
 
         verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);


### PR DESCRIPTION
**Description**:

* Discard address books with no valid nodes
* Fix compilation warning in web3
* Fix handling of duplicate node IDs in a NodeStakeUpdate
* Fix handling of Freeze start/end times out of range
* Sanitize Node and RegisteredNode domain names before insert

**Related issue(s)**:

MN-170
MN-174
MN-178
MN-195

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
