### PR TITLE
Bump Helm from 4.2.4 to 4.3.0

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       with:
-        version: "4.2.4"
+        version: "4.3.0"
 
     - name: Setup Kind
       uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       interval: "weekly"
 
   - directories:
+      - "/charts/marketplace/gcp"
       - "/graphql"
       - "/grpc"
       - "/importer"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: "4.2.4"
+          version: "4.3.0"
 
       - name: Install ct
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
@@ -67,7 +67,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: "4.2.4"
+          version: "4.3.0"
 
       - name: Setup Kind
         uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0

--- a/.github/workflows/wrb-differential.yaml
+++ b/.github/workflows/wrb-differential.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: "4.2.4"
+          version: "4.3.0"
 
       - name: Setup Kind
         uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0

--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -1,25 +1,34 @@
-FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:13.0.10@sha256:60bc54af5578550df364109be383ea575ea97fdcae4c8236398f8647a5f75bee
 
 # Marketplace image still depends upon Helm 3
 # Use kubectl v1.37.0 to address the same vulnerability until the next marketplace deploy_helm image release
-ENV HELM_VERSION=4.3.0
-ENV KUBECTL_VERSION=v1.37.0
-ENV YQ_VERSION=v4.53.6
+ARG HELM_SHA256=86584a54def73570558f66f5111cc53dfed56689637ae32c1201205d494f54fb
+ARG HELM_VERSION=4.3.0
+ARG KUBECTL_SHA256=6129359f4e1f3848a5572ccb0b26cf28b8ca08cef38c95a765b2f64a2c961a2f
+ARG KUBECTL_VERSION=v1.37.0
+ARG YQ_SHA256=c5f056448f973ae7d39b5401949648a78f2dc1947d6a8eb65be60d5c504b9385
+ARG YQ_VERSION=v4.53.6
 
 # Install yq
-RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
-    mv yq_linux_amd64 /usr/local/bin/yq && \
-    chmod +x /usr/local/bin/yq
+RUN set -eu && \
+    wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
+    chmod 755 /usr/local/bin/yq && \
+    echo "${YQ_SHA256} /usr/local/bin/yq" | sha256sum -c -
 
 # Install Helm
-RUN wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | \
-    tar -C /usr/local/bin --strip-components=1 -zxv linux-amd64/helm
+RUN set -eu && \
+    wget -q -O helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    echo "${HELM_SHA256} helm.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local/bin --strip-components=1 -zxf helm.tar.gz linux-amd64/helm && \
+    rm -f helm.tar.gz
 
 # Install kubectl
-RUN rm -rf /opt/kubectl && \
+RUN set -eu && \
+    rm -rf /opt/kubectl && \
     mkdir -p /opt/kubectl/default && \
     wget -q -O /opt/kubectl/default/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
-    chmod 755 /opt/kubectl/default/kubectl
+    chmod 755 /opt/kubectl/default/kubectl && \
+    echo "${KUBECTL_SHA256} /opt/kubectl/default/kubectl" | sha256sum -c -
 
 # Pull in charts
 WORKDIR /app

--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -1,11 +1,10 @@
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm
 
 # Marketplace image still depends upon Helm 3
-# Use helm 4.3.0-rc.1 temporarility to address vulnerability
 # Use kubectl v1.37.0 to address the same vulnerability until the next marketplace deploy_helm image release
-ENV HELM_VERSION=4.3.0-rc.1
+ENV HELM_VERSION=4.3.0
 ENV KUBECTL_VERSION=v1.37.0
-ENV YQ_VERSION=v4.53.2
+ENV YQ_VERSION=v4.53.6
 
 # Install yq
 RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \


### PR DESCRIPTION
**Description**:

* Add binary checksum verification to GCP Marketplace Dockerfile
* Bump Helm from 4.2.4 to 4.3.0
* Pin Marketplace base image

**Related issue(s)**:

MN-185

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
