### PR TITLE
Disable ActuatorHttpServer in tests

### DIFF
--- a/importer/src/main/java/org/hiero/mirror/importer/config/ActuatorHttpServer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/config/ActuatorHttpServer.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,50 +24,50 @@ import org.springframework.boot.health.contributor.Status;
 
 @CustomLog
 @Named
-@RequiredArgsConstructor
 @ConditionalOnMissingClass({"reactor.netty.http.server.HttpServer", "org.apache.catalina.startup.Tomcat"})
-final class ActuatorHttpServer implements InitializingBean, DisposableBean {
+public final class ActuatorHttpServer implements InitializingBean, DisposableBean {
 
-    private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
+    private static final String CONTENT_TYPE = "Content-Type";
     private static final String TEXT_PLAIN_PROMETHEUS = "text/plain; version=0.0.4; charset=utf-8";
 
     private final Function<String, Status> healthResolver;
-    private final PrometheusMeterRegistry prometheusMeterRegistry;
     private final ObjectMapper objectMapper;
+    private final PrometheusMeterRegistry prometheusMeterRegistry;
+    private final HttpServer server;
 
-    @Value("${server.port:8080}")
-    private int port;
-
-    private HttpServer server;
-
-    // Returns the actual bound port (useful when port=0 is used in tests)
-    int getPort() {
-        return server.getAddress().getPort();
-    }
-
-    void setPort(int port) {
-        this.port = port;
-    }
-
-    @Override
-    public void afterPropertiesSet() throws IOException {
+    @SneakyThrows
+    ActuatorHttpServer(
+            Function<String, Status> healthResolver,
+            ObjectMapper objectMapper,
+            PrometheusMeterRegistry prometheusMeterRegistry,
+            @Value("${server.port:8080}") int port) {
+        this.healthResolver = healthResolver;
+        this.objectMapper = objectMapper;
+        this.prometheusMeterRegistry = prometheusMeterRegistry;
         server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/actuator/health/liveness", e -> handleHealth(e, "liveness"));
         server.createContext("/actuator/health/readiness", e -> handleHealth(e, "readiness"));
         server.createContext("/actuator/health/startup", e -> handleHealth(e, "startup"));
         server.createContext("/actuator/prometheus", this::handlePrometheus);
         server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    // Returns the actual bound port (useful when port=0 is used in tests)
+    int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    @Override
+    public void afterPropertiesSet() {
         server.start();
-        log.info("Actuator HTTP server listening on port {}", port);
+        log.info("Actuator HTTP server listening on port {}", getPort());
     }
 
     @Override
     public void destroy() {
-        if (server != null) {
-            server.stop(0);
-            log.info("Actuator HTTP server stopped");
-        }
+        server.stop(0);
+        log.info("Actuator HTTP server stopped");
     }
 
     private void handleHealth(HttpExchange exchange, String group) throws IOException {
@@ -76,6 +76,7 @@ final class ActuatorHttpServer implements InitializingBean, DisposableBean {
                 exchange.sendResponseHeaders(405, -1);
                 return;
             }
+
             final var resolved = healthResolver.apply(group);
             final var status = resolved != null ? resolved : Status.DOWN;
             final int httpStatus = HttpCodeStatusMapper.getDefault().getStatusCode(status);
@@ -92,6 +93,7 @@ final class ActuatorHttpServer implements InitializingBean, DisposableBean {
                 exchange.sendResponseHeaders(405, -1);
                 return;
             }
+
             final var body = prometheusMeterRegistry.scrape().getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set(CONTENT_TYPE, TEXT_PLAIN_PROMETHEUS);
             exchange.sendResponseHeaders(200, body.length);

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/Downloader.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/Downloader.java
@@ -219,7 +219,6 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
                             return streamFileSignature;
                         })
                         .onErrorContinue((e, s) -> log.error("Error downloading signature files for node {}", node, e)))
-                .timeout(downloaderProperties.getCommon().getTimeout())
                 .collect(this::getStreamFileSignatureMultiMap, (map, s) -> map.put(s.getFilename(), s))
                 .subscribeOn(Schedulers.parallel())
                 .block());

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/AbstractBlockTransactionTransformer.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/block/transformer/AbstractBlockTransactionTransformer.java
@@ -52,7 +52,7 @@ abstract class AbstractBlockTransactionTransformer implements BlockTransactionTr
         final var recordItemBuilder = blockTransactionTransformation
                 .recordItemBuilder()
                 .congestionPricingMultiplier(transactionResult.getCongestionPricingMultiplier());
-        final var receiptBuilder = TransactionReceipt.newBuilder().setStatus(transactionResult.getStatus());
+        final var receiptBuilder = TransactionReceipt.newBuilder().setStatusValue(transactionResult.getStatusValue());
         var recordBuilder = recordItemBuilder
                 .transactionRecordBuilder()
                 .addAllAssessedCustomFees(transactionResult.getAssessedCustomFeesList())

--- a/importer/src/main/java/org/hiero/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -104,11 +104,12 @@ public final class S3StreamFileProvider extends AbstractStreamFileProvider {
                 ? downloaderProperties.getBucketName()
                 : blockProperties.getBucketName();
         final var s3Key = streamFilename.getBucketFilePath();
+        final long maxSize = streamFilename.getFileType() == SIGNATURE ? 2 * 1024 : downloaderProperties.getMaxSize();
         final var request = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(s3Key)
                 .requestPayer(RequestPayer.REQUESTER)
-                .range(RANGE_PREFIX + (downloaderProperties.getMaxSize() - 1))
+                .range(RANGE_PREFIX + (maxSize - 1))
                 .build();
         return Mono.fromFuture(s3Client.getObject(request, AsyncResponseTransformer.toBytes()))
                 .map(r -> toStreamFileData(streamFilename, r))

--- a/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/importer/src/main/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -6,7 +6,6 @@ import static org.hiero.mirror.common.domain.token.NftTransfer.WILDCARD_SERIAL_N
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnknownFieldSet;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -18,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -211,7 +209,7 @@ public class EntityRecordItemListener implements RecordItemListener {
                         : null);
         transaction.setType(recordItem.getTransactionType());
         transaction.setValidDurationSeconds(validDurationSeconds);
-        transaction.setValidStartNs(DomainUtils.timeStampInNanos(transactionId.getTransactionValidStart()));
+        transaction.setValidStartNs(DomainUtils.timestampInNanosMax(transactionId.getTransactionValidStart()));
 
         if (txRecord.hasParentConsensusTimestamp()) {
             transaction.setParentConsensusTimestamp(
@@ -665,25 +663,25 @@ public class EntityRecordItemListener implements RecordItemListener {
                     signature = signaturePair.getRSA3072();
                     break;
                 case SIGNATURE_NOT_SET:
-                    Map<Integer, UnknownFieldSet.Field> unknownFields =
-                            signaturePair.getUnknownFields().asMap();
+                    final var unknownFields = signaturePair.getUnknownFields().asMap();
 
                     // If we encounter a signature that our version of the protobuf does not yet support, it will
                     // return SIGNATURE_NOT_SET. Hence we should look in the unknown fields for the new signature.
                     // ByteStrings are stored as length-delimited on the wire, so we search the unknown fields for a
                     // field that has exactly one length-delimited value and assume it's our new signature bytes.
-                    for (Map.Entry<Integer, UnknownFieldSet.Field> entry : unknownFields.entrySet()) {
-                        UnknownFieldSet.Field field = entry.getValue();
-                        if (field.getLengthDelimitedList().size() == 1) {
+                    for (final var entry : unknownFields.entrySet()) {
+                        final var field = entry.getValue();
+                        final var key = entry.getKey();
+
+                        if (field.getLengthDelimitedList().size() == 1 && key != null && DomainUtils.isSmallint(key)) {
                             signature = field.getLengthDelimitedList().get(0);
-                            type = entry.getKey();
+                            type = DomainUtils.toSmallint(key);
                             break;
                         }
                     }
 
                     if (signature == null) {
-                        Utility.handleRecoverableError(
-                                "Unsupported signature at {}: {}", consensusTimestamp, unknownFields);
+                        Utility.handleRecoverableError("Unsupported signature at {}", consensusTimestamp);
                         continue;
                     }
                     break;

--- a/importer/src/test/java/org/hiero/mirror/importer/ImporterIntegrationTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/ImporterIntegrationTest.java
@@ -44,6 +44,7 @@ import org.hiero.mirror.common.domain.DomainBuilder;
 import org.hiero.mirror.common.domain.entity.EntityId;
 import org.hiero.mirror.common.domain.node.ServiceEndpoint;
 import org.hiero.mirror.common.tableusage.EndpointContext;
+import org.hiero.mirror.importer.config.ActuatorHttpServer;
 import org.hiero.mirror.importer.config.DateRangeCalculator;
 import org.hiero.mirror.importer.config.Owner;
 import org.hiero.mirror.importer.converter.JsonbToListConverter;
@@ -63,6 +64,7 @@ import org.springframework.jdbc.core.DataClassRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ExtendWith(SoftAssertionsExtension.class)
 @Import(RedisTestConfiguration.class)
@@ -72,6 +74,10 @@ public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
     protected static final DomainBuilder DOMAIN_BUILDER = new DomainBuilder();
 
     private static final Map<Class<?>, String> DEFAULT_DOMAIN_CLASS_IDS = new ConcurrentHashMap<>();
+
+    // Disable HTTP server during tests
+    @MockitoBean
+    private ActuatorHttpServer actuatorHttpServer;
 
     @Resource
     protected Flyway flyway;

--- a/importer/src/test/java/org/hiero/mirror/importer/config/ActuatorHttpServerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/config/ActuatorHttpServerTest.java
@@ -34,10 +34,8 @@ final class ActuatorHttpServerTest {
     private int port;
 
     @BeforeEach
-    void setup() throws Exception {
-        actuatorHttpServer = new ActuatorHttpServer(healthResolver, prometheusMeterRegistry, new ObjectMapper());
-        // port 0 lets the OS pick a free port
-        actuatorHttpServer.setPort(0);
+    void setup() {
+        actuatorHttpServer = new ActuatorHttpServer(healthResolver, new ObjectMapper(), prometheusMeterRegistry, 0);
         actuatorHttpServer.afterPropertiesSet();
         port = actuatorHttpServer.getPort();
         httpClient = HttpClient.newHttpClient();

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/CommonTransformerTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/block/transformer/CommonTransformerTest.java
@@ -82,4 +82,23 @@ final class CommonTransformerTest extends AbstractTransformerTest {
         // then
         assertRecordFile(recordFile, blockFile, items -> assertThat(items).isEmpty());
     }
+
+    @Test
+    void unknownStatusValue() {
+        // given
+        final var expected = recordItemBuilder
+                .cryptoTransfer()
+                .receipt(r -> r.setStatusValue(Integer.MAX_VALUE))
+                .customize(this::finalize)
+                .build();
+        final var blockTransaction =
+                blockTransactionBuilder.defaultBlockItem(expected).build();
+        final var blockFile = blockFileBuilder.items(List.of(blockTransaction)).build();
+
+        // when
+        final var recordFile = blockFileTransformer.transform(blockFile);
+
+        // then
+        assertRecordFile(recordFile, blockFile, items -> assertThat(items).containsExactly(expected));
+    }
 }

--- a/importer/src/test/java/org/hiero/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -90,6 +90,29 @@ abstract class AbstractStreamFileProviderTest {
         var node = node(3);
         var nodeFileCopier = createDefaultFileCopier();
         nodeFileCopier.copy();
+        var data = streamFileData(node, "2022-07-13T08_46_08.041986003Z.rcd.gz");
+        StepVerifier.create(streamFileProvider.get(data.getStreamFilename()))
+                .thenAwait(Duration.ofSeconds(2L))
+                .expectNext(data)
+                .expectComplete()
+                .verify(Duration.ofSeconds(4000L));
+
+        // Increase data2 1 byte beyond the max size
+        long maxSize = data.getBytes().length;
+        properties.setMaxSize(maxSize);
+        replaceContents(data, Arrays.append(data.getBytes(), (byte) 1));
+
+        StepVerifier.withVirtualTime(() -> streamFileProvider.get(data.getStreamFilename()))
+                .thenAwait(Duration.ofSeconds(10L))
+                .expectError(InvalidDatasetException.class)
+                .verify(Duration.ofSeconds(10L));
+    }
+
+    @Test
+    void getLargeSignatureFile() {
+        var node = node(3);
+        var nodeFileCopier = createDefaultFileCopier();
+        nodeFileCopier.copy();
         var data = streamFileData(node, "2022-07-13T08_46_08.041986003Z.rcd_sig");
         StepVerifier.create(streamFileProvider.get(data.getStreamFilename()))
                 .thenAwait(Duration.ofSeconds(2L))

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/domain/BlockTransactionBuilder.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/domain/BlockTransactionBuilder.java
@@ -1031,7 +1031,7 @@ public class BlockTransactionBuilder {
                 .setHighVolumePricingMultiplier(transactionRecord.getHighVolumePricingMultiplier())
                 .setTransferList(transactionRecord.getTransferList())
                 .setTransactionFeeCharged(transactionRecord.getTransactionFee())
-                .setStatus(transactionRecord.getReceipt().getStatus())
+                .setStatusValue(transactionRecord.getReceipt().getStatusValue())
                 .build();
     }
 

--- a/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
+++ b/importer/src/test/java/org/hiero/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
@@ -19,6 +19,7 @@ import com.hederahashgraph.api.proto.java.ScheduleDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
+import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
@@ -182,6 +183,53 @@ final class EntityRecordItemListenerScheduleTest extends AbstractEntityRecordIte
         assertThat(scheduleRepository.findAll()).containsOnly(expectedSchedule);
         assertThat(transactionSignatureRepository.findAll()).containsOnly(expectedTransactionSignature);
         assertTransactionInRepository(recordItem.getCongestionPricingMultiplier(), timestamp, false, SUCCESS);
+    }
+
+    @Test
+    void scheduleCreateInvalidValidStart() {
+        final var payer = recordItemBuilder.accountId();
+        final var validStart = Timestamp.newBuilder()
+                .setSeconds(Long.MAX_VALUE)
+                .setNanos(Integer.MAX_VALUE)
+                .build();
+        final var recordItem = recordItemBuilder
+                .scheduleCreate()
+                .transactionBodyWrapper(
+                        t -> t.getTransactionIDBuilder().setAccountID(payer).setTransactionValidStart(validStart))
+                .build();
+
+        // when
+        parseRecordItemAndCommit(recordItem);
+
+        // then
+        assertThat(transactionRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting(org.hiero.mirror.common.domain.transaction.Transaction::getValidStartNs)
+                .isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void scheduleCreateInvalidSignature() {
+        final var signature = recordItemBuilder.bytes(32);
+        final var unknownFields = UnknownFieldSet.newBuilder()
+                .addField(
+                        Integer.MAX_VALUE,
+                        UnknownFieldSet.Field.newBuilder()
+                                .addLengthDelimited(signature)
+                                .build())
+                .build();
+        final var recordItem = recordItemBuilder
+                .scheduleCreate()
+                .signatureMap(
+                        s -> s.clear().addSigPair(SignaturePair.newBuilder().setUnknownFields(unknownFields)))
+                .build();
+
+        // when
+        parseRecordItemAndCommit(recordItem);
+
+        // then
+        assertThat(transactionSignatureRepository.findAll()).isEmpty();
     }
 
     @ValueSource(booleans = {true, false})


### PR DESCRIPTION
**Description**:

* Discard unknown signature types with unreasonable values
* Disable `ActuatorHttpServer` in tests
* Don't discard all signature downloads when one download is slow
* Handle invalid `transactionId.transactionValidStart`
* Restrict signature downloads to 2KiB
* Support unknown receipt statuses when transforming block to record streams

**Related issue(s)**:

MN-145
MN-158
MN-165
MN-177

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
