### PR TITLE
Fix `releases-comparator` workflow comparison

### DIFF
--- a/.github/workflows/releases-comparator.yml
+++ b/.github/workflows/releases-comparator.yml
@@ -44,7 +44,7 @@ jobs:
 
           git fetch origin ${{ github.base_ref }} --depth=1
           git show origin/${{ github.base_ref }}:build.gradle.kts > base_build.gradle.kts
-          BASE_VERSION=$(sed -nE "${REGEX}" build.gradle.kts)
+          BASE_VERSION=$(sed -nE "${REGEX}" base_build.gradle.kts)
           BASE_VERSION_TAG="v$BASE_VERSION"
 
           echo "pr_version=$PR_VERSION_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description**:
Due to a regression in the `releases-comparator` workflow, the compared version was always the PR version with itself. This caused us to miss some changes in the model classes upstream. This PR restores the comparison.