### PR TITLE
Conditionally grant role pg_use_reserved_connections

### DIFF
--- a/importer/src/main/resources/db/scripts/init.sh
+++ b/importer/src/main/resources/db/scripts/init.sh
@@ -85,9 +85,16 @@ create user :restJavaUsername with login password :'restJavaPassword' in role re
 create user :rosettaUsername with login password :'rosettaPassword' in role readonly;
 create user :web3Username with login password :'web3Password' in role readonly;
 
--- Allow importer user and owner user to use reserved connection slots
-grant pg_use_reserved_connections to :importerUsername;
-grant pg_use_reserved_connections to :ownerUsername;
+-- Allow importer user and owner user to use reserved connection slots. The pg_use_reserved_connections
+-- predefined role only exists in PostgreSQL 16 and later.
+select case
+    when exists(select from pg_roles where rolname = 'pg_use_reserved_connections') then 'true'
+    else 'false'
+  end as has_reserved_connections \gset
+\if :has_reserved_connections
+  grant pg_use_reserved_connections to :importerUsername;
+  grant pg_use_reserved_connections to :ownerUsername;
+\endif
 
 -- Grant temp schema admin privileges
 grant temporary_admin to :ownerUsername;


### PR DESCRIPTION
**Description**:

This PR fixes the failure in Rosetta API workflow runs:

- Conditionally grant role pg_use_reserved_connections

**Related issue(s)**:

Fixes #14272 

**Notes for reviewer**:

The Rosetta image installs and uses PG14, which doesn't have the system role `pg_use_reserved_connections`. Alternatively, we could improve the Rosetta image by upgrading to >= PG16. However that's more work and need automated PG major version upgrade with existing data of a PG14 server.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
