### PR TITLE
Fix image vulnerability (0.163)

### DIFF
--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -1,7 +1,10 @@
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm
 
 # Marketplace image still depends upon Helm 3
-ENV HELM_VERSION=4.2.0
+# Use helm 4.3.0-rc.1 temporarility to address vulnerability
+# Use kubectl v1.37.0 to address the same vulnerability until the next marketplace deploy_helm image release
+ENV HELM_VERSION=4.3.0-rc.1
+ENV KUBECTL_VERSION=v1.37.0
 ENV YQ_VERSION=v4.53.2
 
 # Install yq
@@ -12,6 +15,12 @@ RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linu
 # Install Helm
 RUN wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | \
     tar -C /usr/local/bin --strip-components=1 -zxv linux-amd64/helm
+
+# Install kubectl
+RUN rm -rf /opt/kubectl && \
+    mkdir -p /opt/kubectl/default && \
+    wget -q -O /opt/kubectl/default/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+    chmod 755 /opt/kubectl/default/kubectl
 
 # Pull in charts
 WORKDIR /app

--- a/graphql/Dockerfile
+++ b/graphql/Dockerfile
@@ -15,9 +15,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/grpc/Dockerfile
+++ b/grpc/Dockerfile
@@ -15,9 +15,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -14,9 +14,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -15,9 +15,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/rest-java/Dockerfile
+++ b/rest-java/Dockerfile
@@ -15,9 +15,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,9 +3,12 @@ FROM eclipse-temurin:25.0.4_7-jre-resolute@sha256:71bfb73662d4146bdc9ee2f97418a7
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 WORKDIR /app
 COPY --chown=1000:1000 build/libs/*-all.jar test.jar
+
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENV ENTRYPOINT_COMMAND="java -jar /app/test.jar"

--- a/web3/Dockerfile
+++ b/web3/Dockerfile
@@ -15,9 +15,11 @@ COPY --chown=1000:1000 --from=builder /app/extracted/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/ ./
 COPY --chown=1000:1000 --from=builder /app/extracted/application/BOOT-INF/lib/common-*.jar ./healthcheck.jar
 
+# install OS updates, and remove pebble due to vulnerability
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*    # install OS updates
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/bin/pebble && rm -rf /var/lib/pebble
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
**Description**:

This PR cherry-picks the fix to `release/0.163`.

- Override the deployer_helm image with helm v4.3.0-rc.1 and kubectl v1.37.0
- Remove pebble from eclipse-temurin jre image

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
